### PR TITLE
docs: correct TPS and determinism claims

### DIFF
--- a/ANALYSIS_REPORT.md
+++ b/ANALYSIS_REPORT.md
@@ -225,8 +225,8 @@ Bonk-RL-Env is a high-performance, headless reinforcement learning environment f
 
 #### 1. Deterministic Physics Engine
 - Uses Box2D with fixed time step (1/30s)
-- Deterministic PRNG ensures reproducible simulations
-- Configured for 30 TPS (ticks per second) with configurable options (15/30/60)
+- Deterministic PRNG enables explicitly seeded reproducibility on the same runtime and architecture
+- Runs at the fixed native rate of 30 TPS (ticks per second)
 
 #### 2. Massively Parallel Worker Pool
 - Scales horizontally using Node.js worker_threads
@@ -254,7 +254,8 @@ Bonk-RL-Env is a high-performance, headless reinforcement learning environment f
 - Fixed physics timestep
 - Deterministic PRNG
 - Synchronized worker execution
-- Enables scientific rigor in RL experiments
+- Explicit seeds reproduce rollouts on the same runtime and architecture
+- Absent seeds intentionally randomize; bit-exact cross-platform parity is not guaranteed
 
 ### Performance Characteristics (from README)
 - Raw PhysicsEngine TPS: 22,612
@@ -275,7 +276,7 @@ Bonk-RL-Env is a high-performance, headless reinforcement learning environment f
 
 ### Configuration Options
 - Number of parallel environments (`numEnvs`)
-- Tick rate (`ticksPerSecond`: 15, 30, or 60)
+- Fixed 30 TPS simulation rate
 - Shared memory usage (`useSharedMemory`: boolean)
 - Telemetry settings (enabled, profile level, debug level, output)
 - Port configuration (`PORT` environment variable)

--- a/ANALYSIS_REPORT.md
+++ b/ANALYSIS_REPORT.md
@@ -276,7 +276,7 @@ Bonk-RL-Env is a high-performance, headless reinforcement learning environment f
 
 ### Configuration Options
 - Number of parallel environments (`numEnvs`)
-- Fixed 30 TPS simulation rate
+- Fixed 30 TPS simulation rate (native Bonk.io rate; the config `physics.ticksPerSecond` field exists but is not applied by the engine)
 - Shared memory usage (`useSharedMemory`: boolean)
 - Telemetry settings (enabled, profile level, debug level, output)
 - Port configuration (`PORT` environment variable)

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ A high-performance, headless simulation engine for *Bonk.io*, designed specifica
 
 ## Overview
 
-This project decouples the core *Bonk.io* physics logic from the original multiplayer networking stack. By removing browser-based rendering and WebSocket bottlenecks, we have created a deterministic, headless simulation loop. This allows machine learning agents to train in minutes rather than days, making it an ideal environment for testing PPO, DQN, or other reinforcement learning algorithms.
+This project decouples the core *Bonk.io* physics logic from the original multiplayer networking stack. By removing browser-based rendering and WebSocket bottlenecks, we have created a seedable, headless simulation loop. This allows machine learning agents to train in minutes rather than days, making it an ideal environment for testing PPO, DQN, or other reinforcement learning algorithms.
 
 ## Architecture
 
 - **Worker Pool**: Operates as a Massively Parallel Vectorized Environment, dynamically scaling to use all available CPU cores via Node.js `worker_threads`.
-- **Synchronous Loop**: Replaces real-time clocks with a synchronous `tick()` system equipped with a deterministic PRNG for perfectly reproducible rollouts.
+- **Synchronous Loop**: Replaces real-time clocks with a synchronous `tick()` system and a deterministic PRNG. Explicit seeds reproduce rollouts on the same runtime and architecture; absent seeds intentionally randomize, and bit-exact cross-platform floating-point parity is not guaranteed.
 - **Batch IPC Bridge**: Utilizes **ZeroMQ (ZMQ) ROUTER/DEALER** patterns for high-speed, batch communication between the TypeScript worker pool and the Python ML pipeline.
 - **Vectorized Gymnasium API**: Implements the `stable_baselines3.common.vec_env.VecEnv` interface natively, allowing the Python agent to dispatch actions and aggregate observations across 64+ parallel environments simultaneously.
 
@@ -29,11 +29,11 @@ This project decouples the core *Bonk.io* physics logic from the original multip
 
 ## Features
 
-- **Deterministic Physics**: Reproducible simulation results for reliable RL training
+- **Seeded Reproducibility**: Explicit seeds reproduce simulation results on the same runtime and architecture
 - **Multi-threaded Parallelism**: Horizontal scaling across all available CPU cores
 - **Gymnasium Compatible**: Native integration with stable-baselines3 and other Python RL frameworks
 - **ZeroMQ Communication**: Low-latency message passing between Node.js and Python
-- **Configurable Tick Rates**: Support for 15/30/60 ticks per second simulation
+- **Native Tick Rate**: Fixed 30 ticks per second, matching the verified Bonk.io simulation rate
 - **Memory Efficient**: Typed arrays for observations, worker thread memory isolation
 
 ## SharedArrayBuffer Worker Pool (Optional Feature)
@@ -56,7 +56,7 @@ The implementation uses JavaScript's `SharedArrayBuffer` combined with the `Atom
 
 - **Reduced Latency**: Eliminates serialization/deserialization overhead for each environment step
 - **Lower Memory Usage**: Single buffer instead of per-message allocation
-- **Improved Throughput**: Particularly beneficial for high-frequency environment stepping (60 ticks/sec)
+- **Improved Throughput**: Particularly beneficial when stepping many environments in parallel
 - **Cache-Friendly**: Shared memory can be more cache-coherent than message passing
 
 ### How to Enable/Disable


### PR DESCRIPTION
## Summary

- removes the remaining stale 15/30/60 and 60 TPS claims
- documents the deobfuscated native simulation rate as a fixed 30 TPS
- scopes deterministic-rollout claims to explicit seeds on the same runtime and architecture
- documents intentional randomization for absent seeds and the lack of bit-exact cross-platform floating-point guarantees

## Evidence

- `src/core/physics-engine.ts` uses `DT = 1 / 30`
- `docs/DEOBFUSCATION.md` verifies the native simulation cadence as 30 TPS
- current worker scheduling is per-environment and does not create the nondeterminism alleged in #157

## Validation

- searched Markdown for `60 TPS`, `60 ticks`, `15/30/60`, and `perfectly reproducible`; no stale matches remain
- `git diff --check`

Closes #44
Closes #99
Closes #157
