### PR TITLE
fix(workers): fail pool on crash or timeout

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -260,7 +260,11 @@ export class WorkerPool {
                 if (this.callbacks.has(id)) {
                     this.callbacks.delete(id);
                     console.error(`[WorkerPool] Message ${id} timed out`);
-                    reject(new Error(`Message ${id} timed out`));
+                    const err = new Error(`Message ${id} timed out`) as Error & { code?: string };
+                    // A timed-out reply means the worker is hung/unreachable,
+                    // which is distinct from an error reply from a live worker.
+                    err.code = 'WORKER_TIMEOUT';
+                    reject(err);
                 }
             }, getConfig().workerPool.messageTimeoutMs);
             this.callbacks.set(id, { resolve, reject, timeout });
@@ -351,10 +355,11 @@ export class WorkerPool {
             }
             const failure = this.createFailure('reset', error);
             // Shared-memory batches can corrupt or desync the pool, so any
-            // failure there is fatal. Message-passing failures are transient
-            // (a worker error reply or a slow worker) and must not kill the
-            // whole pool: callers can retry without a full re-init().
-            if (this.useSharedMemory) {
+            // failure there is fatal. In message mode an error reply from a
+            // live worker is transient and must not kill the pool, but a
+            // timeout means the worker is hung/unreachable: fail so callers
+            // re-init instead of waiting out the full timeout on every call.
+            if (this.useSharedMemory || this.isWorkerTimeout(error)) {
                 await this.failPool(failure);
             }
             throw failure;
@@ -375,10 +380,11 @@ export class WorkerPool {
             }
             const failure = this.createFailure('step', error);
             // Shared-memory batches can corrupt or desync the pool, so any
-            // failure there is fatal. Message-passing failures are transient
-            // (a worker error reply or a slow worker) and must not kill the
-            // whole pool: callers can retry without a full re-init().
-            if (this.useSharedMemory) {
+            // failure there is fatal. In message mode an error reply from a
+            // live worker is transient and must not kill the pool, but a
+            // timeout means the worker is hung/unreachable: fail so callers
+            // re-init instead of waiting out the full timeout on every step.
+            if (this.useSharedMemory || this.isWorkerTimeout(error)) {
                 await this.failPool(failure);
             }
             throw failure;
@@ -686,6 +692,10 @@ export class WorkerPool {
         const failure = new Error(`Worker pool ${operation} failed: ${causeError.message}`);
         (failure as any).cause = causeError;
         return failure;
+    }
+
+    private isWorkerTimeout(error: unknown): boolean {
+        return (error as { code?: string })?.code === 'WORKER_TIMEOUT';
     }
 
     private requireSharedMemoryManager(workerIndex: number): SharedMemoryManager {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -27,6 +27,14 @@ interface SharedObservation {
     tick: number;
 }
 
+type WorkerPoolState = 'idle' | 'initializing' | 'ready' | 'failed' | 'closed';
+
+const SYNC_COMPLETED_INDEX = 0;
+const SYNC_STATUS_OFFSET = 1;
+const WORKER_IDLE = 0;
+const WORKER_COMPLETE = 1;
+const WORKER_ERROR = -1;
+
 export class WorkerPool {
     private workers: Worker[] = [];
     private workerEnvs: number[] = [];
@@ -66,6 +74,10 @@ export class WorkerPool {
     // Shared sync buffer for completion counter (all workers share this)
     private _syncBuffer: SharedArrayBuffer | null = null;
 
+    private state: WorkerPoolState = 'idle';
+    private failure: Error | null = null;
+    private cleanupPromise: Promise<void> | null = null;
+
     constructor(private numWorkers: number = getConfig().workerPool.numWorkers) {
     }
 
@@ -101,9 +113,8 @@ export class WorkerPool {
 
     async init(totalEnvs: number, config: any = {}, useSharedMemory?: boolean) {
         await this.close(); // Clean up existing if re-initialized
-        this.workers = [];
-        this.workerEnvs = [];
-        this.sharedMemManagers = [];
+        this.state = 'initializing';
+        this.failure = null;
 
         // Determine if we should use shared memory
         const sharedMemorySupported = SharedMemoryManager.isSupported();
@@ -115,113 +126,129 @@ export class WorkerPool {
         // Ensure we don't start more workers than environment instances
         const activeWorkers = Math.min(this.numWorkers, totalEnvs);
 
-        // Create shared sync buffer for completion counter
-        this._syncBuffer = new SharedArrayBuffer(4);
+        try {
+            // Index 0 is the wake counter; each worker also owns a status slot.
+            this._syncBuffer = this.useSharedMemory
+                ? new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * (activeWorkers + SYNC_STATUS_OFFSET))
+                : null;
 
-        const baseEnvsPerWorker = Math.floor(totalEnvs / activeWorkers);
-        let remainder = totalEnvs % activeWorkers;
+            const baseEnvsPerWorker = Math.floor(totalEnvs / activeWorkers);
+            let remainder = totalEnvs % activeWorkers;
 
-        const promises = [];
-        let currentStartId = 0;
-        for (let i = 0; i < activeWorkers; i++) {
-            const numEnvs = baseEnvsPerWorker + (remainder > 0 ? 1 : 0);
-            remainder--;
+            const promises = [];
+            let currentStartId = 0;
+            for (let i = 0; i < activeWorkers; i++) {
+                const numEnvs = baseEnvsPerWorker + (remainder > 0 ? 1 : 0);
+                remainder--;
 
-            if (numEnvs > 0) {
-                const workerPath = path.join(__dirname, 'worker-loader.js');
+                if (numEnvs > 0) {
+                    const workerPath = path.join(__dirname, 'worker-loader.js');
 
-                const worker = new Worker(workerPath);
-                this.workers.push(worker);
-                this.workerEnvs.push(numEnvs);
+                    const worker = new Worker(workerPath);
+                    const workerIndex = this.workers.length;
+                    this.workers.push(worker);
+                    this.workerEnvs.push(numEnvs);
 
-                worker.on('message', (msg) => {
-                    const cb = this.callbacks.get(msg.id);
-                    if (cb) {
-                        this.callbacks.delete(msg.id);
-                        clearTimeout(cb.timeout);
-                        if (msg.status === 'error') cb.reject(new Error(msg.error));
-                        else cb.resolve(msg.data);
-                    }
-                });
-
-                worker.on('error', (err) => {
-                    console.error(`[WorkerPool] Worker error: ${err}`);
-                });
-
-                // Initialize shared memory if enabled
-                if (this.useSharedMemory) {
-                    const shm = new SharedMemoryManager(numEnvs, this.ringSize);
-                    this.sharedMemManagers.push(shm);
-
-                    // Send init and wait for it
-                    const initPromise = this.sendMessage(worker, {
-                        type: 'init',
-                        numEnvs,
-                        startId: currentStartId,
-                        config,
-                        sharedBuffer: shm.getBuffer(),
-                        ringSize: this.ringSize,
-                        syncBuffer: this._syncBuffer!
-                    }).then(res => {
-                        // After successful init, trigger the wait-for-action loop
-                        worker.postMessage({ type: 'wait-for-action', config });
-                        return res;
+                    worker.on('message', (msg) => {
+                        const cb = this.callbacks.get(msg.id);
+                        if (cb) {
+                            this.callbacks.delete(msg.id);
+                            clearTimeout(cb.timeout);
+                            if (msg.status === 'error') cb.reject(new Error(msg.error));
+                            else cb.resolve(msg.data);
+                        } else if (msg.status === 'error') {
+                            this.handleWorkerFailure(worker, workerIndex, new Error(msg.error));
+                        }
                     });
 
-                    promises.push(initPromise);
-                } else {
-                    this.sharedMemManagers.push(null);
-                    promises.push(this.sendMessage(worker, { type: 'init', numEnvs, startId: currentStartId, config }));
-                }
-                currentStartId += numEnvs;
-            }
-        }
+                    worker.on('error', (err) => {
+                        this.handleWorkerFailure(worker, workerIndex, err);
+                    });
+                    worker.on('exit', (code: number) => {
+                        if (this.workers[workerIndex] === worker) {
+                            this.handleWorkerFailure(
+                                worker,
+                                workerIndex,
+                                new Error(`Worker ${workerIndex} exited unexpectedly with code ${code}`),
+                            );
+                        }
+                    });
 
-        // Wait for all workers to initialize
-        const results = await Promise.all(promises);
+                    // Initialize shared memory if enabled
+                    if (this.useSharedMemory) {
+                        const shm = new SharedMemoryManager(numEnvs, this.ringSize);
+                        this.sharedMemManagers.push(shm);
 
-        // Initialize buffer pool based on max environments per worker
-        this.maxEnvsPerWorker = Math.max(...this.workerEnvs);
-        for (let i = 0; i < this.workers.length; i++) {
-            this.actionBufferPool.push(new Uint8Array(this.workerEnvs[i]));
-        }
+                        // Send init and wait for it
+                        const initPromise = this.sendMessage(worker, {
+                            type: 'init',
+                            numEnvs,
+                            startId: currentStartId,
+                            workerIndex,
+                            config,
+                            sharedBuffer: shm.getBuffer(),
+                            ringSize: this.ringSize,
+                            syncBuffer: this._syncBuffer!
+                        }).then(res => {
+                            // After successful init, trigger the wait-for-action loop
+                            worker.postMessage({ type: 'wait-for-action', config });
+                            return res;
+                        });
 
-        // Pre-allocate observation pool and finished buffer
-        this.initObsPool(totalEnvs);
-        this._finished = new Uint8Array(this.workers.length);
-
-        // Pre-allocate return times buffer
-        this._returnTimes = new BigUint64Array(this.workers.length);
-
-        // Pre-allocate result objects pool
-        this._resultPool = [];
-        for (let i = 0; i < totalEnvs; i++) {
-            this._resultPool.push({
-                observation: null,
-                reward: 0,
-                done: false,
-                truncated: false,
-                terminated: false,
-                info: { tick: 0 }
-            });
-        }
-
-        // Check if workers actually support shared memory mode
-        if (this.useSharedMemory) {
-            const allSupportShared = results.every((r: any) => r && r.mode === 'shared');
-            if (!allSupportShared) {
-                console.warn('[WorkerPool] Some workers did not support shared memory, falling back to message passing');
-                results.forEach((r: any, idx: number) => {
-                    if (!r || r.mode !== 'shared') {
-                        console.warn(`  - Worker ${idx} returned mode: ${r ? r.mode : 'undefined'}`);
+                        promises.push(initPromise);
+                    } else {
+                        this.sharedMemManagers.push(null);
+                        promises.push(this.sendMessage(worker, { type: 'init', numEnvs, startId: currentStartId, config }));
                     }
-                });
-                this.useSharedMemory = false;
-            } else {
-                console.log('[WorkerPool] All workers successfully initialized with SharedArrayBuffer');
+                    currentStartId += numEnvs;
+                }
             }
-        } else {
-            console.log('[WorkerPool] Shared memory optimization is disabled (either not supported or explicitly turned off)');
+
+            // Wait for all workers to initialize
+            const results = await Promise.all(promises);
+
+            // Initialize buffer pool based on max environments per worker
+            this.maxEnvsPerWorker = Math.max(...this.workerEnvs);
+            for (let i = 0; i < this.workers.length; i++) {
+                this.actionBufferPool.push(new Uint8Array(this.workerEnvs[i]));
+            }
+
+            // Pre-allocate observation pool and finished buffer
+            this.initObsPool(totalEnvs);
+            this._finished = new Uint8Array(this.workers.length);
+
+            // Pre-allocate return times buffer
+            this._returnTimes = new BigUint64Array(this.workers.length);
+
+            // Pre-allocate result objects pool
+            this._resultPool = [];
+            for (let i = 0; i < totalEnvs; i++) {
+                this._resultPool.push({
+                    observation: null,
+                    reward: 0,
+                    done: false,
+                    truncated: false,
+                    terminated: false,
+                    info: { tick: 0 }
+                });
+            }
+
+            // Workers initialized with shared buffers cannot safely switch protocols in place.
+            if (this.useSharedMemory) {
+                const unsupportedWorker = results.findIndex((r: any) => !r || r.mode !== 'shared');
+                if (unsupportedWorker !== -1) {
+                    throw new Error(`Worker ${unsupportedWorker} did not initialize in shared-memory mode`);
+                }
+                console.log('[WorkerPool] All workers successfully initialized with SharedArrayBuffer');
+            } else {
+                console.log('[WorkerPool] Shared memory optimization is disabled (either not supported or explicitly turned off)');
+            }
+
+            this.state = 'ready';
+        } catch (error) {
+            const failure = this.createFailure('initialization', error);
+            await this.failPool(failure);
+            throw failure;
         }
     }
 
@@ -235,125 +262,114 @@ export class WorkerPool {
                     console.error(`[WorkerPool] Message ${id} timed out`);
                     reject(new Error(`Message ${id} timed out`));
                 }
-            }, 30000);  // 30 second timeout for init/other messages
+            }, getConfig().workerPool.messageTimeoutMs);
             this.callbacks.set(id, { resolve, reject, timeout });
-            worker.postMessage({ id, ...msg });
+            try {
+                worker.postMessage({ id, ...msg });
+            } catch (error) {
+                clearTimeout(timeout);
+                this.callbacks.delete(id);
+                reject(error);
+            }
         });
     }
 
     async reset(seeds?: number[]): Promise<any[]> {
-        if (this.useSharedMemory) {
-            // 1. Send reset command to all workers
-            let seedIdx = 0;
+        this.assertReady('reset');
 
-            // Reset shared completion counter before signaling workers
-            const completedArr = new Int32Array(this._syncBuffer!);
-            Atomics.store(completedArr, 0, 0);
+        if (this.useSharedMemory && seeds) {
+            for (const seed of seeds) {
+                if (!Number.isInteger(seed) || seed < 0 || seed > 0xFFFFFFFE) {
+                    throw new Error(`Seed ${seed} out of supported range [0, 4294967294] for shared-memory reset`);
+                }
+            }
+        }
 
-            for (let i = 0; i < this.workers.length; i++) {
-                const wEnvs = this.workerEnvs[i];
-                const wSeeds = seeds ? seeds.slice(seedIdx, seedIdx + wEnvs).map(s => {
-                    // SAB transport encodes "no seed" as 0 and real seeds as
-                    // seed+1 in a Uint32Array. Range-check here so a wrapping
-                    // seed can never silently collide with the sentinel.
-                    if (!Number.isInteger(s) || s < 0 || s > 0xFFFFFFFE) {
-                        throw new Error(`Seed ${s} out of supported range [0, 4294967294] for shared-memory reset`);
+        try {
+            if (this.useSharedMemory) {
+                // 1. Send reset command to all workers
+                let seedIdx = 0;
+
+                const completedArr = this.prepareSharedBatch();
+
+                for (let i = 0; i < this.workers.length; i++) {
+                    const wEnvs = this.workerEnvs[i];
+                    // SAB transport encodes "no seed" as 0 and real seeds as seed+1.
+                    const wSeeds = seeds
+                        ? seeds.slice(seedIdx, seedIdx + wEnvs).map(seed => seed + 1)
+                        : new Array(wEnvs).fill(0);
+                    seedIdx += wEnvs;
+
+                    const shm = this.requireSharedMemoryManager(i);
+                    shm.writeSeeds(wSeeds);
+                    shm.sendCommand(1); // RESET command
+                }
+
+                // 2. Wait for reset completion using shared completion counter
+                await this.waitForSharedCompletion(
+                    completedArr,
+                    'reset',
+                    getConfig().workerPool.messageTimeoutMs,
+                );
+
+                // All workers done — consume their signals
+                for (let i = 0; i < this.workers.length; i++) {
+                    const shm = this.requireSharedMemoryManager(i);
+                    if (!shm.isResultsReady()) {
+                        throw new Error(`Worker ${i} completed reset without publishing results`);
                     }
-                    return s + 1;
-                }) : new Array(wEnvs).fill(0);
-                seedIdx += wEnvs;
-
-                const shm = this.sharedMemManagers[i]!;
-                shm.writeSeeds(wSeeds);
-                shm.sendCommand(1); // RESET command
-            }
-
-            // 2. Wait for reset completion using shared completion counter
-            const timeoutMs = 30000;
-            const startTime = Date.now();
-            const finished = this._finished;
-            finished.fill(0);  // Reset from previous step
-
-            // First pass: check if any workers already done
-            for (let i = 0; i < this.workers.length; i++) {
-                if (this.sharedMemManagers[i]!.isResultsReady()) {
-                    this.sharedMemManagers[i]!.consumeResultsSignal();
-                    finished[i] = 1;
-                }
-            }
-
-            // Wait for ALL workers to complete using shared completion counter
-            {
-                const numWorkers = this.workers.length;
-                let waitVal = Atomics.load(completedArr, 0);
-                while (waitVal < numWorkers) {
-                    const elapsed = Date.now() - startTime;
-                    const remaining = Math.max(1, timeoutMs - elapsed);
-                    Atomics.wait(completedArr, 0, waitVal, remaining);
-                    waitVal = Atomics.load(completedArr, 0);
-                    if (Date.now() - startTime >= timeoutMs) break;
-                }
-            }
-
-            // All workers done — consume their signals
-            for (let i = 0; i < this.workers.length; i++) {
-                if (finished[i]) continue;
-                const shm = this.sharedMemManagers[i]!;
-                try {
                     shm.consumeResultsSignal();
-                } catch (e: any) {
-                    console.warn(`[WorkerPool] reset: worker ${i} failed during consume:`, e.message);
                 }
-                finished[i] = 1;
-            }
 
-            // 3. Extract observations
-            const observations: any[] = [];
-            let globalEnvIdx = 0;
-            for (let i = 0; i < this.workers.length; i++) {
-                const wEnvs = this.workerEnvs[i];
-                try {
-                    const res = this.sharedMemManagers[i]!.readResults();
+                // 3. Extract observations
+                const observations: any[] = [];
+                let globalEnvIdx = 0;
+                for (let i = 0; i < this.workers.length; i++) {
+                    const wEnvs = this.workerEnvs[i];
+                    const res = this.requireSharedMemoryManager(i).readResults();
                     for (let j = 0; j < wEnvs; j++) {
                         observations.push(this.extractObservation(res.observations, j, globalEnvIdx));
                         globalEnvIdx++;
                     }
-                } catch (e: any) {
-                    console.warn(`[WorkerPool] reset: worker ${i} failed to read results:`, e.message);
-                    // Push zeroed observations so the array length stays consistent
-                    for (let j = 0; j < wEnvs; j++) {
-                        observations.push(null);
-                        globalEnvIdx++;
-                    }
                 }
+                return observations;
             }
-            return observations;
-        }
 
-        const promises = [];
-        let seedIdx = 0;
-        for (let i = 0; i < this.workers.length; i++) {
-            const wEnvs = this.workerEnvs[i];
-            const wSeeds = seeds ? seeds.slice(seedIdx, seedIdx + wEnvs) : undefined;
-            promises.push(
-                this.sendMessage(this.workers[i], { type: 'reset', seeds: wSeeds })
-                    .catch(e => {
-                        console.warn(`[WorkerPool] reset: worker ${i} failed:`, e.message);
-                        return new Array(wEnvs).fill(null);
-                    })
-            );
-            seedIdx += wEnvs;
+            const promises = [];
+            let seedIdx = 0;
+            for (let i = 0; i < this.workers.length; i++) {
+                const wEnvs = this.workerEnvs[i];
+                const wSeeds = seeds ? seeds.slice(seedIdx, seedIdx + wEnvs) : undefined;
+                promises.push(this.sendMessage(this.workers[i], { type: 'reset', seeds: wSeeds }));
+                seedIdx += wEnvs;
+            }
+            const results = await Promise.all(promises);
+            return results.flat();
+        } catch (error) {
+            if (this.state === 'closed') {
+                throw error;
+            }
+            const failure = this.createFailure('reset', error);
+            await this.failPool(failure);
+            throw failure;
         }
-        const results = await Promise.all(promises);
-        return results.flat();
     }
 
     async step(actions: any[]): Promise<any[]> {
-        // Use shared memory mode if enabled
-        if (this.useSharedMemory) {
-            return this.stepSharedMemory(actions);
-        } else {
-            return this.stepMessagePassing(actions);
+        this.assertReady('step');
+        try {
+            // Use shared memory mode if enabled
+            if (this.useSharedMemory) {
+                return await this.stepSharedMemory(actions);
+            }
+            return await this.stepMessagePassing(actions);
+        } catch (error) {
+            if (this.state === 'closed') {
+                throw error;
+            }
+            const failure = this.createFailure('step', error);
+            await this.failPool(failure);
+            throw failure;
         }
     }
 
@@ -369,9 +385,7 @@ export class WorkerPool {
         // 1. Encode actions and signal all workers in parallel
         let actionIdx = 0;
 
-        // Reset shared completion counter before signaling workers
-        const completedArr = new Int32Array(this._syncBuffer!);
-        Atomics.store(completedArr, 0, 0);
+        const completedArr = this.prepareSharedBatch();
 
         for (let i = 0; i < this.workers.length; i++) {
             const wEnvs = this.workerEnvs[i];
@@ -382,20 +396,18 @@ export class WorkerPool {
             }
             actionIdx += wEnvs;
 
-            const shm = this.sharedMemManagers[i]!;
+            const shm = this.requireSharedMemoryManager(i);
             shm.writeActionsQuiet(encodedActions);
             shm.sendCommand(0); // STEP command (also notifies worker)
         }
 
-        // 2. Wait for results from all workers using Atomics.wait (no polling overhead)
-        const timeoutMs = 5000;
-        const startTime = Date.now();
+        // 2. Wait for results from all workers without blocking worker event delivery.
         const finished = this._finished;
         finished.fill(0);  // Reset from previous step
 
         // First pass: check if any workers already done (non-blocking)
         for (let i = 0; i < this.workers.length; i++) {
-            const shm = this.sharedMemManagers[i]!;
+            const shm = this.requireSharedMemoryManager(i);
             if (shm.isResultsReady()) {
                 shm.consumeResultsSignal();
                 returnTimes[i] = process.hrtime.bigint();
@@ -403,23 +415,19 @@ export class WorkerPool {
             }
         }
 
-        // Wait for ALL workers to complete using shared completion counter
-        {
-            const numWorkers = this.workers.length;
-            let waitVal = Atomics.load(completedArr, 0);
-            while (waitVal < numWorkers) {
-                const elapsed = Date.now() - startTime;
-                const remaining = Math.max(1, timeoutMs - elapsed);
-                Atomics.wait(completedArr, 0, waitVal, remaining);
-                waitVal = Atomics.load(completedArr, 0);
-                if (Date.now() - startTime >= timeoutMs) break;
-            }
-        }
+        await this.waitForSharedCompletion(
+            completedArr,
+            'step',
+            getConfig().workerPool.stepTimeoutMs,
+        );
 
         // All workers done — consume their signals
         for (let i = 0; i < this.workers.length; i++) {
             if (finished[i]) continue;
-            const shm = this.sharedMemManagers[i]!;
+            const shm = this.requireSharedMemoryManager(i);
+            if (!shm.isResultsReady()) {
+                throw new Error(`Worker ${i} completed step without publishing results`);
+            }
             shm.consumeResultsSignal();
             returnTimes[i] = process.hrtime.bigint();
             finished[i] = 1;
@@ -632,37 +640,225 @@ export class WorkerPool {
      * Each worker returns a copy of its local TelemetryBuffer.
      */
     async getTelemetrySnapshots(): Promise<BigUint64Array[]> {
-        const promises = [];
-        for (let i = 0; i < this.workers.length; i++) {
-            promises.push(this.sendMessage(this.workers[i], { type: 'GET_TELEMETRY' }));
+        this.assertReady('get telemetry');
+        try {
+            const promises = [];
+            for (let i = 0; i < this.workers.length; i++) {
+                promises.push(this.sendMessage(this.workers[i], { type: 'GET_TELEMETRY' }));
+            }
+            const snapshots = await Promise.all(promises);
+            return snapshots as BigUint64Array[];
+        } catch (error) {
+            if (this.state === 'closed') {
+                throw error;
+            }
+            const failure = this.createFailure('telemetry', error);
+            await this.failPool(failure);
+            throw failure;
         }
-        const snapshots = await Promise.all(promises);
-        return snapshots as BigUint64Array[];
     }
 
     async close() {
-        for (const callback of this.callbacks.values()) {
-            clearTimeout(callback.timeout);
-            callback.reject(new Error('Worker pool closed'));
+        this.state = 'closed';
+        this.failure = null;
+        this.wakeSharedWaiters();
+        await this.cleanup(new Error('Worker pool closed'));
+        this.useSharedMemory = false;
+    }
+
+    private assertReady(operation: string): void {
+        if (this.state === 'failed') {
+            throw new Error(`Cannot ${operation}: worker pool is in failed state (${this.failure?.message ?? 'unknown failure'})`);
         }
-        this.callbacks.clear();
+        if (this.state !== 'ready') {
+            throw new Error(`Cannot ${operation}: worker pool is ${this.state}`);
+        }
+    }
 
-        const terminatePromises = this.workers.map(w => w.terminate());
-        await Promise.all(terminatePromises);
+    private createFailure(operation: string, cause: unknown): Error {
+        const causeError = cause instanceof Error ? cause : new Error(String(cause));
+        if (this.state === 'failed' && this.failure) {
+            return this.failure;
+        }
+        const failure = new Error(`Worker pool ${operation} failed: ${causeError.message}`);
+        (failure as any).cause = causeError;
+        return failure;
+    }
 
-        // Properly dispose of SharedMemoryManager instances to prevent memory leaks
-        for (const shm of this.sharedMemManagers) {
-            if (shm) {
-                shm.dispose();
+    private requireSharedMemoryManager(workerIndex: number): SharedMemoryManager {
+        const shm = this.sharedMemManagers[workerIndex];
+        if (!shm) {
+            throw new Error(`Shared memory manager not initialized for worker ${workerIndex}`);
+        }
+        return shm;
+    }
+
+    private prepareSharedBatch(): Int32Array {
+        if (!this._syncBuffer) {
+            throw new Error('Shared completion state is not initialized');
+        }
+        const sync = new Int32Array(this._syncBuffer);
+        Atomics.store(sync, SYNC_COMPLETED_INDEX, 0);
+        for (let i = 0; i < this.workers.length; i++) {
+            Atomics.store(sync, SYNC_STATUS_OFFSET + i, WORKER_IDLE);
+        }
+        return sync;
+    }
+
+    private async waitForSharedCompletion(sync: Int32Array, operation: string, timeoutMs: number): Promise<void> {
+        const startedAt = Date.now();
+        const numWorkers = this.workers.length;
+
+        while (true) {
+            if (this.state === 'failed' && this.failure) {
+                throw this.failure;
+            }
+            if (this.state !== 'ready') {
+                throw new Error(`Shared-memory ${operation} interrupted because worker pool is ${this.state}`);
+            }
+
+            const failedWorker = this.findWorkerWithStatus(sync, WORKER_ERROR);
+            if (failedWorker !== -1) {
+                throw new Error(`Worker ${failedWorker} reported an error during shared-memory ${operation}`);
+            }
+
+            const completed = Atomics.load(sync, SYNC_COMPLETED_INDEX);
+            if (completed >= numWorkers) {
+                break;
+            }
+
+            const remaining = timeoutMs - (Date.now() - startedAt);
+            if (remaining <= 0) {
+                throw this.createSharedTimeout(operation, sync, timeoutMs);
+            }
+
+            const waiter = (Atomics as any).waitAsync(sync, SYNC_COMPLETED_INDEX, completed, remaining);
+            const waitResult = waiter.async ? await waiter.value : waiter.value;
+            if (waitResult === 'timed-out') {
+                throw this.createSharedTimeout(operation, sync, timeoutMs);
             }
         }
 
+        const incompleteWorkers: number[] = [];
+        for (let i = 0; i < numWorkers; i++) {
+            if (Atomics.load(sync, SYNC_STATUS_OFFSET + i) !== WORKER_COMPLETE) {
+                incompleteWorkers.push(i);
+            }
+        }
+        if (incompleteWorkers.length > 0) {
+            throw new Error(
+                `Shared-memory ${operation} completion was invalid for worker(s) ${incompleteWorkers.join(', ')}`,
+            );
+        }
+    }
+
+    private createSharedTimeout(operation: string, sync: Int32Array, timeoutMs: number): Error {
+        const pendingWorkers: number[] = [];
+        for (let i = 0; i < this.workers.length; i++) {
+            if (Atomics.load(sync, SYNC_STATUS_OFFSET + i) !== WORKER_COMPLETE) {
+                pendingWorkers.push(i);
+            }
+        }
+        return new Error(
+            `Shared-memory ${operation} timed out after ${timeoutMs}ms waiting for worker(s) ${pendingWorkers.join(', ')}`,
+        );
+    }
+
+    private findWorkerWithStatus(sync: Int32Array, status: number): number {
+        for (let i = 0; i < this.workers.length; i++) {
+            if (Atomics.load(sync, SYNC_STATUS_OFFSET + i) === status) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private handleWorkerFailure(worker: Worker, workerIndex: number, error: Error): void {
+        if (this.workers[workerIndex] !== worker || this.state === 'closed' || this.state === 'failed') {
+            return;
+        }
+        const failure = new Error(`Worker ${workerIndex} failed: ${error.message}`);
+        (failure as any).cause = error;
+        this.recordSharedWorkerFailure(workerIndex);
+        void this.failPool(failure);
+    }
+
+    private recordSharedWorkerFailure(workerIndex: number): void {
+        if (!this._syncBuffer) return;
+        const sync = new Int32Array(this._syncBuffer);
+        const statusIndex = SYNC_STATUS_OFFSET + workerIndex;
+        const previous = Atomics.exchange(sync, statusIndex, WORKER_ERROR);
+        if (previous === WORKER_IDLE) {
+            Atomics.add(sync, SYNC_COMPLETED_INDEX, 1);
+        }
+        Atomics.notify(sync, SYNC_COMPLETED_INDEX);
+    }
+
+    private wakeSharedWaiters(): void {
+        if (!this._syncBuffer) return;
+        const sync = new Int32Array(this._syncBuffer);
+        Atomics.add(sync, SYNC_COMPLETED_INDEX, Math.max(1, this.workers.length));
+        Atomics.notify(sync, SYNC_COMPLETED_INDEX);
+    }
+
+    private async failPool(error: Error): Promise<void> {
+        if (this.state !== 'failed') {
+            this.state = 'failed';
+            this.failure = error;
+            this.wakeSharedWaiters();
+        }
+        await this.cleanup(this.failure ?? error);
+    }
+
+    private cleanup(callbackError: Error): Promise<void> {
+        if (this.cleanupPromise) {
+            return this.cleanupPromise;
+        }
+
+        for (const callback of this.callbacks.values()) {
+            clearTimeout(callback.timeout);
+            callback.reject(callbackError);
+        }
+        this.callbacks.clear();
+
+        const workers = this.workers;
+        const sharedMemManagers = this.sharedMemManagers;
         this.workers = [];
         this.workerEnvs = [];
         this.sharedMemManagers = [];
         this.actionBufferPool = [];
         this._obsPool = [];
         this._terminalObsPool = [];
+        this._obsPoolSize = 0;
+        this._finished = new Uint8Array(0);
+        this._returnTimes = new BigUint64Array(0);
+        this._resultPool = [];
+        this._convertedResults = [];
+        this.maxEnvsPerWorker = 0;
+
+        const cleanupPromise = (async () => {
+            try {
+                await Promise.all(workers.map(async worker => {
+                    try {
+                        await worker.terminate();
+                    } catch {
+                        // Continue terminating and disposing the rest of the pool.
+                    }
+                }));
+                for (const shm of sharedMemManagers) {
+                    try {
+                        shm?.dispose();
+                    } catch {
+                        // Continue disposing the rest of the pool.
+                    }
+                }
+            } finally {
+                this._syncBuffer = null;
+                this.cleanupPromise = null;
+            }
+        })();
+        this.cleanupPromise = cleanupPromise;
+        return cleanupPromise;
     }
 
     /**

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -347,7 +347,7 @@ export class WorkerPool {
                 promises.push(this.sendMessage(this.workers[i], { type: 'reset', seeds: wSeeds }));
                 seedIdx += wEnvs;
             }
-            const results = await Promise.all(promises);
+            const results = await this.settleMessageBatch(promises);
             return results.flat();
         } catch (error) {
             if (this.state === 'closed') {
@@ -546,7 +546,7 @@ export class WorkerPool {
             actionIdx += wEnvs;
         }
 
-        const results = await Promise.all(promises);
+        const results = await this.settleMessageBatch(promises);
         const batchEnd = process.hrtime.bigint();
 
         // Record Batch Latency
@@ -663,8 +663,25 @@ export class WorkerPool {
         for (let i = 0; i < this.workers.length; i++) {
             promises.push(this.sendMessage(this.workers[i], { type: 'GET_TELEMETRY' }));
         }
-        const snapshots = await Promise.all(promises);
-        return snapshots as BigUint64Array[];
+        const settled = await Promise.allSettled(promises);
+        const hungWorker = settled.find(r => r.status === 'rejected' && this.isWorkerTimeout(r.reason));
+        if (hungWorker) {
+            const failure = this.createFailure('telemetry', (hungWorker as { reason: Error }).reason);
+            // In shared mode workers block in Atomics.wait and never service
+            // GET_TELEMETRY, so that timeout is expected and recoverable. In
+            // message mode a timeout means the worker is hung/unreachable:
+            // fail so callers re-init instead of burning the full timeout on
+            // every snapshot.
+            if (!this.useSharedMemory) {
+                await this.failPool(failure);
+            }
+            throw failure;
+        }
+        const firstRejection = settled.find(r => r.status === 'rejected');
+        if (firstRejection) {
+            throw (firstRejection as { reason: Error }).reason;
+        }
+        return settled.map(r => (r as { value: any }).value) as BigUint64Array[];
     }
 
     async close() {
@@ -696,6 +713,26 @@ export class WorkerPool {
 
     private isWorkerTimeout(error: unknown): boolean {
         return (error as { code?: string })?.code === 'WORKER_TIMEOUT';
+    }
+
+    /**
+     * Settles a message-mode batch, preferring a hung-worker timeout over any
+     * live-worker error reply that happened to reject first. Promise.all would
+     * swallow the later timeout once the batch has settled, leaving the pool
+     * ready with an unreachable worker; waiting for every worker keeps the
+     * tagged timeout visible so the caller can fail the pool.
+     */
+    private async settleMessageBatch(promises: Promise<any>[]): Promise<any[]> {
+        const settled = await Promise.allSettled(promises);
+        const hungWorker = settled.find(r => r.status === 'rejected' && this.isWorkerTimeout(r.reason));
+        if (hungWorker) {
+            throw (hungWorker as { reason: Error }).reason;
+        }
+        const firstRejection = settled.find(r => r.status === 'rejected');
+        if (firstRejection) {
+            throw (firstRejection as { reason: Error }).reason;
+        }
+        return settled.map(r => (r as { value: any }).value);
     }
 
     private requireSharedMemoryManager(workerIndex: number): SharedMemoryManager {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -350,7 +350,13 @@ export class WorkerPool {
                 throw error;
             }
             const failure = this.createFailure('reset', error);
-            await this.failPool(failure);
+            // Shared-memory batches can corrupt or desync the pool, so any
+            // failure there is fatal. Message-passing failures are transient
+            // (a worker error reply or a slow worker) and must not kill the
+            // whole pool: callers can retry without a full re-init().
+            if (this.useSharedMemory) {
+                await this.failPool(failure);
+            }
             throw failure;
         }
     }
@@ -368,7 +374,13 @@ export class WorkerPool {
                 throw error;
             }
             const failure = this.createFailure('step', error);
-            await this.failPool(failure);
+            // Shared-memory batches can corrupt or desync the pool, so any
+            // failure there is fatal. Message-passing failures are transient
+            // (a worker error reply or a slow worker) and must not kill the
+            // whole pool: callers can retry without a full re-init().
+            if (this.useSharedMemory) {
+                await this.failPool(failure);
+            }
             throw failure;
         }
     }
@@ -641,21 +653,12 @@ export class WorkerPool {
      */
     async getTelemetrySnapshots(): Promise<BigUint64Array[]> {
         this.assertReady('get telemetry');
-        try {
-            const promises = [];
-            for (let i = 0; i < this.workers.length; i++) {
-                promises.push(this.sendMessage(this.workers[i], { type: 'GET_TELEMETRY' }));
-            }
-            const snapshots = await Promise.all(promises);
-            return snapshots as BigUint64Array[];
-        } catch (error) {
-            if (this.state === 'closed') {
-                throw error;
-            }
-            const failure = this.createFailure('telemetry', error);
-            await this.failPool(failure);
-            throw failure;
+        const promises = [];
+        for (let i = 0; i < this.workers.length; i++) {
+            promises.push(this.sendMessage(this.workers[i], { type: 'GET_TELEMETRY' }));
         }
+        const snapshots = await Promise.all(promises);
+        return snapshots as BigUint64Array[];
     }
 
     async close() {

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -24,12 +24,9 @@ const WORKER_ERROR = -1;
 
 function signalSyncCompleted(status: number = WORKER_COMPLETE) {
     if (!syncCompleted) return;
-    try {
-        Atomics.store(syncCompleted, syncWorkerIndex + 1, status);
-    } finally {
-        Atomics.add(syncCompleted, 0, 1);
-        Atomics.notify(syncCompleted, 0, 1);
-    }
+    Atomics.store(syncCompleted, syncWorkerIndex + 1, status);
+    Atomics.add(syncCompleted, 0, 1);
+    Atomics.notify(syncCompleted, 0, 1);
 }
 
 /**

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -17,9 +17,16 @@ let sharedMem: SharedMemoryManager | null = null;
 let numEnvs = 0;
 let globalOffset = 0;
 let syncCompleted: Int32Array | null = null;
+let syncWorkerIndex = 0;
 
-function signalSyncCompleted() {
-    if (syncCompleted) {
+const WORKER_COMPLETE = 1;
+const WORKER_ERROR = -1;
+
+function signalSyncCompleted(status: number = WORKER_COMPLETE) {
+    if (!syncCompleted) return;
+    try {
+        Atomics.store(syncCompleted, syncWorkerIndex + 1, status);
+    } finally {
         Atomics.add(syncCompleted, 0, 1);
         Atomics.notify(syncCompleted, 0, 1);
     }
@@ -95,6 +102,7 @@ parentPort.on('message', (msg) => {
                 );
                 if (msg.syncBuffer) {
                     syncCompleted = new Int32Array(msg.syncBuffer);
+                    syncWorkerIndex = msg.workerIndex ?? 0;
                 }
                 parentPort!.postMessage({
                     id: msg.id,
@@ -298,6 +306,7 @@ parentPort.on('message', (msg) => {
                 }
                 } catch (e: any) {
                     console.error(`[Worker ${globalOffset}] wait-for-action crashed:`, e.message, e.stack);
+                    signalSyncCompleted(WORKER_ERROR);
                     parentPort!.postMessage({ id: msg.id, status: 'error', error: `worker-loop-crash: ${e.message}` });
                 }
             } else {

--- a/tests/integration/worker-pool-errors.test.ts
+++ b/tests/integration/worker-pool-errors.test.ts
@@ -120,10 +120,11 @@ describe('WorkerPool uncovered lines', () => {
       // while useSharedMemory is still true — simulates a corrupted state
       (pool as any).sharedMemManagers[0] = null;
 
-      // Error occurs at line 361 (writeActionsQuiet) before the defensive check at 434
       await expect(pool.step([0])).rejects.toThrow(
-        "Cannot read properties of null (reading 'writeActionsQuiet')"
+        'Shared memory manager not initialized for worker 0'
       );
+
+      await expect(pool.step([0])).rejects.toThrow('worker pool is in failed state');
     });
 
     it('throws error with correct worker index for multi-worker setup', async () => {
@@ -140,7 +141,7 @@ describe('WorkerPool uncovered lines', () => {
       (pool as any).sharedMemManagers[0] = null;
 
       await expect(pool.step([0, 0, 0, 0])).rejects.toThrow(
-        "Cannot read properties of null (reading 'writeActionsQuiet')"
+        'Shared memory manager not initialized for worker 0'
       );
     });
   });

--- a/tests/unit/worker-pool-failures.test.ts
+++ b/tests/unit/worker-pool-failures.test.ts
@@ -7,6 +7,7 @@ const fakes = vi.hoisted(() => {
   const control = {
     initBehaviors: [] as Array<'ok' | 'error'>,
     resetMessageBehavior: 'ok' as 'ok' | 'error',
+    stepMessageBehavior: 'ok' as 'ok' | 'error',
     commandBehaviors: [] as CommandBehavior[],
     readError: false,
     stepTimeoutMs: 1000,
@@ -60,7 +61,11 @@ const fakes = vi.hoisted(() => {
           this.emit('message', { id: message.id, status: 'ok', data: [{}] });
         }
       } else if (message.type === 'step') {
-        this.emit('message', { id: message.id, status: 'ok', data: [] });
+        if (control.stepMessageBehavior === 'error') {
+          this.emit('message', { id: message.id, status: 'error', error: 'synthetic step failure' });
+        } else {
+          this.emit('message', { id: message.id, status: 'ok', data: [{}] });
+        }
       }
     }
 
@@ -153,6 +158,7 @@ const fakes = vi.hoisted(() => {
     FakeSharedMemoryManager.instances = [];
     control.initBehaviors = [];
     control.resetMessageBehavior = 'ok';
+    control.stepMessageBehavior = 'ok';
     control.commandBehaviors = [];
     control.readError = false;
     control.stepTimeoutMs = 1000;
@@ -258,15 +264,42 @@ describe('WorkerPool failure state', () => {
     expect(fakes.FakeSharedMemoryManager.instances[0].disposed).toBe(true);
   });
 
-  it('propagates message-mode reset errors instead of returning null observations', async () => {
+  it('propagates message-mode reset errors without failing the pool', async () => {
     pool = new WorkerPool(1);
     await pool.init(1, {}, false);
     fakes.control.resetMessageBehavior = 'error';
 
     await expect(pool.reset()).rejects.toThrow('synthetic reset failure');
 
-    expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
-    await expect(pool.reset()).rejects.toThrow('worker pool is in failed state');
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(false);
+    fakes.control.resetMessageBehavior = 'ok';
+    const observations = await pool.reset();
+    expect(observations).toHaveLength(1);
+  });
+
+  it('propagates message-mode step errors without failing the pool', async () => {
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, false);
+    fakes.control.stepMessageBehavior = 'error';
+
+    await expect(pool.step([0])).rejects.toThrow('synthetic step failure');
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(false);
+    fakes.control.stepMessageBehavior = 'ok';
+    const results = await pool.step([0]);
+    expect(results).toHaveLength(1);
+  });
+
+  it('propagates telemetry snapshot errors without failing the pool', async () => {
+    fakes.control.messageTimeoutMs = 20;
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, true);
+
+    await expect(pool.getTelemetrySnapshots()).rejects.toThrow('timed out');
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(false);
+    const results = await pool.step([0]);
+    expect(results).toHaveLength(1);
   });
 
   it('propagates shared-memory read errors and disposes the pool', async () => {

--- a/tests/unit/worker-pool-failures.test.ts
+++ b/tests/unit/worker-pool-failures.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fakes = vi.hoisted(() => {
+  type WorkerEvent = 'message' | 'error' | 'exit';
+  type CommandBehavior = 'complete' | 'error' | 'timeout' | 'crash';
+
+  const control = {
+    initBehaviors: [] as Array<'ok' | 'error'>,
+    resetMessageBehavior: 'ok' as 'ok' | 'error',
+    commandBehaviors: [] as CommandBehavior[],
+    readError: false,
+    stepTimeoutMs: 1000,
+    messageTimeoutMs: 1000,
+  };
+
+  class FakeWorker {
+    static instances: FakeWorker[] = [];
+
+    readonly index: number;
+    readonly handlers = new Map<WorkerEvent, Array<(...args: any[]) => void>>();
+    terminated = false;
+
+    constructor(_path: string) {
+      this.index = FakeWorker.instances.length;
+      FakeWorker.instances.push(this);
+    }
+
+    on(event: WorkerEvent, handler: (...args: any[]) => void): this {
+      const handlers = this.handlers.get(event) ?? [];
+      handlers.push(handler);
+      this.handlers.set(event, handlers);
+      return this;
+    }
+
+    emit(event: WorkerEvent, ...args: any[]): void {
+      for (const handler of this.handlers.get(event) ?? []) {
+        handler(...args);
+      }
+    }
+
+    postMessage(message: any): void {
+      if (message.type === 'init') {
+        const manager = FakeSharedMemoryManager.instances.find(
+          candidate => candidate.getBuffer() === message.sharedBuffer,
+        );
+        manager?.connect(message.syncBuffer, message.workerIndex, this);
+        if (control.initBehaviors[this.index] === 'error') {
+          this.emit('message', { id: message.id, status: 'error', error: 'synthetic init failure' });
+        } else {
+          this.emit('message', {
+            id: message.id,
+            status: 'ok',
+            data: { mode: message.sharedBuffer ? 'shared' : 'message' },
+          });
+        }
+      } else if (message.type === 'reset') {
+        if (control.resetMessageBehavior === 'error') {
+          this.emit('message', { id: message.id, status: 'error', error: 'synthetic reset failure' });
+        } else {
+          this.emit('message', { id: message.id, status: 'ok', data: [{}] });
+        }
+      } else if (message.type === 'step') {
+        this.emit('message', { id: message.id, status: 'ok', data: [] });
+      }
+    }
+
+    terminate(): Promise<number> {
+      this.terminated = true;
+      return Promise.resolve(1);
+    }
+  }
+
+  class FakeSharedMemoryManager {
+    static instances: FakeSharedMemoryManager[] = [];
+
+    readonly index: number;
+    readonly buffer = new SharedArrayBuffer(4);
+    readonly numEnvs: number;
+    disposed = false;
+    ready = false;
+    readCalls = 0;
+    private sync: Int32Array | null = null;
+    private workerIndex = 0;
+    private worker: FakeWorker | null = null;
+
+    constructor(numEnvs: number) {
+      this.index = FakeSharedMemoryManager.instances.length;
+      this.numEnvs = numEnvs;
+      FakeSharedMemoryManager.instances.push(this);
+    }
+
+    static isSupported(): boolean {
+      return true;
+    }
+
+    getBuffer(): SharedArrayBuffer {
+      return this.buffer;
+    }
+
+    connect(syncBuffer: SharedArrayBuffer, workerIndex: number, worker: FakeWorker): void {
+      this.sync = new Int32Array(syncBuffer);
+      this.workerIndex = workerIndex;
+      this.worker = worker;
+    }
+
+    writeSeeds(_seeds: number[]): void {}
+    writeActionsQuiet(_actions: Uint8Array): void {}
+
+    sendCommand(_command: number): void {
+      const behavior = control.commandBehaviors[this.index] ?? 'complete';
+      if (behavior === 'timeout') return;
+      if (behavior === 'crash') {
+        queueMicrotask(() => this.worker?.emit('error', new Error('synthetic worker crash')));
+        return;
+      }
+
+      if (!this.sync) throw new Error('fake manager was not connected');
+      this.ready = behavior === 'complete';
+      Atomics.store(this.sync, this.workerIndex + 1, behavior === 'complete' ? 1 : -1);
+      Atomics.add(this.sync, 0, 1);
+      Atomics.notify(this.sync, 0);
+    }
+
+    isResultsReady(): boolean {
+      return this.ready;
+    }
+
+    consumeResultsSignal(): void {
+      this.ready = false;
+    }
+
+    readResults(): any {
+      this.readCalls++;
+      if (control.readError) throw new Error('synthetic shared-memory read failure');
+      return {
+        observations: new Float32Array(this.numEnvs * 16),
+        terminalObservations: new Float32Array(this.numEnvs * 16),
+        hasTerminalObs: new Uint8Array(this.numEnvs),
+        rewards: new Float32Array(this.numEnvs),
+        dones: new Uint8Array(this.numEnvs),
+        truncated: new Uint8Array(this.numEnvs),
+        ticks: new Uint32Array(this.numEnvs),
+      };
+    }
+
+    dispose(): void {
+      this.disposed = true;
+    }
+  }
+
+  function reset(): void {
+    FakeWorker.instances = [];
+    FakeSharedMemoryManager.instances = [];
+    control.initBehaviors = [];
+    control.resetMessageBehavior = 'ok';
+    control.commandBehaviors = [];
+    control.readError = false;
+    control.stepTimeoutMs = 1000;
+    control.messageTimeoutMs = 1000;
+  }
+
+  return { control, FakeWorker, FakeSharedMemoryManager, reset };
+});
+
+vi.mock('worker_threads', () => ({ Worker: fakes.FakeWorker }));
+vi.mock('../../src/ipc/shared-memory', () => ({
+  SharedMemoryManager: fakes.FakeSharedMemoryManager,
+}));
+vi.mock('../../src/config/config-loader', () => ({
+  getConfig: () => ({
+    workerPool: {
+      numWorkers: 1,
+      useSharedMemory: true,
+      ringBufferSize: 16,
+      messageTimeoutMs: fakes.control.messageTimeoutMs,
+      stepTimeoutMs: fakes.control.stepTimeoutMs,
+    },
+  }),
+}));
+
+import { WorkerPool } from '../../src/core/worker-pool';
+
+describe('WorkerPool failure state', () => {
+  let pool: WorkerPool | undefined;
+
+  beforeEach(() => {
+    fakes.reset();
+  });
+
+  afterEach(async () => {
+    await pool?.close();
+    vi.restoreAllMocks();
+  });
+
+  it('cleans every started worker and shared manager after partial init failure', async () => {
+    fakes.control.initBehaviors = ['ok', 'error'];
+    pool = new WorkerPool(2);
+
+    await expect(pool.init(2, {}, true)).rejects.toThrow('synthetic init failure');
+
+    expect(fakes.FakeWorker.instances).toHaveLength(2);
+    expect(fakes.FakeWorker.instances.every(worker => worker.terminated)).toBe(true);
+    expect(fakes.FakeSharedMemoryManager.instances).toHaveLength(2);
+    expect(fakes.FakeSharedMemoryManager.instances.every(manager => manager.disposed)).toBe(true);
+    await expect(pool.step([0, 0])).rejects.toThrow('worker pool is in failed state');
+  });
+
+  it('rejects a shared worker error without reading partial results', async () => {
+    pool = new WorkerPool(2);
+    await pool.init(2, {}, true);
+    fakes.control.commandBehaviors = ['complete', 'error'];
+
+    await expect(pool.step([0, 0])).rejects.toThrow('Worker 1 reported an error');
+
+    expect(fakes.FakeSharedMemoryManager.instances.every(manager => manager.readCalls === 0)).toBe(true);
+    expect(fakes.FakeSharedMemoryManager.instances.every(manager => manager.disposed)).toBe(true);
+    await expect(pool.reset()).rejects.toThrow('worker pool is in failed state');
+  });
+
+  it('times out without reading stale results and fails the pool', async () => {
+    fakes.control.stepTimeoutMs = 20;
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, true);
+    fakes.control.commandBehaviors = ['timeout'];
+
+    await expect(pool.step([0])).rejects.toThrow(
+      'Shared-memory step timed out after 20ms waiting for worker(s) 0',
+    );
+
+    expect(fakes.FakeSharedMemoryManager.instances[0].readCalls).toBe(0);
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
+    expect(fakes.FakeSharedMemoryManager.instances[0].disposed).toBe(true);
+  });
+
+  it('times out during reset without returning stale observations', async () => {
+    fakes.control.messageTimeoutMs = 20;
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, true);
+    fakes.control.commandBehaviors = ['timeout'];
+
+    await expect(pool.reset()).rejects.toThrow(
+      'Shared-memory reset timed out after 20ms waiting for worker(s) 0',
+    );
+
+    expect(fakes.FakeSharedMemoryManager.instances[0].readCalls).toBe(0);
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
+    expect(fakes.FakeSharedMemoryManager.instances[0].disposed).toBe(true);
+  });
+
+  it('propagates a worker crash through the active shared batch', async () => {
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, true);
+    fakes.control.commandBehaviors = ['crash'];
+
+    await expect(pool.step([0])).rejects.toThrow('Worker 0 failed: synthetic worker crash');
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
+    expect(fakes.FakeSharedMemoryManager.instances[0].disposed).toBe(true);
+  });
+
+  it('propagates message-mode reset errors instead of returning null observations', async () => {
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, false);
+    fakes.control.resetMessageBehavior = 'error';
+
+    await expect(pool.reset()).rejects.toThrow('synthetic reset failure');
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
+    await expect(pool.reset()).rejects.toThrow('worker pool is in failed state');
+  });
+
+  it('propagates shared-memory read errors and disposes the pool', async () => {
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, true);
+    fakes.control.readError = true;
+
+    await expect(pool.step([0])).rejects.toThrow('synthetic shared-memory read failure');
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
+    expect(fakes.FakeSharedMemoryManager.instances[0].disposed).toBe(true);
+  });
+});

--- a/tests/unit/worker-pool-failures.test.ts
+++ b/tests/unit/worker-pool-failures.test.ts
@@ -381,6 +381,19 @@ describe('WorkerPool failure state', () => {
     await expect(pool.reset()).rejects.toThrow('worker pool is in failed state');
   });
 
+  it('keeps the pool usable when only live workers error-reply in a message-mode batch', async () => {
+    fakes.control.stepBehaviors = ['error', 'ok'];
+    pool = new WorkerPool(2);
+    await pool.init(2, {}, false);
+
+    await expect(pool.step([0, 0])).rejects.toThrow('synthetic step failure');
+
+    expect(fakes.FakeWorker.instances.every(worker => worker.terminated)).toBe(false);
+    fakes.control.stepBehaviors = ['ok', 'ok'];
+    const results = await pool.step([0, 0]);
+    expect(results).toHaveLength(2);
+  });
+
   it('fails the pool when a message-mode telemetry snapshot times out', async () => {
     fakes.control.messageTimeoutMs = 20;
     pool = new WorkerPool(1);

--- a/tests/unit/worker-pool-failures.test.ts
+++ b/tests/unit/worker-pool-failures.test.ts
@@ -8,6 +8,8 @@ const fakes = vi.hoisted(() => {
     initBehaviors: [] as Array<'ok' | 'error' | 'timeout'>,
     resetMessageBehavior: 'ok' as 'ok' | 'error' | 'silent',
     stepMessageBehavior: 'ok' as 'ok' | 'error' | 'silent',
+    resetBehaviors: [] as Array<'ok' | 'error' | 'silent'>,
+    stepBehaviors: [] as Array<'ok' | 'error' | 'silent'>,
     commandBehaviors: [] as CommandBehavior[],
     readError: false,
     stepTimeoutMs: 1000,
@@ -55,15 +57,17 @@ const fakes = vi.hoisted(() => {
           });
         }
       } else if (message.type === 'reset') {
-        if (control.resetMessageBehavior === 'error') {
+        const behavior = control.resetBehaviors[this.index] ?? control.resetMessageBehavior;
+        if (behavior === 'error') {
           this.emit('message', { id: message.id, status: 'error', error: 'synthetic reset failure' });
-        } else if (control.resetMessageBehavior !== 'silent') {
+        } else if (behavior !== 'silent') {
           this.emit('message', { id: message.id, status: 'ok', data: [{}] });
         }
       } else if (message.type === 'step') {
-        if (control.stepMessageBehavior === 'error') {
+        const behavior = control.stepBehaviors[this.index] ?? control.stepMessageBehavior;
+        if (behavior === 'error') {
           this.emit('message', { id: message.id, status: 'error', error: 'synthetic step failure' });
-        } else if (control.stepMessageBehavior !== 'silent') {
+        } else if (behavior !== 'silent') {
           this.emit('message', { id: message.id, status: 'ok', data: [{}] });
         }
       }
@@ -163,6 +167,8 @@ const fakes = vi.hoisted(() => {
     control.initBehaviors = [];
     control.resetMessageBehavior = 'ok';
     control.stepMessageBehavior = 'ok';
+    control.resetBehaviors = [];
+    control.stepBehaviors = [];
     control.commandBehaviors = [];
     control.readError = false;
     control.stepTimeoutMs = 1000;
@@ -349,6 +355,41 @@ describe('WorkerPool failure state', () => {
 
     expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
     await expect(pool.reset()).rejects.toThrow('worker pool is in failed state');
+  });
+
+  it('fails the pool when a hung worker times out after another worker error-replies in the same step batch', async () => {
+    fakes.control.messageTimeoutMs = 20;
+    fakes.control.stepBehaviors = ['error', 'silent'];
+    pool = new WorkerPool(2);
+    await pool.init(2, {}, false);
+
+    await expect(pool.step([0, 0])).rejects.toThrow('timed out');
+
+    expect(fakes.FakeWorker.instances.every(worker => worker.terminated)).toBe(true);
+    await expect(pool.step([0, 0])).rejects.toThrow('worker pool is in failed state');
+  });
+
+  it('fails the pool when a hung worker times out after another worker error-replies in the same reset batch', async () => {
+    fakes.control.messageTimeoutMs = 20;
+    fakes.control.resetBehaviors = ['error', 'silent'];
+    pool = new WorkerPool(2);
+    await pool.init(2, {}, false);
+
+    await expect(pool.reset()).rejects.toThrow('timed out');
+
+    expect(fakes.FakeWorker.instances.every(worker => worker.terminated)).toBe(true);
+    await expect(pool.reset()).rejects.toThrow('worker pool is in failed state');
+  });
+
+  it('fails the pool when a message-mode telemetry snapshot times out', async () => {
+    fakes.control.messageTimeoutMs = 20;
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, false);
+
+    await expect(pool.getTelemetrySnapshots()).rejects.toThrow('timed out');
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
+    await expect(pool.step([0])).rejects.toThrow('worker pool is in failed state');
   });
 
   it('propagates message-mode reset errors without failing the pool', async () => {

--- a/tests/unit/worker-pool-failures.test.ts
+++ b/tests/unit/worker-pool-failures.test.ts
@@ -2,12 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const fakes = vi.hoisted(() => {
   type WorkerEvent = 'message' | 'error' | 'exit';
-  type CommandBehavior = 'complete' | 'error' | 'timeout' | 'crash';
+  type CommandBehavior = 'complete' | 'error' | 'timeout' | 'crash' | 'exit';
 
   const control = {
-    initBehaviors: [] as Array<'ok' | 'error'>,
+    initBehaviors: [] as Array<'ok' | 'error' | 'timeout'>,
     resetMessageBehavior: 'ok' as 'ok' | 'error',
-    stepMessageBehavior: 'ok' as 'ok' | 'error',
+    stepMessageBehavior: 'ok' as 'ok' | 'error' | 'silent',
     commandBehaviors: [] as CommandBehavior[],
     readError: false,
     stepTimeoutMs: 1000,
@@ -47,7 +47,7 @@ const fakes = vi.hoisted(() => {
         manager?.connect(message.syncBuffer, message.workerIndex, this);
         if (control.initBehaviors[this.index] === 'error') {
           this.emit('message', { id: message.id, status: 'error', error: 'synthetic init failure' });
-        } else {
+        } else if (control.initBehaviors[this.index] !== 'timeout') {
           this.emit('message', {
             id: message.id,
             status: 'ok',
@@ -63,7 +63,7 @@ const fakes = vi.hoisted(() => {
       } else if (message.type === 'step') {
         if (control.stepMessageBehavior === 'error') {
           this.emit('message', { id: message.id, status: 'error', error: 'synthetic step failure' });
-        } else {
+        } else if (control.stepMessageBehavior !== 'silent') {
           this.emit('message', { id: message.id, status: 'ok', data: [{}] });
         }
       }
@@ -116,6 +116,10 @@ const fakes = vi.hoisted(() => {
       if (behavior === 'timeout') return;
       if (behavior === 'crash') {
         queueMicrotask(() => this.worker?.emit('error', new Error('synthetic worker crash')));
+        return;
+      }
+      if (behavior === 'exit') {
+        queueMicrotask(() => this.worker?.emit('exit', 1));
         return;
       }
 
@@ -262,6 +266,65 @@ describe('WorkerPool failure state', () => {
 
     expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
     expect(fakes.FakeSharedMemoryManager.instances[0].disposed).toBe(true);
+  });
+
+  it('fails the pool when a worker exits during an active shared batch', async () => {
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, true);
+    fakes.control.commandBehaviors = ['exit'];
+
+    await expect(pool.step([0])).rejects.toThrow(
+      'Worker 0 failed: Worker 0 exited unexpectedly with code 1',
+    );
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
+    expect(fakes.FakeSharedMemoryManager.instances[0].disposed).toBe(true);
+    await expect(pool.step([0])).rejects.toThrow('worker pool is in failed state');
+  });
+
+  it('fails the pool when a worker exits during an active message-passing batch', async () => {
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, false);
+    fakes.control.stepMessageBehavior = 'silent';
+
+    const pendingStep = pool.step([0]);
+    fakes.FakeWorker.instances[0].emit('exit', 1);
+
+    await expect(pendingStep).rejects.toThrow(
+      'Worker 0 failed: Worker 0 exited unexpectedly with code 1',
+    );
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
+    await expect(pool.step([0])).rejects.toThrow('worker pool is in failed state');
+  });
+
+  it('interrupts an active shared batch when close() is called and stays closed', async () => {
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, true);
+    fakes.control.commandBehaviors = ['timeout'];
+
+    const pendingStep = pool.step([0]);
+    await pool.close();
+
+    await expect(pendingStep).rejects.toThrow(
+      'Shared-memory step interrupted because worker pool is closed',
+    );
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
+    expect(fakes.FakeSharedMemoryManager.instances[0].disposed).toBe(true);
+    await expect(pool.step([0])).rejects.toThrow('worker pool is closed');
+  });
+
+  it('fails the pool and cleans up when a worker never answers init', async () => {
+    fakes.control.messageTimeoutMs = 20;
+    fakes.control.initBehaviors = ['timeout'];
+    pool = new WorkerPool(1);
+
+    await expect(pool.init(1, {}, true)).rejects.toThrow('timed out');
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
+    expect(fakes.FakeSharedMemoryManager.instances[0].disposed).toBe(true);
+    await expect(pool.step([0])).rejects.toThrow('worker pool is in failed state');
   });
 
   it('propagates message-mode reset errors without failing the pool', async () => {

--- a/tests/unit/worker-pool-failures.test.ts
+++ b/tests/unit/worker-pool-failures.test.ts
@@ -6,7 +6,7 @@ const fakes = vi.hoisted(() => {
 
   const control = {
     initBehaviors: [] as Array<'ok' | 'error' | 'timeout'>,
-    resetMessageBehavior: 'ok' as 'ok' | 'error',
+    resetMessageBehavior: 'ok' as 'ok' | 'error' | 'silent',
     stepMessageBehavior: 'ok' as 'ok' | 'error' | 'silent',
     commandBehaviors: [] as CommandBehavior[],
     readError: false,
@@ -57,7 +57,7 @@ const fakes = vi.hoisted(() => {
       } else if (message.type === 'reset') {
         if (control.resetMessageBehavior === 'error') {
           this.emit('message', { id: message.id, status: 'error', error: 'synthetic reset failure' });
-        } else {
+        } else if (control.resetMessageBehavior !== 'silent') {
           this.emit('message', { id: message.id, status: 'ok', data: [{}] });
         }
       } else if (message.type === 'step') {
@@ -325,6 +325,30 @@ describe('WorkerPool failure state', () => {
     expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
     expect(fakes.FakeSharedMemoryManager.instances[0].disposed).toBe(true);
     await expect(pool.step([0])).rejects.toThrow('worker pool is in failed state');
+  });
+
+  it('fails the pool when a message-mode worker hangs on step', async () => {
+    fakes.control.messageTimeoutMs = 20;
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, false);
+    fakes.control.stepMessageBehavior = 'silent';
+
+    await expect(pool.step([0])).rejects.toThrow('timed out');
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
+    await expect(pool.step([0])).rejects.toThrow('worker pool is in failed state');
+  });
+
+  it('fails the pool when a message-mode worker hangs on reset', async () => {
+    fakes.control.messageTimeoutMs = 20;
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, false);
+    fakes.control.resetMessageBehavior = 'silent';
+
+    await expect(pool.reset()).rejects.toThrow('timed out');
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
+    await expect(pool.reset()).rejects.toThrow('worker pool is in failed state');
   });
 
   it('propagates message-mode reset errors without failing the pool', async () => {

--- a/tests/unit/worker-shared-error.test.ts
+++ b/tests/unit/worker-shared-error.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fakes = vi.hoisted(() => {
+  const parentPort = {
+    on: vi.fn(),
+    postMessage: vi.fn(),
+  };
+
+  class ThrowingEnvironment {
+    reset(): any {
+      return {};
+    }
+
+    step(): never {
+      throw new Error('synthetic environment failure');
+    }
+
+    getObservationFast(): Float32Array {
+      return new Float32Array(16);
+    }
+  }
+
+  class FakeSharedMemoryManager {
+    static isSupported(): boolean {
+      return true;
+    }
+
+    constructor(_numEnvs: number, _ringSize: number, _buffer: SharedArrayBuffer) {}
+    waitForActions(): string { return 'not-equal'; }
+    readCommand(): number { return 0; }
+    readActionSlot(): number { return 0; }
+    getActionsView(): Uint8Array { return new Uint8Array(1); }
+  }
+
+  return { parentPort, ThrowingEnvironment, FakeSharedMemoryManager };
+});
+
+vi.mock('worker_threads', () => ({ parentPort: fakes.parentPort }));
+vi.mock('../../src/core/environment', () => ({
+  BonkEnvironment: fakes.ThrowingEnvironment,
+}));
+vi.mock('../../src/ipc/shared-memory', () => ({
+  SharedMemoryManager: fakes.FakeSharedMemoryManager,
+}));
+
+import '../../src/core/worker';
+
+describe('shared-memory worker error signaling', () => {
+  let messageHandler: (message: any) => void;
+
+  beforeEach(() => {
+    messageHandler = fakes.parentPort.on.mock.calls[0][1];
+    fakes.parentPort.postMessage.mockClear();
+  });
+
+  it('publishes an error status and wakes the pool when environment work throws', () => {
+    const syncBuffer = new SharedArrayBuffer(Int32Array.BYTES_PER_ELEMENT * 2);
+    const sync = new Int32Array(syncBuffer);
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    messageHandler({
+      type: 'init',
+      id: 'init',
+      numEnvs: 1,
+      workerIndex: 0,
+      sharedBuffer: new SharedArrayBuffer(4),
+      syncBuffer,
+    });
+    fakes.parentPort.postMessage.mockClear();
+
+    messageHandler({ type: 'wait-for-action' });
+
+    expect(Atomics.load(sync, 0)).toBe(1);
+    expect(Atomics.load(sync, 1)).toBe(-1);
+    expect(fakes.parentPort.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        error: 'worker-loop-crash: synthetic environment failure',
+      }),
+    );
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
﻿## Summary

- introduces explicit WorkerPool lifecycle states and fail-fast behavior after initialization, worker, reset, step, telemetry, or shared-memory failures
- replaces blind shared completion counting with a wake counter plus one status slot per worker
- uses non-blocking `Atomics.waitAsync` so worker error/exit events can abort an active shared batch promptly
- rejects reset/step on timeout instead of reading stale or partial observations
- terminates all workers, rejects pending callbacks, and disposes shared memory before returning a pool failure
- cleans partially initialized workers and removes null-observation fallbacks
- makes shared workers publish an explicit error status before reporting a loop exception
- fails the pool on message-mode send timeouts (hung worker) while keeping live-worker error replies recoverable; message-mode batches settle every worker (`Promise.allSettled`) so a hung worker's timeout surfaces even after an earlier error reply
- fails the pool on message-mode telemetry timeouts (shared-mode telemetry timeouts stay recoverable, as shared workers legitimately never service `GET_TELEMETRY`)

## Validation

- `npm test -- tests/unit/worker-pool-failures.test.ts tests/unit/worker-shared-error.test.ts tests/integration/worker-pool-errors.test.ts tests/integration/worker-pool-sharedmem-regression.test.ts tests/integration/worker-integration.test.ts` (49 passed)
- `git diff --check`
- Combined merge with PR #170 head (`git merge origin/fix-worker-protocol-hardening`, no conflicts): 59 passed across both PRs' suites
- `npm run typecheck` is blocked by pre-existing errors also present on `main` (missing Node/ES2020 test libs and existing telemetry/test typing failures)

Closes #54
Closes #61
Closes #64
Closes #89
Closes #101
Closes #102
Closes #114
Closes #118
Closes #132
Closes #133
Closes #136
Closes #141
Closes #143
Closes #150
Closes #158
