### PR TITLE
Fix sign inversion in NavigationReward potential shaping

### DIFF
--- a/python/reward/reward_functions.py
+++ b/python/reward/reward_functions.py
@@ -192,7 +192,7 @@ class NavigationReward(BaseRewardFunction):
         potential_current = -current_distance * self.distance_scale
         potential_next = -next_distance * self.distance_scale
         
-        shaping_reward = self.gamma * potential_next - potential_current
+        shaping_reward = potential_current - self.gamma * potential_next
         
         return shaping_reward
     


### PR DESCRIPTION
## Summary

Fixes a sign inversion bug in  that completely breaks RL training when potential shaping is enabled.

## Bug

Standard potential-based reward shaping (PFRL) formula: **Φ(s) - γ·Φ(s')**

Previous (broken):


Correct:


## Impact

The inverted signal punishes agents for moving toward the goal and rewards them for moving away — the opposite of intended behavior.

## Fix

Single-line fix in  line 195.

## Testing

-  passes ✓
- Existing reward test suite: 46 passed (3 pre-existing failures unrelated to this change) ✓
- Issue: https://github.com/Varuu-0/bonk-rl-env/issues/126