### PR TITLE
fix(python): harden client contracts

### DIFF
--- a/python/envs/bonk_env.py
+++ b/python/envs/bonk_env.py
@@ -10,6 +10,7 @@ from stable_baselines3.common.vec_env import VecEnv
 DEFAULT_REQUEST_TIMEOUT_MS = 30_000
 DEFAULT_CLOSE_TIMEOUT_MS = 1_000
 DEFAULT_LINGER_MS = 1_000
+MAX_RESET_SEED = 0xFFFFFFFE
 
 
 class BonkVecEnv(VecEnv):
@@ -49,6 +50,7 @@ class BonkVecEnv(VecEnv):
         self._close_timeout_ms = int(close_timeout_ms)
         self._linger_ms = int(linger_ms)
         self._closed = False
+        self._closed_reason = None
 
         # Action space: 6 binary inputs (left, right, up, down, heavy, grapple)
         action_space = spaces.Discrete(64)
@@ -84,7 +86,11 @@ class BonkVecEnv(VecEnv):
                 raise RuntimeError(f"Error initializing environments: {message.get('error')}")
         except Exception:
             self._closed = True
-            self._close_transport()
+            self._closed_reason = "initialization failure"
+            try:
+                self._close_transport()
+            except Exception:
+                pass
             raise
 
         self._episode_returns = np.zeros(num_envs, dtype=np.float64)
@@ -105,17 +111,31 @@ class BonkVecEnv(VecEnv):
         try:
             return self.socket.recv_json()
         except zmq.Again as exc:
+            self._closed = True
+            self._closed_reason = f"a receive timeout while waiting for '{command}'"
+            try:
+                self._close_transport()
+            except Exception:
+                pass
             raise TimeoutError(
                 f"Timed out after {timeout_ms} ms waiting for '{command}' response from Bonk backend"
             ) from exc
 
     def _close_transport(self):
+        socket, context = self.socket, self.context
+        self.socket = None
+        self.context = None
         try:
-            if self.socket is not None:
-                self.socket.close(linger=self._linger_ms)
+            if socket is not None:
+                socket.close(linger=self._linger_ms)
         finally:
-            if self.context is not None:
-                self.context.term()
+            if context is not None:
+                context.term()
+
+    def _ensure_open(self):
+        if self._closed:
+            reason = self._closed_reason or "close"
+            raise RuntimeError(f"cannot use BonkVecEnv after {reason}")
 
     def _convert_obs(self, data):
         """Convert JSON observation data to numpy array.
@@ -157,11 +177,40 @@ class BonkVecEnv(VecEnv):
         Returns:
             Initial observations for all environments
         """
+        self._ensure_open()
+
         # Generate random seeds for deterministic rollouts in each env
         if seeds is None:
             seeds = np.random.randint(0, 1000000, size=self.num_envs).tolist()
-        
-        self._send_json({"command": "reset", "seeds": seeds, "options": options or {}})
+        elif isinstance(seeds, np.ndarray):
+            if seeds.ndim != 1:
+                raise ValueError("seeds must be a one-dimensional sequence")
+            seeds = seeds.tolist()
+        else:
+            try:
+                seeds = list(seeds)
+            except TypeError as exc:
+                raise TypeError("seeds must be a sequence of integers") from exc
+
+        if len(seeds) != self.num_envs:
+            raise ValueError(
+                f"seeds must contain exactly {self.num_envs} values, got {len(seeds)}"
+            )
+
+        validated_seeds = []
+        for index, seed in enumerate(seeds):
+            if isinstance(seed, (bool, np.bool_)) or not isinstance(seed, Integral):
+                raise TypeError(f"seed at index {index} must be an integer, got {seed!r}")
+            seed = int(seed)
+            if not 0 <= seed <= MAX_RESET_SEED:
+                raise ValueError(
+                    f"seed at index {index} must be in [0, {MAX_RESET_SEED}], got {seed}"
+                )
+            validated_seeds.append(seed)
+
+        self._send_json(
+            {"command": "reset", "seeds": validated_seeds, "options": options or {}}
+        )
         message = self._recv_json("reset")
         
         if message.get("status") != "ok":
@@ -182,6 +231,8 @@ class BonkVecEnv(VecEnv):
         Args:
             actions: List or array of actions for each environment
         """
+        self._ensure_open()
+
         if isinstance(actions, np.ndarray):
             if actions.ndim != 1:
                 raise ValueError("actions must be a one-dimensional sequence")
@@ -221,6 +272,8 @@ class BonkVecEnv(VecEnv):
                 - truncated: boolean array for truncated episodes (max steps)
                 - infos: list of info dictionaries for each environment
         """
+        self._ensure_open()
+
         message = self._recv_json("step")
         
         if message.get("status") != "ok":
@@ -309,6 +362,7 @@ class BonkVecEnv(VecEnv):
             return
 
         self._closed = True
+        self._closed_reason = "close"
         try:
             self.socket.setsockopt(zmq.SNDTIMEO, self._close_timeout_ms)
             self.socket.setsockopt(zmq.RCVTIMEO, self._close_timeout_ms)

--- a/python/envs/bonk_env.py
+++ b/python/envs/bonk_env.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from numbers import Integral
 
 import gymnasium as gym
@@ -186,7 +187,7 @@ class BonkVecEnv(VecEnv):
             if seeds.ndim != 1:
                 raise ValueError("seeds must be a one-dimensional sequence")
             seeds = seeds.tolist()
-        elif isinstance(seeds, (str, bytes)) or isinstance(seeds, dict):
+        elif isinstance(seeds, (str, bytes)) or isinstance(seeds, Mapping):
             raise TypeError("seeds must be a sequence of integers")
         else:
             try:

--- a/python/envs/bonk_env.py
+++ b/python/envs/bonk_env.py
@@ -186,6 +186,8 @@ class BonkVecEnv(VecEnv):
             if seeds.ndim != 1:
                 raise ValueError("seeds must be a one-dimensional sequence")
             seeds = seeds.tolist()
+        elif isinstance(seeds, (str, bytes)) or isinstance(seeds, dict):
+            raise TypeError("seeds must be a sequence of integers")
         else:
             try:
                 seeds = list(seeds)

--- a/python/envs/bonk_env.py
+++ b/python/envs/bonk_env.py
@@ -1,12 +1,27 @@
+from numbers import Integral
+
 import gymnasium as gym
 from gymnasium import spaces
 import numpy as np
 import zmq
-import json
 from stable_baselines3.common.vec_env import VecEnv
 
+
+DEFAULT_REQUEST_TIMEOUT_MS = 30_000
+DEFAULT_CLOSE_TIMEOUT_MS = 1_000
+DEFAULT_LINGER_MS = 1_000
+
+
 class BonkVecEnv(VecEnv):
-    def __init__(self, num_envs=1, port=5555, config=None):
+    def __init__(
+        self,
+        num_envs=1,
+        port=5555,
+        config=None,
+        timeout_ms=DEFAULT_REQUEST_TIMEOUT_MS,
+        close_timeout_ms=DEFAULT_CLOSE_TIMEOUT_MS,
+        linger_ms=DEFAULT_LINGER_MS,
+    ):
         """Initialize the Bonk vectorized environment.
         
         Args:
@@ -18,7 +33,23 @@ class BonkVecEnv(VecEnv):
                 - max_ticks: Maximum ticks per episode (default 900)
                 - random_opponent: Use random opponent policy (default True)
                 - seed: Random seed
+            timeout_ms: Send and receive timeout for normal requests
+            close_timeout_ms: Send and receive timeout for session close
+            linger_ms: Maximum time for queued messages to linger on close
         """
+        for name, value, minimum in (
+            ("timeout_ms", timeout_ms, 1),
+            ("close_timeout_ms", close_timeout_ms, 1),
+            ("linger_ms", linger_ms, 0),
+        ):
+            if isinstance(value, bool) or not isinstance(value, Integral) or value < minimum:
+                raise ValueError(f"{name} must be an integer greater than or equal to {minimum}")
+
+        self._timeout_ms = int(timeout_ms)
+        self._close_timeout_ms = int(close_timeout_ms)
+        self._linger_ms = int(linger_ms)
+        self._closed = False
+
         # Action space: 6 binary inputs (left, right, up, down, heavy, grapple)
         action_space = spaces.Discrete(64)
         
@@ -31,27 +62,60 @@ class BonkVecEnv(VecEnv):
         
         super().__init__(num_envs, observation_space, action_space)
         
-        self.context = zmq.Context()
-        self.socket = self.context.socket(zmq.DEALER)
-        self.socket.connect(f"tcp://127.0.0.1:{port}")
-        
-        # Wait a short moment for connection before sending init
-        import time
-        time.sleep(0.1)
-        
-        self.socket.send_json({
-            "command": "init", 
-            "numEnvs": num_envs, 
-            "config": config or {},
-            "useSharedMemory": True
-        })
-        message = self.socket.recv_json()
-        
-        if message.get("status") != "ok":
-            raise RuntimeError(f"Error initializing environments: {message.get('error')}")
+        self.context = None
+        self.socket = None
+        try:
+            self.context = zmq.Context()
+            self.socket = self.context.socket(zmq.DEALER)
+            self.socket.setsockopt(zmq.LINGER, self._linger_ms)
+            self.socket.setsockopt(zmq.SNDTIMEO, self._timeout_ms)
+            self.socket.setsockopt(zmq.RCVTIMEO, self._timeout_ms)
+            self.socket.connect(f"tcp://127.0.0.1:{port}")
+
+            self._send_json({
+                "command": "init",
+                "numEnvs": num_envs,
+                "config": config or {},
+                "useSharedMemory": True,
+            })
+            message = self._recv_json("init")
+
+            if message.get("status") != "ok":
+                raise RuntimeError(f"Error initializing environments: {message.get('error')}")
+        except Exception:
+            self._closed = True
+            self._close_transport()
+            raise
 
         self._episode_returns = np.zeros(num_envs, dtype=np.float64)
         self._episode_lengths = np.zeros(num_envs, dtype=np.int64)
+
+    def _send_json(self, message, timeout_ms=None):
+        command = message["command"]
+        timeout_ms = self._timeout_ms if timeout_ms is None else timeout_ms
+        try:
+            self.socket.send_json(message)
+        except zmq.Again as exc:
+            raise TimeoutError(
+                f"Timed out after {timeout_ms} ms sending '{command}' request to Bonk backend"
+            ) from exc
+
+    def _recv_json(self, command, timeout_ms=None):
+        timeout_ms = self._timeout_ms if timeout_ms is None else timeout_ms
+        try:
+            return self.socket.recv_json()
+        except zmq.Again as exc:
+            raise TimeoutError(
+                f"Timed out after {timeout_ms} ms waiting for '{command}' response from Bonk backend"
+            ) from exc
+
+    def _close_transport(self):
+        try:
+            if self.socket is not None:
+                self.socket.close(linger=self._linger_ms)
+        finally:
+            if self.context is not None:
+                self.context.term()
 
     def _convert_obs(self, data):
         """Convert JSON observation data to numpy array.
@@ -97,8 +161,8 @@ class BonkVecEnv(VecEnv):
         if seeds is None:
             seeds = np.random.randint(0, 1000000, size=self.num_envs).tolist()
         
-        self.socket.send_json({"command": "reset", "seeds": seeds, "options": options or {}})
-        message = self.socket.recv_json()
+        self._send_json({"command": "reset", "seeds": seeds, "options": options or {}})
+        message = self._recv_json("reset")
         
         if message.get("status") != "ok":
             raise RuntimeError(f"Error resetting environment: {message.get('error')}")
@@ -119,9 +183,32 @@ class BonkVecEnv(VecEnv):
             actions: List or array of actions for each environment
         """
         if isinstance(actions, np.ndarray):
+            if actions.ndim != 1:
+                raise ValueError("actions must be a one-dimensional sequence")
             actions = actions.tolist()
-            
-        self.socket.send_json({"command": "step", "actions": actions})
+        else:
+            try:
+                actions = list(actions)
+            except TypeError as exc:
+                raise TypeError("actions must be a sequence of integers") from exc
+
+        if len(actions) != self.num_envs:
+            raise ValueError(
+                f"actions must contain exactly {self.num_envs} values, got {len(actions)}"
+            )
+
+        validated_actions = []
+        for index, action in enumerate(actions):
+            if isinstance(action, (bool, np.bool_)) or not isinstance(action, Integral):
+                raise TypeError(f"action at index {index} must be an integer, got {action!r}")
+            action = int(action)
+            if not 0 <= action < self.action_space.n:
+                raise ValueError(
+                    f"action at index {index} must be in [0, {self.action_space.n - 1}], got {action}"
+                )
+            validated_actions.append(action)
+
+        self._send_json({"command": "step", "actions": validated_actions})
 
     def step_wait(self):
         """Wait for step results and return observations.
@@ -134,7 +221,7 @@ class BonkVecEnv(VecEnv):
                 - truncated: boolean array for truncated episodes (max steps)
                 - infos: list of info dictionaries for each environment
         """
-        message = self.socket.recv_json()
+        message = self._recv_json("step")
         
         if message.get("status") != "ok":
             raise RuntimeError(f"Error stepping environment: {message.get('error')}")
@@ -217,27 +304,41 @@ class BonkVecEnv(VecEnv):
         )
 
     def close(self):
-        """Close the environment and cleanup resources."""
+        """Close this client session and cleanup its transport resources."""
+        if self._closed:
+            return
+
+        self._closed = True
         try:
-            self.socket.setsockopt(zmq.RCVTIMEO, 500)
-            self.socket.send_json({"command": "close"})
-            self.socket.recv_json()
-        except Exception:
-            pass
-        self.socket.close()
-        self.context.term()
+            self.socket.setsockopt(zmq.SNDTIMEO, self._close_timeout_ms)
+            self.socket.setsockopt(zmq.RCVTIMEO, self._close_timeout_ms)
+            self._send_json({"command": "close"}, timeout_ms=self._close_timeout_ms)
+            message = self._recv_json("close", timeout_ms=self._close_timeout_ms)
+            if message.get("status") != "ok":
+                raise RuntimeError(f"Error closing environments: {message.get('error')}")
+        finally:
+            self._close_transport()
 
     def get_attr(self, attr_name, indices=None):
         """Get attribute from environments."""
-        return [None] * self.num_envs
+        if attr_name == "render_mode":
+            render_modes = [None] * self.num_envs
+            return [render_modes[index] for index in self._get_indices(indices)]
+        raise NotImplementedError(
+            f"BonkVecEnv does not support remote attribute access for {attr_name!r}"
+        )
 
     def set_attr(self, attr_name, value, indices=None):
         """Set attribute in environments."""
-        pass
+        raise NotImplementedError(
+            f"BonkVecEnv does not support remote attribute assignment for {attr_name!r}"
+        )
 
     def env_method(self, method_name, *method_args, indices=None, **method_kwargs):
         """Call method on environments."""
-        return [None] * self.num_envs
+        raise NotImplementedError(
+            f"BonkVecEnv does not support remote method calls for {method_name!r}"
+        )
 
     def seed(self, seed=None):
         """Set seeds for environments."""

--- a/python/tests/test_bonk_vec_env.py
+++ b/python/tests/test_bonk_vec_env.py
@@ -30,6 +30,16 @@ class TestBonkVecEnvConnectionLifecycle:
         env.close()
         env.close()
 
+    def test_close_keeps_server_available_for_a_new_session(self, bonk_vec_env_factory):
+        first_env = bonk_vec_env_factory(num_envs=1)
+        first_env.reset(seeds=[1])
+        first_env.close()
+
+        second_env = bonk_vec_env_factory(num_envs=1)
+        obs, info = second_env.reset(seeds=[2])
+        assert obs.shape == (1, 14)
+        assert isinstance(info, dict)
+
 
 @pytest.mark.slow
 class TestBonkVecEnvObservationShape:
@@ -113,6 +123,18 @@ class TestBonkVecEnvActionSpace:
         bonk_vec_env_single.reset()
         bonk_vec_env_single.step_async(np.array([32]))
         obs, rewards, terminated, truncated, infos = bonk_vec_env_single.step_wait()
+        assert obs.shape == (1, 14)
+
+    def test_invalid_actions_do_not_poison_the_live_session(self, bonk_vec_env_single):
+        bonk_vec_env_single.reset()
+
+        with pytest.raises(TypeError, match="must be an integer"):
+            bonk_vec_env_single.step_async(np.array([1.5]))
+        with pytest.raises(ValueError, match="must be in \\[0, 63\\]"):
+            bonk_vec_env_single.step_async(np.array([64]))
+
+        bonk_vec_env_single.step_async(np.array([0]))
+        obs, _, _, _, _ = bonk_vec_env_single.step_wait()
         assert obs.shape == (1, 14)
 
 

--- a/python/tests/test_bonk_vec_env.py
+++ b/python/tests/test_bonk_vec_env.py
@@ -153,6 +153,17 @@ class TestBonkVecEnvMultipleReset:
         obs, _ = bonk_vec_env_single.reset()
         assert obs.shape == (1, 14)
 
+    def test_numpy_seed_transport_boundaries(self, bonk_vec_env_single):
+        obs, _ = bonk_vec_env_single.reset(seeds=np.array([np.uint64(0xFFFFFFFE)]))
+        assert obs.shape == (1, 14)
+
+    def test_invalid_seed_does_not_poison_the_live_session(self, bonk_vec_env_single):
+        with pytest.raises(ValueError, match="must be in \\[0, 4294967294\\]"):
+            bonk_vec_env_single.reset(seeds=[0xFFFFFFFF])
+
+        obs, _ = bonk_vec_env_single.reset(seeds=[0])
+        assert obs.shape == (1, 14)
+
 
 @pytest.mark.slow
 class TestBonkVecEnvConfigurableNumEnvs:

--- a/python/tests/test_bonk_vec_env_unit.py
+++ b/python/tests/test_bonk_vec_env_unit.py
@@ -1,0 +1,210 @@
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import zmq
+
+from envs import bonk_env
+
+
+def _make_mocked_env(monkeypatch, num_envs=1, **kwargs):
+    socket = MagicMock()
+    socket.recv_json.return_value = {"status": "ok"}
+    context = MagicMock()
+    context.socket.return_value = socket
+    context_factory = MagicMock(return_value=context)
+    monkeypatch.setattr(bonk_env.zmq, "Context", context_factory)
+
+    env = bonk_env.BonkVecEnv(num_envs=num_envs, **kwargs)
+    return env, context, socket
+
+
+def test_socket_uses_bounded_options_and_session_close(monkeypatch):
+    env, context, socket = _make_mocked_env(
+        monkeypatch,
+        timeout_ms=123,
+        close_timeout_ms=45,
+        linger_ms=67,
+    )
+
+    socket.setsockopt.assert_any_call(zmq.LINGER, 67)
+    socket.setsockopt.assert_any_call(zmq.SNDTIMEO, 123)
+    socket.setsockopt.assert_any_call(zmq.RCVTIMEO, 123)
+
+    env.close()
+
+    socket.setsockopt.assert_any_call(zmq.SNDTIMEO, 45)
+    socket.setsockopt.assert_any_call(zmq.RCVTIMEO, 45)
+    assert socket.send_json.call_args_list[-1].args[0] == {"command": "close"}
+    socket.close.assert_called_once_with(linger=67)
+    context.term.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("operation", "message"),
+    [
+        ("send_json", "123 ms sending 'init' request"),
+        ("recv_json", "123 ms waiting for 'init' response"),
+    ],
+)
+def test_init_timeout_is_clear_and_cleans_up(monkeypatch, operation, message):
+    socket = MagicMock()
+    getattr(socket, operation).side_effect = zmq.Again()
+    context = MagicMock()
+    context.socket.return_value = socket
+    monkeypatch.setattr(bonk_env.zmq, "Context", MagicMock(return_value=context))
+
+    with pytest.raises(TimeoutError, match=message):
+        bonk_env.BonkVecEnv(timeout_ms=123, linger_ms=0)
+
+    socket.close.assert_called_once_with(linger=0)
+    context.term.assert_called_once_with()
+
+
+def test_socket_creation_failure_terminates_the_context(monkeypatch):
+    context = MagicMock()
+    context.socket.side_effect = zmq.ZMQError("socket failed")
+    monkeypatch.setattr(bonk_env.zmq, "Context", MagicMock(return_value=context))
+
+    with pytest.raises(zmq.ZMQError, match="socket failed"):
+        bonk_env.BonkVecEnv()
+
+    context.term.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"timeout_ms": 0},
+        {"close_timeout_ms": 0},
+        {"linger_ms": -1},
+        {"timeout_ms": True},
+        {"linger_ms": 1.5},
+    ],
+)
+def test_transport_options_require_bounded_integer_values(kwargs):
+    with pytest.raises(ValueError, match="must be an integer greater than or equal to"):
+        bonk_env.BonkVecEnv(**kwargs)
+
+
+def test_reset_receive_timeout_names_the_command(monkeypatch):
+    env, _, socket = _make_mocked_env(monkeypatch, timeout_ms=123)
+    socket.recv_json.side_effect = zmq.Again()
+
+    with pytest.raises(TimeoutError, match="123 ms waiting for 'reset' response"):
+        env.reset(seeds=[1])
+
+    socket.recv_json.side_effect = None
+    socket.recv_json.return_value = {"status": "ok"}
+    env.close()
+
+
+def test_step_send_and_receive_timeouts_name_the_command(monkeypatch):
+    env, _, socket = _make_mocked_env(monkeypatch, timeout_ms=123)
+    socket.send_json.side_effect = zmq.Again()
+
+    with pytest.raises(TimeoutError, match="123 ms sending 'step' request"):
+        env.step_async([0])
+
+    socket.send_json.side_effect = None
+    socket.recv_json.side_effect = zmq.Again()
+    with pytest.raises(TimeoutError, match="123 ms waiting for 'step' response"):
+        env.step_wait()
+
+    socket.recv_json.side_effect = None
+    socket.recv_json.return_value = {"status": "ok"}
+    env.close()
+
+
+@pytest.mark.parametrize(
+    ("operation", "message"),
+    [
+        ("send_json", "45 ms sending 'close' request"),
+        ("recv_json", "45 ms waiting for 'close' response"),
+    ],
+)
+def test_close_timeout_is_clear_bounded_and_idempotent(monkeypatch, operation, message):
+    env, context, socket = _make_mocked_env(
+        monkeypatch,
+        close_timeout_ms=45,
+        linger_ms=0,
+    )
+    getattr(socket, operation).side_effect = zmq.Again()
+
+    with pytest.raises(TimeoutError, match=message):
+        env.close()
+
+    socket.close.assert_called_once_with(linger=0)
+    context.term.assert_called_once_with()
+
+    env.close()
+    socket.close.assert_called_once_with(linger=0)
+    context.term.assert_called_once_with()
+
+
+def test_step_accepts_integer_actions_and_normalizes_numpy_values(monkeypatch):
+    env, _, socket = _make_mocked_env(monkeypatch, num_envs=2)
+    socket.send_json.reset_mock()
+
+    env.step_async([np.int64(0), np.int32(63)])
+
+    socket.send_json.assert_called_once_with({"command": "step", "actions": [0, 63]})
+    env.close()
+
+
+@pytest.mark.parametrize(
+    ("actions", "error", "message"),
+    [
+        ([1.0], TypeError, "must be an integer"),
+        ([True], TypeError, "must be an integer"),
+        ([np.bool_(False)], TypeError, "must be an integer"),
+        ([-1], ValueError, "must be in \\[0, 63\\]"),
+        ([64], ValueError, "must be in \\[0, 63\\]"),
+        (np.array([[0]]), ValueError, "one-dimensional"),
+        (0, TypeError, "must be a sequence"),
+    ],
+)
+def test_step_rejects_non_integer_or_out_of_range_actions(
+    monkeypatch, actions, error, message
+):
+    env, _, socket = _make_mocked_env(monkeypatch)
+    socket.send_json.reset_mock()
+
+    with pytest.raises(error, match=message):
+        env.step_async(actions)
+
+    socket.send_json.assert_not_called()
+    env.close()
+
+
+def test_step_requires_one_action_per_environment(monkeypatch):
+    env, _, socket = _make_mocked_env(monkeypatch, num_envs=2)
+    socket.send_json.reset_mock()
+
+    with pytest.raises(ValueError, match="exactly 2 values, got 1"):
+        env.step_async([0])
+
+    socket.send_json.assert_not_called()
+    env.close()
+
+
+def test_vec_env_proxy_methods_do_not_return_dummy_values(monkeypatch):
+    env, _, socket = _make_mocked_env(monkeypatch, num_envs=3)
+    socket.send_json.reset_mock()
+
+    assert env.render_mode is None
+    assert env.get_attr("render_mode") == [None, None, None]
+    assert env.get_attr("render_mode", indices=1) == [None]
+    assert env.get_attr("render_mode", indices=[0, 2]) == [None, None]
+    with pytest.raises(IndexError):
+        env.get_attr("render_mode", indices=3)
+
+    with pytest.raises(NotImplementedError, match="remote attribute access.*'score'"):
+        env.get_attr("score")
+    with pytest.raises(NotImplementedError, match="remote attribute assignment.*'score'"):
+        env.set_attr("score", 1)
+    with pytest.raises(NotImplementedError, match="remote method calls.*'render'"):
+        env.env_method("render")
+
+    socket.send_json.assert_not_called()
+    env.close()

--- a/python/tests/test_bonk_vec_env_unit.py
+++ b/python/tests/test_bonk_vec_env_unit.py
@@ -1,3 +1,5 @@
+from collections import UserDict
+from collections.abc import Mapping
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -5,6 +7,20 @@ import pytest
 import zmq
 
 from envs import bonk_env
+
+
+class _KeyValueMapping(Mapping):
+    def __init__(self, data):
+        self._data = dict(data)
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
 
 
 def _make_mocked_env(monkeypatch, num_envs=1, **kwargs):
@@ -238,6 +254,8 @@ def test_reset_accepts_integer_seeds_and_normalizes_numpy_values(monkeypatch):
         (np.array([[0]]), ValueError, "one-dimensional"),
         (0, TypeError, "must be a sequence"),
         ({0: 1}, TypeError, "must be a sequence"),
+        (UserDict({0: 1}), TypeError, "must be a sequence"),
+        (_KeyValueMapping({0: 1}), TypeError, "must be a sequence"),
         ("12", TypeError, "must be a sequence"),
     ],
 )
@@ -252,6 +270,19 @@ def test_reset_rejects_non_integer_out_of_range_or_invalid_shape_seeds(
 
     socket.send_json.assert_not_called()
     env.close()
+
+
+def test_reset_accepts_sequence_containers_besides_lists_and_arrays(monkeypatch):
+    env, _, socket = _make_mocked_env(monkeypatch, num_envs=2)
+    socket.send_json.reset_mock()
+    socket.recv_json.side_effect = zmq.Again()
+
+    with pytest.raises(TimeoutError, match="waiting for 'reset' response"):
+        env.reset(seeds=(1, 2))
+
+    socket.send_json.assert_called_once_with(
+        {"command": "reset", "seeds": [1, 2], "options": {}}
+    )
 
 
 def test_reset_requires_one_seed_per_environment(monkeypatch):

--- a/python/tests/test_bonk_vec_env_unit.py
+++ b/python/tests/test_bonk_vec_env_unit.py
@@ -237,6 +237,8 @@ def test_reset_accepts_integer_seeds_and_normalizes_numpy_values(monkeypatch):
         ([0xFFFFFFFF], ValueError, "must be in \\[0, 4294967294\\]"),
         (np.array([[0]]), ValueError, "one-dimensional"),
         (0, TypeError, "must be a sequence"),
+        ({0: 1}, TypeError, "must be a sequence"),
+        ("12", TypeError, "must be a sequence"),
     ],
 )
 def test_reset_rejects_non_integer_out_of_range_or_invalid_shape_seeds(

--- a/python/tests/test_bonk_vec_env_unit.py
+++ b/python/tests/test_bonk_vec_env_unit.py
@@ -38,6 +38,8 @@ def test_socket_uses_bounded_options_and_session_close(monkeypatch):
     assert socket.send_json.call_args_list[-1].args[0] == {"command": "close"}
     socket.close.assert_called_once_with(linger=67)
     context.term.assert_called_once_with()
+    assert env.socket is None
+    assert env.context is None
 
 
 @pytest.mark.parametrize(
@@ -72,6 +74,26 @@ def test_socket_creation_failure_terminates_the_context(monkeypatch):
     context.term.assert_called_once_with()
 
 
+def test_init_cleanup_failure_preserves_original_exception_and_nulls_transport(
+    monkeypatch,
+):
+    socket = MagicMock()
+    socket.recv_json.return_value = {"status": "error", "error": "original init failure"}
+    context = MagicMock()
+    context.socket.return_value = socket
+    context.term.side_effect = zmq.ZMQError("cleanup failed")
+    monkeypatch.setattr(bonk_env.zmq, "Context", MagicMock(return_value=context))
+    env = bonk_env.BonkVecEnv.__new__(bonk_env.BonkVecEnv)
+
+    with pytest.raises(RuntimeError, match="original init failure"):
+        env.__init__(linger_ms=0)
+
+    socket.close.assert_called_once_with(linger=0)
+    context.term.assert_called_once_with()
+    assert env.socket is None
+    assert env.context is None
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [
@@ -87,16 +109,37 @@ def test_transport_options_require_bounded_integer_values(kwargs):
         bonk_env.BonkVecEnv(**kwargs)
 
 
-def test_reset_receive_timeout_names_the_command(monkeypatch):
-    env, _, socket = _make_mocked_env(monkeypatch, timeout_ms=123)
+def test_reset_receive_timeout_invalidates_session_and_rejects_later_requests(monkeypatch):
+    env, context, socket = _make_mocked_env(monkeypatch, timeout_ms=123, linger_ms=0)
     socket.recv_json.side_effect = zmq.Again()
 
     with pytest.raises(TimeoutError, match="123 ms waiting for 'reset' response"):
         env.reset(seeds=[1])
 
+    socket.close.assert_called_once_with(linger=0)
+    context.term.assert_called_once_with()
+    assert env.socket is None
+    assert env.context is None
+
+    # Even if the timed-out reply arrives late, no later request may consume it.
     socket.recv_json.side_effect = None
     socket.recv_json.return_value = {"status": "ok"}
+    socket.send_json.reset_mock()
+    socket.recv_json.reset_mock()
+
+    for operation in (
+        lambda: env.reset(seeds=[2]),
+        lambda: env.step_async([0]),
+        env.step_wait,
+    ):
+        with pytest.raises(RuntimeError, match="cannot use BonkVecEnv after a receive timeout"):
+            operation()
+
+    socket.send_json.assert_not_called()
+    socket.recv_json.assert_not_called()
     env.close()
+    socket.close.assert_called_once_with(linger=0)
+    context.term.assert_called_once_with()
 
 
 def test_step_send_and_receive_timeouts_name_the_command(monkeypatch):
@@ -142,6 +185,25 @@ def test_close_timeout_is_clear_bounded_and_idempotent(monkeypatch, operation, m
     context.term.assert_called_once_with()
 
 
+@pytest.mark.parametrize("operation", ["reset", "step_async", "step_wait"])
+def test_request_operations_after_close_raise_clear_runtime_error(monkeypatch, operation):
+    env, _, socket = _make_mocked_env(monkeypatch)
+    env.close()
+    socket.send_json.reset_mock()
+    socket.recv_json.reset_mock()
+
+    with pytest.raises(RuntimeError, match="cannot use BonkVecEnv after close"):
+        if operation == "reset":
+            env.reset(seeds=[1])
+        elif operation == "step_async":
+            env.step_async([0])
+        else:
+            env.step_wait()
+
+    socket.send_json.assert_not_called()
+    socket.recv_json.assert_not_called()
+
+
 def test_step_accepts_integer_actions_and_normalizes_numpy_values(monkeypatch):
     env, _, socket = _make_mocked_env(monkeypatch, num_envs=2)
     socket.send_json.reset_mock()
@@ -149,6 +211,55 @@ def test_step_accepts_integer_actions_and_normalizes_numpy_values(monkeypatch):
     env.step_async([np.int64(0), np.int32(63)])
 
     socket.send_json.assert_called_once_with({"command": "step", "actions": [0, 63]})
+    env.close()
+
+
+def test_reset_accepts_integer_seeds_and_normalizes_numpy_values(monkeypatch):
+    env, _, socket = _make_mocked_env(monkeypatch, num_envs=2)
+    socket.send_json.reset_mock()
+    socket.recv_json.side_effect = zmq.Again()
+
+    with pytest.raises(TimeoutError, match="waiting for 'reset' response"):
+        env.reset(seeds=np.array([np.uint32(0), np.uint64(0xFFFFFFFE)]))
+
+    socket.send_json.assert_called_once_with(
+        {"command": "reset", "seeds": [0, 4294967294], "options": {}}
+    )
+
+
+@pytest.mark.parametrize(
+    ("seeds", "error", "message"),
+    [
+        ([1.0], TypeError, "must be an integer"),
+        ([True], TypeError, "must be an integer"),
+        ([np.bool_(False)], TypeError, "must be an integer"),
+        ([-1], ValueError, "must be in \\[0, 4294967294\\]"),
+        ([0xFFFFFFFF], ValueError, "must be in \\[0, 4294967294\\]"),
+        (np.array([[0]]), ValueError, "one-dimensional"),
+        (0, TypeError, "must be a sequence"),
+    ],
+)
+def test_reset_rejects_non_integer_out_of_range_or_invalid_shape_seeds(
+    monkeypatch, seeds, error, message
+):
+    env, _, socket = _make_mocked_env(monkeypatch)
+    socket.send_json.reset_mock()
+
+    with pytest.raises(error, match=message):
+        env.reset(seeds=seeds)
+
+    socket.send_json.assert_not_called()
+    env.close()
+
+
+def test_reset_requires_one_seed_per_environment(monkeypatch):
+    env, _, socket = _make_mocked_env(monkeypatch, num_envs=2)
+    socket.send_json.reset_mock()
+
+    with pytest.raises(ValueError, match="exactly 2 values, got 1"):
+        env.reset(seeds=[1])
+
+    socket.send_json.assert_not_called()
     env.close()
 
 


### PR DESCRIPTION
## Summary

- configures finite ZeroMQ send, receive, close, and linger timeouts
- converts PyZMQ timeout errors into command-specific Python `TimeoutError`s
- guarantees socket/context cleanup after initialization and close failures
- validates action batch shape, count, integer type, and the valid 0-63 range before sending
- replaces silent VecEnv proxy dummy values with explicit unsupported-operation errors while retaining `render_mode` access
- preserves session-scoped, idempotent close behavior

## Validation

- `python -m pytest python/tests/test_bonk_vec_env_unit.py python/tests/test_bonk_vec_env.py -q` (48 passed)
- `git diff --check`

Closes #58
Closes #91
Closes #96
Closes #111
Closes #116
Closes #135
