### PR TITLE
fix(worker): harden message publication protocol

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -225,9 +225,25 @@ export class WorkerPool {
         }
     }
 
+    private allocateMessageId(): number {
+        const liveCallbacks = this.callbacks.size;
+        if (liveCallbacks >= 0x100000000) {
+            throw new Error('WorkerPool message ID space exhausted');
+        }
+
+        let id = this.msgId >>> 0;
+        for (let attempt = 0; attempt <= liveCallbacks; attempt++) {
+            this.msgId = (id + 1) >>> 0;
+            if (!this.callbacks.has(id)) return id;
+            id = this.msgId;
+        }
+
+        throw new Error('WorkerPool could not allocate a message ID');
+    }
+
     private sendMessage(worker: Worker, msg: any): Promise<any> {
         return new Promise((resolve, reject) => {
-            const id = this.msgId++;
+            const id = this.allocateMessageId();
             // Set a timeout to reject if no response
             const timeout = setTimeout(() => {
                 if (this.callbacks.has(id)) {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -227,10 +227,17 @@ export class WorkerPool {
 
     private allocateMessageId(): number {
         const liveCallbacks = this.callbacks.size;
+        // Defensive invariant: a free uint32 id always exists below, so this
+        // guard can never fire unless the callback map holds 2^32 entries.
         if (liveCallbacks >= 0x100000000) {
             throw new Error('WorkerPool message ID space exhausted');
         }
 
+        // Probe `liveCallbacks + 1` distinct uint32 ids while only
+        // `liveCallbacks` can be occupied, so a free id is guaranteed to be
+        // found (pigeonhole principle) and a live callback is never overwritten.
+        // The map is bounded in practice by in-flight messages because replies
+        // and 30s timeouts both delete their callback entry.
         let id = this.msgId >>> 0;
         for (let attempt = 0; attempt <= liveCallbacks; attempt++) {
             this.msgId = (id + 1) >>> 0;
@@ -238,6 +245,7 @@ export class WorkerPool {
             id = this.msgId;
         }
 
+        // Unreachable; kept as a defensive guard for future allocator changes.
         throw new Error('WorkerPool could not allocate a message ID');
     }
 

--- a/src/ipc/shared-memory.ts
+++ b/src/ipc/shared-memory.ts
@@ -125,8 +125,8 @@ export class SharedMemoryManager {
 
     writeActions(actions: Uint8Array) {
         const slot = this.currentActionSlot;
-        Atomics.store(this.control.actionSlotIndex, 0, slot);
         this.views.actions.set(actions, slot * this.numEnvs);
+        Atomics.store(this.control.actionSlotIndex, 0, slot);
         this.currentActionSlot = (this.currentActionSlot + 1) & this.actionRingMask;
         // Signal that new actions are available
         Atomics.store(this.control.workerReady, 0, 1);
@@ -135,8 +135,8 @@ export class SharedMemoryManager {
 
     writeActionsQuiet(actions: Uint8Array) {
         const slot = this.currentActionSlot;
-        Atomics.store(this.control.actionSlotIndex, 0, slot);
         this.views.actions.set(actions, slot * this.numEnvs);
+        Atomics.store(this.control.actionSlotIndex, 0, slot);
         this.currentActionSlot = (this.currentActionSlot + 1) & this.actionRingMask;
         // Does NOT signal — caller must call sendCommand separately
     }

--- a/tests/integration/shared-memory.test.ts
+++ b/tests/integration/shared-memory.test.ts
@@ -17,6 +17,7 @@ describe('SharedMemoryManager', () => {
     });
 
     afterEach(() => {
+      vi.restoreAllMocks();
       shm?.dispose();
       shm = null;
     });
@@ -45,6 +46,37 @@ describe('SharedMemoryManager', () => {
 
       const readActions = shm!.readActions(slot2);
       expect(Array.from(readActions)).toEqual([16, 32, 1, 2]);
+    });
+
+    it.each([
+      ['writeActions', true],
+      ['writeActionsQuiet', false],
+    ] as const)('%s publishes the slot only after its payload', (method, shouldWakeWorker) => {
+      const actions = new Uint8Array([8, 4, 2, 1]);
+      const actionSlotIndex = shm!.getControl().actionSlotIndex;
+      const publishedPayloads: number[][] = [];
+      const atomics = (globalThis as any).Atomics as {
+        store(array: Int32Array, index: number, value: number): number;
+      };
+      const originalStore = atomics.store;
+      const storeSpy = vi.spyOn(atomics, 'store').mockImplementation((array: Int32Array, index: number, value: number) => {
+        if (array === actionSlotIndex) {
+          publishedPayloads.push(Array.from(shm!.readActions(value)));
+        }
+        return originalStore(array, index, value);
+      });
+
+      shm![method](actions);
+      storeSpy.mockRestore();
+
+      expect(publishedPayloads).toEqual([[8, 4, 2, 1]]);
+      expect(shm!.hasNewActions()).toBe(shouldWakeWorker);
+
+      if (!shouldWakeWorker) {
+        shm!.sendCommand(1);
+        expect(shm!.readCommand()).toBe(1);
+        expect(shm!.hasNewActions()).toBe(true);
+      }
     });
   });
 

--- a/tests/unit/worker-pool-protocol.test.ts
+++ b/tests/unit/worker-pool-protocol.test.ts
@@ -23,6 +23,7 @@ describe('WorkerPool message protocol', () => {
     expect(pool.callbacks.get(0xFFFFFFFF)).toBe(liveAtMax);
     expect(pool.callbacks.get(0)).toBe(liveAtZero);
 
+    expect(pool.callbacks.get(1)).toBeDefined();
     const callback = pool.callbacks.get(1);
     pool.callbacks.delete(1);
     clearTimeout(callback.timeout);

--- a/tests/unit/worker-pool-protocol.test.ts
+++ b/tests/unit/worker-pool-protocol.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WorkerPool } from '../../src/core/worker-pool';
+
+describe('WorkerPool message protocol', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('wraps the message counter and skips IDs with live callbacks', async () => {
+    vi.useFakeTimers();
+    const pool = new WorkerPool(1) as any;
+    const liveAtMax = { resolve: vi.fn(), reject: vi.fn(), timeout: undefined };
+    const liveAtZero = { resolve: vi.fn(), reject: vi.fn(), timeout: undefined };
+    pool.msgId = 0xFFFFFFFF;
+    pool.callbacks.set(0xFFFFFFFF, liveAtMax);
+    pool.callbacks.set(0, liveAtZero);
+
+    const worker = { postMessage: vi.fn() };
+    const response = pool.sendMessage(worker, { type: 'test' });
+
+    expect(worker.postMessage).toHaveBeenCalledWith({ id: 1, type: 'test' });
+    expect(pool.callbacks.get(0xFFFFFFFF)).toBe(liveAtMax);
+    expect(pool.callbacks.get(0)).toBe(liveAtZero);
+
+    const callback = pool.callbacks.get(1);
+    pool.callbacks.delete(1);
+    clearTimeout(callback.timeout);
+    callback.resolve('ok');
+
+    await expect(response).resolves.toBe('ok');
+  });
+
+  it('removes the allocated callback when a message times out', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const pool = new WorkerPool(1) as any;
+    const worker = { postMessage: vi.fn() };
+
+    const response = pool.sendMessage(worker, { type: 'test' });
+    const rejection = expect(response).rejects.toThrow('Message 0 timed out');
+    expect(pool.callbacks.has(0)).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(30000);
+
+    await rejection;
+    expect(pool.callbacks.has(0)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- bounds WorkerPool message IDs to uint32 and skips IDs that still have live callbacks
- prevents precision-loss callback collisions after numeric wrap
- writes shared action payload bytes before publishing the ring slot
- preserves existing worker command/wakeup and timeout cleanup behavior
- adds forced-wrap, timeout-cleanup, and publication-order regressions

## Validation

- `npm test -- tests/unit/worker-pool-protocol.test.ts tests/integration/shared-memory.test.ts` (10 passed)
- `git diff --check`
- `npm run typecheck` remains blocked by pre-existing errors also present on `main` (missing Node/ES2020 test libs and existing telemetry/test typing failures); this branch adds no new reported compiler category

Closes #33
Closes #48
Closes #125
Closes #148
Closes #149
Closes #154
Closes #161
