### PR TITLE
fix(prng): normalize state and remove integer bias

### DIFF
--- a/docs/DEOBFUSCATION_FIX_TRACKER.md
+++ b/docs/DEOBFUSCATION_FIX_TRACKER.md
@@ -368,7 +368,7 @@ math, benchmarks, map data, examples, and test infrastructure.
 | R3M3 | `TelemetryController.shutdown()` final report skipped by window guard; tick counters desynced | `telemetry-controller.ts` L309-320 | ❌ |
 | R3M4 | `startCollection()` interval never stopped on shutdown (dead code but latent leak) | `profiler.ts` L399-413 | ❌ |
 | R3M5 | `BonkEnv.stop()` calls `pool.close()` without await; port released before workers terminate — race on port reuse | `bonk-env.ts` L107, `worker-pool.ts` L588-604 | ✅ (close is awaited everywhere; pending callbacks rejected on close) |
-| R3M6 | `PRNG` seed not normalized to 32-bit unsigned — negative/large seeds break determinism | `prng.ts` L19-24, L30-32 | ❌ |
+| R3M6 | `PRNG` seed/state not normalized to 32-bit unsigned — out-of-domain seeds and long runs can leave the uint32 ring and lose precision | `prng.ts` L19-24, L30-32 | ✅ (seed and state normalized; canonical sequence preserved) |
 | R3M7 | Physics hooks permanently wrapped; trampoline adds 2 fn calls/tick even when telemetry disabled; no disable path | `physics-engine.ts` L759-781 | ❌ |
 | R3M8 | `bonk-env.ts` StepResult.observation typed `any`; contradicts `environment.ts` Observation; types README shows third shape | `bonk-env.ts` L28-34, `types/README.md` L44-57 | ❌ |
 | R3M9 | `ipc-bridge.test.ts` asserts step/reset without init returns `ok` — encodes missing-validation bug | `ipc-bridge.test.ts` L179-193 | ✅ (init validation added; tests updated including `ipc-bridge-constructor` telemetry-step tests) |

--- a/src/core/prng.ts
+++ b/src/core/prng.ts
@@ -7,6 +7,10 @@ const STATE_INCREMENT = 0x6D2B79F5;
  * This class implements the Mulberry32 algorithm, which is a fast, 
  * high-quality pseudorandom number generator suitable for applications 
  * requiring reproducible random sequences.
+ *
+ * next() always emits the canonical Mulberry32 sequence. nextInt() samples
+ * integers without modulo bias; see nextInt() for how rejection sampling
+ * affects stream consumption and backward-compatible outputs.
  */
 export class PRNG {
     /** 
@@ -60,7 +64,16 @@ export class PRNG {
      * @param max - The upper bound (inclusive). Will be floored to an integer.
      * @returns An integer in the range [min, max] (inclusive).
      * 
-     * @throws {Error} If min is greater than max after flooring or the inclusive
+     * Consumes exactly one raw 32-bit word when the inclusive range is a power
+     * of two, and the returned values are then identical to the previous
+     * float-scaled implementation. For every other range, rejection sampling
+     * may consume additional words and the returned values intentionally
+     * differ from the float-scaled implementation to remove modulo bias.
+     * Because draw consumption is data-dependent for such ranges, interleaving
+     * next() and nextInt() advances the shared stream by a variable number of
+* words; next() itself always emits the canonical sequence.
+ *
+ * @throws {Error} If min is greater than max after flooring or the inclusive
      *                 range contains more than 2^32 values.
      */
     nextInt(min: number, max: number): number {
@@ -83,6 +96,14 @@ export class PRNG {
             );
         }
 
+        // Powers of two evenly divide the uint32 space: one word is exactly
+        // uniform, and mapping it to the high bits matches the legacy
+        // float-scaled outputs exactly.
+        if ((range & (range - 1)) === 0) {
+            const value = this.next() * UINT32_SIZE;
+            return Math.floor(value / (UINT32_SIZE / range)) + _min;
+        }
+
         // Reject the incomplete high bucket so every result has the same number of preimages.
         const limit = UINT32_SIZE - (UINT32_SIZE % range);
         let value: number;
@@ -91,5 +112,25 @@ export class PRNG {
         } while (value >= limit);
 
         return (value % range) + _min;
+    }
+
+    /**
+     * Read the current internal state.
+     *
+     * Intended for tests and diagnostics; not part of the public API.
+     * @internal
+     */
+    getState(): number {
+        return this.a;
+    }
+
+    /**
+     * Overwrite the internal state, normalized to a 32-bit unsigned integer.
+     *
+     * Intended for tests and diagnostics; not part of the public API.
+     * @internal
+     */
+    setState(state: number): void {
+        this.a = state >>> 0;
     }
 }

--- a/src/core/prng.ts
+++ b/src/core/prng.ts
@@ -1,3 +1,6 @@
+const UINT32_SIZE = 0x100000000;
+const STATE_INCREMENT = 0x6D2B79F5;
+
 /**
  * PRNG based on Mulberry32 for deterministic random number generation.
  * 
@@ -13,14 +16,11 @@ export class PRNG {
 
     /**
      * Create a new PRNG instance with the given seed.
-     * @param seed - The initial seed. Any number can be used; the algorithm 
-     *               will mix it sufficiently through its operations.
+     * @param seed - The initial seed. It is normalized to a 32-bit unsigned integer.
      */
     constructor(seed: number) {
-        // Initialize state with the provided seed.
-        // Note: The Mulberry32 algorithm does not require additional seeding 
-        // steps beyond setting the initial state.
-        this.a = seed;
+        // Canonical Mulberry32 uses the normalized seed directly, without a warmup.
+        this.a = seed >>> 0;
     }
 
     /**
@@ -28,7 +28,7 @@ export class PRNG {
      * @param seed - The new seed value.
      */
     setSeed(seed: number): void {
-        this.a = seed;
+        this.a = seed >>> 0;
     }
 
     /**
@@ -41,8 +41,8 @@ export class PRNG {
      * 3. Extract the final 32-bit value and convert it to a fraction.
      */
     next(): number {
-        // Step 1: Update state with the golden ratio-like constant.
-        let t = this.a += 0x6D2B79F5;
+        // Step 1: Update state in the uint32 ring to avoid long-run precision loss.
+        let t = this.a = ((this.a >>> 0) + STATE_INCREMENT) >>> 0;
         
         // Step 2: First mixing step.
         t = Math.imul(t ^ t >>> 15, t | 1);
@@ -51,7 +51,7 @@ export class PRNG {
         t ^= t + Math.imul(t ^ t >>> 7, t | 61);
         
         // Step 4: Convert to unsigned 32-bit and then to double in [0, 1).
-        return ((t ^ t >>> 14) >>> 0) / 4294967296;
+        return ((t ^ t >>> 14) >>> 0) / UINT32_SIZE;
     }
 
     /**
@@ -60,7 +60,8 @@ export class PRNG {
      * @param max - The upper bound (inclusive). Will be floored to an integer.
      * @returns An integer in the range [min, max] (inclusive).
      * 
-     * @throws {Error} If min is greater than max after flooring.
+     * @throws {Error} If min is greater than max after flooring or the inclusive
+     *                 range contains more than 2^32 values.
      */
     nextInt(min: number, max: number): number {
         // Convert min and max to integers by flooring.
@@ -74,10 +75,21 @@ export class PRNG {
             );
         }
         
-        // Calculate the size of the range.
+        // Calculate the size of the range. One uint32 word can sample at most 2^32 values.
         const range = _max - _min + 1;
-        
-        // Generate a float in [0, 1), scale it to the range, and floor to get an integer.
-        return Math.floor(this.next() * range) + _min;
+        if (!(range >= 1 && range <= UINT32_SIZE)) {
+            throw new Error(
+                `Invalid range size: nextInt supports at most ${UINT32_SIZE} values`
+            );
+        }
+
+        // Reject the incomplete high bucket so every result has the same number of preimages.
+        const limit = UINT32_SIZE - (UINT32_SIZE % range);
+        let value: number;
+        do {
+            value = this.next() * UINT32_SIZE;
+        } while (value >= limit);
+
+        return (value % range) + _min;
     }
 }

--- a/src/core/prng.ts
+++ b/src/core/prng.ts
@@ -71,9 +71,9 @@ export class PRNG {
      * differ from the float-scaled implementation to remove modulo bias.
      * Because draw consumption is data-dependent for such ranges, interleaving
      * next() and nextInt() advances the shared stream by a variable number of
-* words; next() itself always emits the canonical sequence.
- *
- * @throws {Error} If min is greater than max after flooring or the inclusive
+     * words; next() itself always emits the canonical sequence.
+     *
+     * @throws {Error} If min is greater than max after flooring or the inclusive
      *                 range contains more than 2^32 values.
      */
     nextInt(min: number, max: number): number {

--- a/tests/unit/prng.test.ts
+++ b/tests/unit/prng.test.ts
@@ -8,14 +8,6 @@ import { PRNG } from '../../src/core/prng';
 const UINT32_SIZE = 0x100000000;
 const STATE_INCREMENT = 0x6D2B79F5;
 
-function getState(prng: PRNG): number {
-    return (prng as unknown as { a: number }).a;
-}
-
-function setState(prng: PRNG, state: number): void {
-    (prng as unknown as { a: number }).a = state;
-}
-
 describe('PRNG', () => {
     describe('basic random generation', () => {
         it('generates numbers in [0,1)', () => {
@@ -101,7 +93,7 @@ describe('PRNG', () => {
             const prng = new PRNG(seed);
             const normalized = new PRNG(normalizedSeed);
 
-            expect(getState(prng)).toBe(normalizedSeed);
+            expect(prng.getState()).toBe(normalizedSeed);
             expect(Array.from({ length: 20 }, () => prng.next())).toEqual(
                 Array.from({ length: 20 }, () => normalized.next())
             );
@@ -113,7 +105,7 @@ describe('PRNG', () => {
 
             prng.setSeed(UINT32_SIZE + 42);
 
-            expect(getState(prng)).toBe(42);
+            expect(prng.getState()).toBe(42);
             expect(Array.from({ length: 20 }, () => prng.next())).toEqual(
                 Array.from({ length: 20 }, () => normalized.next())
             );
@@ -124,30 +116,30 @@ describe('PRNG', () => {
 
             prng.next();
 
-            expect(getState(prng)).toBe((0xFFFFFFFF + STATE_INCREMENT) >>> 0);
+            expect(prng.getState()).toBe((0xFFFFFFFF + STATE_INCREMENT) >>> 0);
         });
 
         it('preserves the final output before the legacy state loses precision', () => {
             const legacyStateBeforeFinalExactStep = 4_917_757 * STATE_INCREMENT;
             const prng = new PRNG(0);
             const normalized = new PRNG(legacyStateBeforeFinalExactStep >>> 0);
-            setState(prng, legacyStateBeforeFinalExactStep);
+            prng.setState(legacyStateBeforeFinalExactStep);
 
             expect(prng.next()).toBe(normalized.next());
-            expect(getState(prng)).toBe(getState(normalized));
+            expect(prng.getState()).toBe(normalized.getState());
         });
 
         it('normalizes a forced long-running state before precision can alter the wrap', () => {
             const legacyStateAtPrecisionBoundary = 4_917_758 * STATE_INCREMENT;
             const prng = new PRNG(0);
             const normalized = new PRNG(legacyStateAtPrecisionBoundary >>> 0);
-            setState(prng, legacyStateAtPrecisionBoundary);
+            prng.setState(legacyStateAtPrecisionBoundary);
 
             expect((legacyStateAtPrecisionBoundary + STATE_INCREMENT) >>> 0).not.toBe(
                 ((legacyStateAtPrecisionBoundary >>> 0) + STATE_INCREMENT) >>> 0
             );
             expect(prng.next()).toBe(normalized.next());
-            expect(getState(prng)).toBe(getState(normalized));
+            expect(prng.getState()).toBe(normalized.getState());
         });
     });
 
@@ -219,10 +211,19 @@ describe('PRNG', () => {
             ]);
         });
 
-        it('supports the full uint32-sized inclusive range', () => {
+it('supports the full uint32-sized inclusive range', () => {
             const prng = new PRNG(0);
 
             expect(prng.nextInt(-0x80000000, 0x7FFFFFFF)).toBe(-0x3BCB4B9E);
+        });
+
+        it('matches legacy float-scaled outputs for power-of-two ranges using one word', () => {
+            const prng = new PRNG(42);
+
+            expect(Array.from({ length: 10 }, () => prng.nextInt(0, 7))).toEqual([
+                4, 3, 6, 5, 1, 4, 2, 4, 6, 3,
+            ]);
+            expect(prng.next()).toBe(0x3FFB0079 / UINT32_SIZE);
         });
 
         it('deterministically rejects values in the incomplete high bucket', () => {

--- a/tests/unit/prng.test.ts
+++ b/tests/unit/prng.test.ts
@@ -211,7 +211,7 @@ describe('PRNG', () => {
             ]);
         });
 
-it('supports the full uint32-sized inclusive range', () => {
+        it('supports the full uint32-sized inclusive range', () => {
             const prng = new PRNG(0);
 
             expect(prng.nextInt(-0x80000000, 0x7FFFFFFF)).toBe(-0x3BCB4B9E);

--- a/tests/unit/prng.test.ts
+++ b/tests/unit/prng.test.ts
@@ -5,6 +5,17 @@
 import { describe, it, expect } from 'vitest';
 import { PRNG } from '../../src/core/prng';
 
+const UINT32_SIZE = 0x100000000;
+const STATE_INCREMENT = 0x6D2B79F5;
+
+function getState(prng: PRNG): number {
+    return (prng as unknown as { a: number }).a;
+}
+
+function setState(prng: PRNG, state: number): void {
+    (prng as unknown as { a: number }).a = state;
+}
+
 describe('PRNG', () => {
     describe('basic random generation', () => {
         it('generates numbers in [0,1)', () => {
@@ -42,6 +53,102 @@ describe('PRNG', () => {
             const identical = seq1.every((v, i) => v === seq2[i]);
             expect(identical).toBe(true);
         });
+
+        it('matches the canonical Mulberry32 sequence without a warmup', () => {
+            const prng = new PRNG(0);
+            const expectedWords = [
+                0x4434B462,
+                0x00159C37,
+                0x39285B08,
+                0x256D8104,
+                0x77A2CBD4,
+                0x8B885631,
+                0x9D811D5F,
+                0xA623E7E6,
+                0x74BCE381,
+                0x94CAC42A,
+            ];
+
+            expect(expectedWords.map(() => prng.next())).toEqual(
+                expectedWords.map(word => word / UINT32_SIZE)
+            );
+        });
+
+        it('preserves the canonical sequence after setSeed', () => {
+            const prng = new PRNG(999);
+            prng.setSeed(42);
+
+            const expectedWords = [
+                0x99E1EF7C,
+                0x72C32B8A,
+                0xDA3B32C0,
+                0xAB73B0AD,
+                0x2CC09A8A,
+            ];
+
+            expect(expectedWords.map(() => prng.next())).toEqual(
+                expectedWords.map(word => word / UINT32_SIZE)
+            );
+        });
+    });
+
+    describe('uint32 state', () => {
+        it.each([
+            [-1, 0xFFFFFFFF],
+            [UINT32_SIZE + 42, 42],
+            [(2 ** 40) + 123, 123],
+        ])('normalizes seed %d to the same sequence as %d', (seed, normalizedSeed) => {
+            const prng = new PRNG(seed);
+            const normalized = new PRNG(normalizedSeed);
+
+            expect(getState(prng)).toBe(normalizedSeed);
+            expect(Array.from({ length: 20 }, () => prng.next())).toEqual(
+                Array.from({ length: 20 }, () => normalized.next())
+            );
+        });
+
+        it('normalizes setSeed values to uint32', () => {
+            const prng = new PRNG(0);
+            const normalized = new PRNG(42);
+
+            prng.setSeed(UINT32_SIZE + 42);
+
+            expect(getState(prng)).toBe(42);
+            expect(Array.from({ length: 20 }, () => prng.next())).toEqual(
+                Array.from({ length: 20 }, () => normalized.next())
+            );
+        });
+
+        it('wraps the internal state after every step', () => {
+            const prng = new PRNG(0xFFFFFFFF);
+
+            prng.next();
+
+            expect(getState(prng)).toBe((0xFFFFFFFF + STATE_INCREMENT) >>> 0);
+        });
+
+        it('preserves the final output before the legacy state loses precision', () => {
+            const legacyStateBeforeFinalExactStep = 4_917_757 * STATE_INCREMENT;
+            const prng = new PRNG(0);
+            const normalized = new PRNG(legacyStateBeforeFinalExactStep >>> 0);
+            setState(prng, legacyStateBeforeFinalExactStep);
+
+            expect(prng.next()).toBe(normalized.next());
+            expect(getState(prng)).toBe(getState(normalized));
+        });
+
+        it('normalizes a forced long-running state before precision can alter the wrap', () => {
+            const legacyStateAtPrecisionBoundary = 4_917_758 * STATE_INCREMENT;
+            const prng = new PRNG(0);
+            const normalized = new PRNG(legacyStateAtPrecisionBoundary >>> 0);
+            setState(prng, legacyStateAtPrecisionBoundary);
+
+            expect((legacyStateAtPrecisionBoundary + STATE_INCREMENT) >>> 0).not.toBe(
+                ((legacyStateAtPrecisionBoundary >>> 0) + STATE_INCREMENT) >>> 0
+            );
+            expect(prng.next()).toBe(normalized.next());
+            expect(getState(prng)).toBe(getState(normalized));
+        });
     });
 
     describe('different seeds', () => {
@@ -66,6 +173,13 @@ describe('PRNG', () => {
         it('throws when min > max', () => {
             const prng = new PRNG(123);
             expect(() => prng.nextInt(5, 2)).toThrow();
+        });
+
+        it('throws when the inclusive range exceeds the uint32 sample space', () => {
+            const prng = new PRNG(123);
+            expect(() => prng.nextInt(0, UINT32_SIZE)).toThrow(
+                `Invalid range size: nextInt supports at most ${UINT32_SIZE} values`
+            );
         });
     });
 
@@ -95,6 +209,27 @@ describe('PRNG', () => {
                 results.push(prng.nextInt(5, 10));
             }
             expect(results.includes(10)).toBe(true);
+        });
+
+        it('is deterministic with inclusive negative bounds', () => {
+            const prng = new PRNG(42);
+
+            expect(Array.from({ length: 10 }, () => prng.nextInt(-3, 3))).toEqual([
+                0, -1, -3, 1, 3, -2, -1, -3, 3, 1,
+            ]);
+        });
+
+        it('supports the full uint32-sized inclusive range', () => {
+            const prng = new PRNG(0);
+
+            expect(prng.nextInt(-0x80000000, 0x7FFFFFFF)).toBe(-0x3BCB4B9E);
+        });
+
+        it('deterministically rejects values in the incomplete high bucket', () => {
+            const prng = new PRNG(1);
+
+            expect(prng.nextInt(0, 0x80000000)).toBe(0x00B349C9);
+            expect(prng.next()).toBe(0x8706C4EB / UINT32_SIZE);
         });
     });
 


### PR DESCRIPTION
## Summary

- normalizes constructor, reset, and per-step PRNG state to the uint32 ring
- preserves canonical Mulberry32 outputs before the legacy implementation would lose integer precision
- replaces scaled-float integer sampling with deterministic rejection sampling
- supports inclusive ranges up to the complete uint32 sample space
- documents completion of deobfuscation tracker item R3M6
- adds canonical vectors, seed equivalence, state-wrap, precision-boundary, range, and rejection-path tests

## Validation

- `npm test -- tests/unit/prng.test.ts tests/unit/seed-determinism.test.ts` (38 passed)
- `git diff --check`
- `npm run typecheck` remains blocked by pre-existing failures also present on `main` (missing Node/ES2020 test libs and existing telemetry/test typing errors)

## Non-goals

This does not add seed warmup or seed hashing. Those reports were refuted because the implementation intentionally follows canonical Mulberry32.

Closes #57
Closes #93
Closes #106
Closes #122
Closes #123
Closes #147
