### PR TITLE
bench(ipc): measure shared-memory worker scaling

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -58,8 +58,10 @@ Tests both default and frame-skip configurations.
 
 ### Layer 4 — Worker Pool (`layer4-worker-pool.ts`)
 Tests `WorkerPool.step()` with SharedArrayBuffer IPC across exactly 1, 2, 4, and
-8 workers, with one environment per worker. Eight balanced-order samples report
-median, P25, and P75 latency plus aggregate environment throughput; worker
+8 workers, with one environment per worker. Each worker count runs in a single
+reused pool; eight balanced-order samples of 2,000 steps report per-step median,
+P25, and P75 latency plus aggregate environment throughput. A seeded
+deterministic pseudo-random action workload keeps runs reproducible, and worker
 startup and warmup are excluded from measurements.
 
 ### Layer 5 — Memory (`layer5-memory.ts`)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -57,8 +57,10 @@ extraction, reward calculation, and action decoding. No worker threads or IPC.
 Tests both default and frame-skip configurations.
 
 ### Layer 4 — Worker Pool (`layer4-worker-pool.ts`)
-Tests `WorkerPool.step()` with SharedArrayBuffer IPC across N=1,2,4,8,16
-environments. This is the TypeScript multi-env path with Atomics synchronization.
+Tests `WorkerPool.step()` with SharedArrayBuffer IPC across exactly 1, 2, 4, and
+8 workers, with one environment per worker. Eight balanced-order samples report
+median, P25, and P75 latency plus aggregate environment throughput; worker
+startup and warmup are excluded from measurements.
 
 ### Layer 5 — Memory (`layer5-memory.ts`)
 Runs 50K steps and monitors heap growth, peak RSS, and GC effectiveness.
@@ -92,6 +94,7 @@ and key metrics per layer.
 | 2 | PhysicsEngine TPS | > 15,000 |
 | 3 | BonkEnvironment SPS | > 30,000 |
 | 4 | WorkerPool SPS (N=1) | > 2,000 |
+| 4 | Aggregate Env-SPS (N>1) | >= 90% of N=1 |
 | 5 | Heap growth (50K steps) | < 5 MB |
 | 6 | Throughput CV (100K steps) | < 10% |
 

--- a/benchmarks/layer4-worker-pool.ts
+++ b/benchmarks/layer4-worker-pool.ts
@@ -22,6 +22,7 @@ import {
 
 const STEPS_PER_SAMPLE = 2_000;
 const WARMUP_STEPS = 250;
+const MAX_ATTEMPTS = 3;
 const WORKER_COUNTS = [1, 2, 4, 8];
 const SAMPLE_ORDERS = [
     [1, 2, 4, 8],
@@ -48,31 +49,65 @@ function quantile(values: number[], q: number): number {
     return sorted[lower] * (1 - weight) + sorted[upper] * weight;
 }
 
-async function measureSample(numWorkers: number): Promise<number> {
-    const pool = new WorkerPool(numWorkers);
-    try {
-        await pool.init(numWorkers, BENCH_CONFIG, true);
-        if (!pool.isUsingSharedMemory()) {
-            throw new Error('SharedArrayBuffer mode unavailable');
-        }
-        await pool.reset(Array.from({ length: numWorkers }, (_, index) => index + 1));
-        const actions = new Array(numWorkers).fill(0);
-
-        for (let i = 0; i < WARMUP_STEPS; i++) {
-            await pool.step(actions);
-        }
-
-        const start = performance.now();
-        for (let i = 0; i < STEPS_PER_SAMPLE; i++) {
-            await pool.step(actions);
-        }
-        return (performance.now() - start) / STEPS_PER_SAMPLE;
-    } finally {
-        await pool.close();
+/**
+ * Deterministic pseudo-random action workload. A fixed-seed LCG keeps the
+ * exact action sequence reproducible across runs while exercising more than
+ * the idle action.
+ */
+function makeActions(numWorkers: number): number[] {
+    let state = (0x0BAD5EED + numWorkers * 0x9E3779B9) >>> 0;
+    const actions = new Array<number>(numWorkers);
+    for (let i = 0; i < numWorkers; i++) {
+        state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+        actions[i] = state % 64;
     }
+    return actions;
 }
 
-function createResult(numWorkers: number, latenciesMs: number[], baselineEnvSps: number): BenchmarkResult {
+async function createPool(numWorkers: number): Promise<WorkerPool> {
+    let lastError: unknown;
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+        try {
+            const pool = new WorkerPool(numWorkers);
+            await pool.init(numWorkers, BENCH_CONFIG, true);
+            if (!pool.isUsingSharedMemory()) {
+                await pool.close();
+                throw new Error('SharedArrayBuffer mode unavailable');
+            }
+            return pool;
+        } catch (e) {
+            lastError = e;
+        }
+    }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+/**
+ * Returns per-step latencies (ms) for STEPS_PER_SAMPLE measured steps.
+ * Warmup is excluded; the caller resets the pool to a deterministic state
+ * before each sample.
+ */
+async function measureSample(pool: WorkerPool, actions: number[]): Promise<number[]> {
+    const seeds = actions.map((_, index) => index + 1);
+    await pool.reset(seeds);
+
+    for (let i = 0; i < WARMUP_STEPS; i++) {
+        await pool.step(actions);
+    }
+
+    const stepLatencies = new Array<number>(STEPS_PER_SAMPLE);
+    let prev = performance.now();
+    for (let i = 0; i < STEPS_PER_SAMPLE; i++) {
+        await pool.step(actions);
+        const now = performance.now();
+        stepLatencies[i] = now - prev;
+        prev = now;
+    }
+    return stepLatencies;
+}
+
+function createResult(numWorkers: number, samples: number[][], baselineEnvSps: number): BenchmarkResult {
+    const latenciesMs = samples.flat();
     const medianLatencyMs = quantile(latenciesMs, 0.5);
     const batchSps = 1_000 / medianLatencyMs;
     const envSps = batchSps * numWorkers;
@@ -85,7 +120,7 @@ function createResult(numWorkers: number, latenciesMs: number[], baselineEnvSps:
         name: `WorkerPool.step() N=${numWorkers}`,
         passed,
         status: passed ? 'PASS' : 'FAIL',
-        durationMs: latenciesMs.reduce((sum, latency) => sum + latency * STEPS_PER_SAMPLE, 0),
+        durationMs: latenciesMs.reduce((sum, latency) => sum + latency, 0),
         metrics: [
             { label: 'Batch SPS', value: Math.round(batchSps), unit: 'batches/sec' },
             { label: 'Env-SPS (aggregate)', value: Math.round(envSps), unit: 'env-steps/sec' },
@@ -94,7 +129,7 @@ function createResult(numWorkers: number, latenciesMs: number[], baselineEnvSps:
             { label: 'P75 latency', value: +quantile(latenciesMs, 0.75).toFixed(3), unit: 'ms' },
             { label: 'Workers', value: numWorkers, unit: '' },
             { label: 'Envs per worker', value: 1, unit: '' },
-            { label: 'Samples', value: latenciesMs.length, unit: '' },
+            { label: 'Samples', value: samples.length, unit: '' },
             { label: 'Steps per sample', value: STEPS_PER_SAMPLE, unit: '' },
         ],
     };
@@ -103,23 +138,48 @@ function createResult(numWorkers: number, latenciesMs: number[], baselineEnvSps:
 async function main(): Promise<void> {
     const suiteStart = performance.now();
     const suite = createSuite(4, 'Worker Pool', 'SharedArrayBuffer IPC scaling across exact worker counts');
-    const samples = new Map<number, number[]>(WORKER_COUNTS.map(count => [count, []]));
+    const samples = new Map<number, number[][]>(WORKER_COUNTS.map(count => [count, []]));
     const errors = new Map<number, string>();
+    const pools = new Map<number, WorkerPool>();
 
-    for (const order of SAMPLE_ORDERS) {
-        for (const numWorkers of order) {
-            if (errors.has(numWorkers)) continue;
+    try {
+        for (const numWorkers of WORKER_COUNTS) {
             try {
-                samples.get(numWorkers)!.push(await measureSample(numWorkers));
+                pools.set(numWorkers, await createPool(numWorkers));
             } catch (e: any) {
-                errors.set(numWorkers, e instanceof Error ? e.message : String(e));
+                errors.set(numWorkers, `pool init failed: ${e instanceof Error ? e.message : String(e)}`);
             }
+        }
+
+        for (const order of SAMPLE_ORDERS) {
+            for (const numWorkers of order) {
+                if (errors.has(numWorkers)) continue;
+                const pool = pools.get(numWorkers)!;
+                const actions = makeActions(numWorkers);
+                let lastError: unknown;
+                for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+                    try {
+                        samples.get(numWorkers)!.push(await measureSample(pool, actions));
+                        lastError = undefined;
+                        break;
+                    } catch (e) {
+                        lastError = e;
+                    }
+                }
+                if (lastError !== undefined) {
+                    errors.set(numWorkers, `sample failed after ${MAX_ATTEMPTS} attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
+                }
+            }
+        }
+    } finally {
+        for (const pool of pools.values()) {
+            await pool.close();
         }
     }
 
     const baselineLatencies = samples.get(1)!;
-    const baselineEnvSps = baselineLatencies.length === SAMPLE_ORDERS.length
-        ? 1_000 / quantile(baselineLatencies, 0.5)
+    const baselineEnvSps = baselineLatencies.length > 0
+        ? 1_000 / quantile(baselineLatencies.flat(), 0.5)
         : 0;
 
     for (const numWorkers of WORKER_COUNTS) {

--- a/benchmarks/layer4-worker-pool.ts
+++ b/benchmarks/layer4-worker-pool.ts
@@ -34,6 +34,7 @@ const SAMPLE_ORDERS = [
     [2, 1, 8, 4],
     [1, 8, 4, 2],
 ];
+const MIN_BASELINE_SAMPLES = SAMPLE_ORDERS.length;
 const BENCH_CONFIG = {
     verboseTelemetry: false,
     numOpponents: 1,
@@ -67,16 +68,20 @@ function makeActions(numWorkers: number): number[] {
 async function createPool(numWorkers: number): Promise<WorkerPool> {
     let lastError: unknown;
     for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+        const pool = new WorkerPool(numWorkers);
         try {
-            const pool = new WorkerPool(numWorkers);
             await pool.init(numWorkers, BENCH_CONFIG, true);
             if (!pool.isUsingSharedMemory()) {
-                await pool.close();
                 throw new Error('SharedArrayBuffer mode unavailable');
             }
             return pool;
         } catch (e) {
             lastError = e;
+            try {
+                await pool.close();
+            } catch {
+                // preserve the original error
+            }
         }
     }
     throw lastError instanceof Error ? lastError : new Error(String(lastError));
@@ -178,13 +183,13 @@ async function main(): Promise<void> {
     }
 
     const baselineLatencies = samples.get(1)!;
-    const baselineEnvSps = baselineLatencies.length > 0
+    const baselineUnderpowered = baselineLatencies.length < MIN_BASELINE_SAMPLES;
+    const baselineEnvSps = !baselineUnderpowered
         ? 1_000 / quantile(baselineLatencies.flat(), 0.5)
         : 0;
 
     for (const numWorkers of WORKER_COUNTS) {
-        const error = errors.get(numWorkers);
-        if (errors.has(numWorkers) || (numWorkers !== 1 && baselineEnvSps === 0)) {
+        if (errors.has(numWorkers)) {
             recordResult(suite, {
                 layer: 4,
                 name: `WorkerPool.step() N=${numWorkers}`,
@@ -192,7 +197,17 @@ async function main(): Promise<void> {
                 status: 'ERROR',
                 durationMs: 0,
                 metrics: [],
-                error: error || 'N=1 baseline unavailable',
+                error: errors.get(numWorkers)!,
+            });
+        } else if (baselineUnderpowered) {
+            recordResult(suite, {
+                layer: 4,
+                name: `WorkerPool.step() N=${numWorkers}`,
+                passed: false,
+                status: 'ERROR',
+                durationMs: 0,
+                metrics: [],
+                error: `N=1 baseline underpowered (${baselineLatencies.length}/${MIN_BASELINE_SAMPLES} samples) — scaling gate not evaluated`,
             });
         } else {
             recordResult(suite, createResult(numWorkers, samples.get(numWorkers)!, baselineEnvSps));

--- a/benchmarks/layer4-worker-pool.ts
+++ b/benchmarks/layer4-worker-pool.ts
@@ -34,7 +34,7 @@ const SAMPLE_ORDERS = [
     [2, 1, 8, 4],
     [1, 8, 4, 2],
 ];
-const MIN_BASELINE_SAMPLES = SAMPLE_ORDERS.length;
+const MIN_SAMPLES_PER_COUNT = SAMPLE_ORDERS.length / 2;
 const BENCH_CONFIG = {
     verboseTelemetry: false,
     numOpponents: 1,
@@ -172,7 +172,9 @@ async function main(): Promise<void> {
                     }
                 }
                 if (lastError !== undefined) {
-                    errors.set(numWorkers, `sample failed after ${MAX_ATTEMPTS} attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
+                    // Drop only this sample; earlier samples stay retained and
+                    // later orders keep collecting for this worker count.
+                    console.warn(`[Layer 4] N=${numWorkers} sample dropped after ${MAX_ATTEMPTS} attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}`);
                 }
             }
         }
@@ -183,12 +185,13 @@ async function main(): Promise<void> {
     }
 
     const baselineLatencies = samples.get(1)!;
-    const baselineUnderpowered = baselineLatencies.length < MIN_BASELINE_SAMPLES;
+    const baselineUnderpowered = baselineLatencies.length < MIN_SAMPLES_PER_COUNT;
     const baselineEnvSps = !baselineUnderpowered
         ? 1_000 / quantile(baselineLatencies.flat(), 0.5)
         : 0;
 
     for (const numWorkers of WORKER_COUNTS) {
+        const retainedSamples = samples.get(numWorkers)!.length;
         if (errors.has(numWorkers)) {
             recordResult(suite, {
                 layer: 4,
@@ -199,7 +202,7 @@ async function main(): Promise<void> {
                 metrics: [],
                 error: errors.get(numWorkers)!,
             });
-        } else if (baselineUnderpowered) {
+        } else if (retainedSamples < MIN_SAMPLES_PER_COUNT) {
             recordResult(suite, {
                 layer: 4,
                 name: `WorkerPool.step() N=${numWorkers}`,
@@ -207,7 +210,17 @@ async function main(): Promise<void> {
                 status: 'ERROR',
                 durationMs: 0,
                 metrics: [],
-                error: `N=1 baseline underpowered (${baselineLatencies.length}/${MIN_BASELINE_SAMPLES} samples) — scaling gate not evaluated`,
+                error: `only ${retainedSamples}/${SAMPLE_ORDERS.length} samples retained for N=${numWorkers}`,
+            });
+        } else if (baselineUnderpowered && numWorkers !== 1) {
+            recordResult(suite, {
+                layer: 4,
+                name: `WorkerPool.step() N=${numWorkers}`,
+                passed: false,
+                status: 'ERROR',
+                durationMs: 0,
+                metrics: [],
+                error: `N=1 baseline underpowered (${baselineLatencies.length}/${SAMPLE_ORDERS.length} samples) — scaling gate not evaluated`,
             });
         } else {
             recordResult(suite, createResult(numWorkers, samples.get(numWorkers)!, baselineEnvSps));

--- a/benchmarks/layer4-worker-pool.ts
+++ b/benchmarks/layer4-worker-pool.ts
@@ -1,10 +1,9 @@
 /**
  * Layer 4: Worker Pool Shared Memory Throughput
  *
- * Measures WorkerPool.step() with SharedArrayBuffer IPC across
- * varying environment counts. This is the TypeScript-side
- * multi-env path — main thread dispatches actions to N workers
- * via shared memory and collects results via Atomics.
+ * Measures WorkerPool.step() with SharedArrayBuffer IPC across exact
+ * worker counts. Each worker owns one environment so aggregate throughput
+ * exposes scaling without changing the amount of work assigned per worker.
  *
  * Layer: 4 — Worker Pool
  * Run:   npx tsx benchmarks/layer4-worker-pool.ts
@@ -21,70 +20,122 @@ import {
     formatSuiteSummary,
 } from '../src/utils/bench-report';
 
-const STEPS = 2_000;
-const WARMUP = 100;
-const ENV_COUNTS = [1, 2, 4, 8, 16];
+const STEPS_PER_SAMPLE = 2_000;
+const WARMUP_STEPS = 250;
+const WORKER_COUNTS = [1, 2, 4, 8];
+const SAMPLE_ORDERS = [
+    [1, 2, 4, 8],
+    [2, 4, 8, 1],
+    [4, 8, 1, 2],
+    [8, 1, 2, 4],
+    [8, 4, 2, 1],
+    [4, 2, 1, 8],
+    [2, 1, 8, 4],
+    [1, 8, 4, 2],
+];
+const BENCH_CONFIG = {
+    verboseTelemetry: false,
+    numOpponents: 1,
+    frameSkip: 1,
+};
 
-async function benchWorkerPool(numEnvs: number): Promise<BenchmarkResult> {
-    const pool = new WorkerPool();
-    await pool.init(numEnvs, {}, true);
-    await pool.reset();
+function quantile(values: number[], q: number): number {
+    const sorted = [...values].sort((a, b) => a - b);
+    const position = (sorted.length - 1) * q;
+    const lower = Math.floor(position);
+    const upper = Math.ceil(position);
+    const weight = position - lower;
+    return sorted[lower] * (1 - weight) + sorted[upper] * weight;
+}
 
-    const actions: number[] = [];
-    for (let i = 0; i < numEnvs; i++) {
-        actions.push(Math.floor(Math.random() * 64));
+async function measureSample(numWorkers: number): Promise<number> {
+    const pool = new WorkerPool(numWorkers);
+    try {
+        await pool.init(numWorkers, BENCH_CONFIG, true);
+        if (!pool.isUsingSharedMemory()) {
+            throw new Error('SharedArrayBuffer mode unavailable');
+        }
+        await pool.reset(Array.from({ length: numWorkers }, (_, index) => index + 1));
+        const actions = new Array(numWorkers).fill(0);
+
+        for (let i = 0; i < WARMUP_STEPS; i++) {
+            await pool.step(actions);
+        }
+
+        const start = performance.now();
+        for (let i = 0; i < STEPS_PER_SAMPLE; i++) {
+            await pool.step(actions);
+        }
+        return (performance.now() - start) / STEPS_PER_SAMPLE;
+    } finally {
+        await pool.close();
     }
+}
 
-    for (let i = 0; i < WARMUP; i++) {
-        await pool.step(actions);
-    }
-
-    const start = performance.now();
-    for (let i = 0; i < STEPS; i++) {
-        await pool.step(actions);
-    }
-    const elapsed = performance.now() - start;
-    const sps = STEPS / (elapsed / 1000);
-    const envSps = sps * numEnvs;
-    const msPerStep = elapsed / STEPS;
-
-    pool.close();
-    await new Promise(r => setTimeout(r, 200));
+function createResult(numWorkers: number, latenciesMs: number[], baselineEnvSps: number): BenchmarkResult {
+    const medianLatencyMs = quantile(latenciesMs, 0.5);
+    const batchSps = 1_000 / medianLatencyMs;
+    const envSps = batchSps * numWorkers;
+    const passed = numWorkers === 1
+        ? batchSps > 2_000
+        : baselineEnvSps > 0 && envSps >= baselineEnvSps * 0.9;
 
     return {
         layer: 4,
-        name: `WorkerPool.step() N=${numEnvs}`,
-        passed: sps > 2_000,
-        status: sps > 2_000 ? 'PASS' : 'FAIL',
-        durationMs: elapsed,
+        name: `WorkerPool.step() N=${numWorkers}`,
+        passed,
+        status: passed ? 'PASS' : 'FAIL',
+        durationMs: latenciesMs.reduce((sum, latency) => sum + latency * STEPS_PER_SAMPLE, 0),
         metrics: [
-            { label: 'SPS (per-env)', value: Math.round(sps), unit: 'steps/sec' },
+            { label: 'Batch SPS', value: Math.round(batchSps), unit: 'batches/sec' },
             { label: 'Env-SPS (aggregate)', value: Math.round(envSps), unit: 'env-steps/sec' },
-            { label: 'Latency', value: +msPerStep.toFixed(3), unit: 'ms' },
-            { label: 'Envs', value: numEnvs, unit: '' },
-            { label: 'Steps', value: STEPS, unit: '' },
+            { label: 'Median latency', value: +medianLatencyMs.toFixed(3), unit: 'ms' },
+            { label: 'P25 latency', value: +quantile(latenciesMs, 0.25).toFixed(3), unit: 'ms' },
+            { label: 'P75 latency', value: +quantile(latenciesMs, 0.75).toFixed(3), unit: 'ms' },
+            { label: 'Workers', value: numWorkers, unit: '' },
+            { label: 'Envs per worker', value: 1, unit: '' },
+            { label: 'Samples', value: latenciesMs.length, unit: '' },
+            { label: 'Steps per sample', value: STEPS_PER_SAMPLE, unit: '' },
         ],
     };
 }
 
 async function main(): Promise<void> {
     const suiteStart = performance.now();
-    const suite = createSuite(4, 'Worker Pool', 'SharedArrayBuffer IPC throughput across env counts');
+    const suite = createSuite(4, 'Worker Pool', 'SharedArrayBuffer IPC scaling across exact worker counts');
+    const samples = new Map<number, number[]>(WORKER_COUNTS.map(count => [count, []]));
+    const errors = new Map<number, string>();
 
-    for (const n of ENV_COUNTS) {
-        try {
-            const result = await benchWorkerPool(n);
-            recordResult(suite, result);
-        } catch (e: any) {
+    for (const order of SAMPLE_ORDERS) {
+        for (const numWorkers of order) {
+            if (errors.has(numWorkers)) continue;
+            try {
+                samples.get(numWorkers)!.push(await measureSample(numWorkers));
+            } catch (e: any) {
+                errors.set(numWorkers, e instanceof Error ? e.message : String(e));
+            }
+        }
+    }
+
+    const baselineLatencies = samples.get(1)!;
+    const baselineEnvSps = baselineLatencies.length === SAMPLE_ORDERS.length
+        ? 1_000 / quantile(baselineLatencies, 0.5)
+        : 0;
+
+    for (const numWorkers of WORKER_COUNTS) {
+        const error = errors.get(numWorkers);
+        if (errors.has(numWorkers) || (numWorkers !== 1 && baselineEnvSps === 0)) {
             recordResult(suite, {
                 layer: 4,
-                name: `WorkerPool.step() N=${n}`,
+                name: `WorkerPool.step() N=${numWorkers}`,
                 passed: false,
                 status: 'ERROR',
                 durationMs: 0,
                 metrics: [],
-                error: e.message,
+                error: error || 'N=1 baseline unavailable',
             });
+        } else {
+            recordResult(suite, createResult(numWorkers, samples.get(numWorkers)!, baselineEnvSps));
         }
     }
 

--- a/benchmarks/runner.ts
+++ b/benchmarks/runner.ts
@@ -72,7 +72,7 @@ const LAYERS: Record<string, { file: string; name: string; description: string }
     '1': { file: 'layer1-primitives.ts', name: 'Primitives', description: 'Atomics, TypedArray, object allocation latencies' },
     '2': { file: 'layer2-physics.ts', name: 'Raw Physics', description: 'Box2D physics engine tick throughput (isolated)' },
     '3': { file: 'layer3-environment.ts', name: 'Environment', description: 'BonkEnvironment step throughput (no IPC)' },
-    '4': { file: 'layer4-worker-pool.ts', name: 'Worker Pool', description: 'SharedArrayBuffer IPC throughput across env counts' },
+    '4': { file: 'layer4-worker-pool.ts', name: 'Worker Pool', description: 'SharedArrayBuffer IPC scaling across exact worker counts' },
     '5': { file: 'layer5-memory.ts', name: 'Memory', description: 'Heap stability and reset cycle memory leaks' },
     '6': { file: 'layer6-stability.ts', name: 'Stability', description: 'Long-running throughput variance and GC pressure' },
 };
@@ -340,14 +340,17 @@ function printConsolidatedSummary(results: SuiteRunResult[]) {
     // ─── SCALING ANALYSIS (Layer 4) ─────────────────────────────────
     const layer4 = results.find(r => r.layer === 4 && r.suite);
     if (layer4 && layer4.suite) {
+        const scalingResults = layer4.suite.results.filter(bench =>
+            bench.metrics.some(metric => metric.label === 'Workers'),
+        );
         print('SCALING ANALYSIS (Layer 4: Worker Pool)', colors.bright + colors.white);
         print(hr);
 
-        const n1Sps = getMetric(layer4.suite.results, 'WorkerPool.step() N=1', 'SPS (per-env)') ?? 0;
+        const n1Sps = getMetric(scalingResults, 'WorkerPool.step() N=1', 'Batch SPS') ?? 0;
 
         const scHeader =
             '  ' + pad('N', 4) + ' ' +
-            padLeft('SPS', 10) + ' ' +
+            padLeft('Batch SPS', 10) + ' ' +
             padLeft('Env-SPS', 12) + ' ' +
             padLeft('Speedup', 10) + ' ' +
             padLeft('Efficiency', 12) + ' ' +
@@ -361,11 +364,11 @@ function printConsolidatedSummary(results: SuiteRunResult[]) {
             '\u2500'.repeat(12) + ' ' +
             '\u2500'.repeat(10));
 
-        for (const bench of layer4.suite.results) {
-            const n = bench.metrics.find(m => m.label === 'Envs')?.value ?? 0;
-            const sps = bench.metrics.find(m => m.label === 'SPS (per-env)')?.value ?? 0;
+        for (const bench of scalingResults) {
+            const n = bench.metrics.find(m => m.label === 'Workers')?.value ?? 0;
+            const sps = bench.metrics.find(m => m.label === 'Batch SPS')?.value ?? 0;
             const envSps = bench.metrics.find(m => m.label === 'Env-SPS (aggregate)')?.value ?? 0;
-            const latency = bench.metrics.find(m => m.label === 'Latency')?.value ?? 0;
+            const latency = bench.metrics.find(m => m.label === 'Median latency')?.value ?? 0;
             const speedup = n1Sps > 0 ? (envSps / n1Sps) : 0;
             const efficiency = n > 0 ? (speedup / n) * 100 : 0;
 
@@ -382,12 +385,12 @@ function printConsolidatedSummary(results: SuiteRunResult[]) {
         console.log();
 
         // Scaling insights
-        const envCounts = layer4.suite.results.map(b => b.metrics.find(m => m.label === 'Envs')?.value ?? 0);
-        const envSpsValues = layer4.suite.results.map(b => b.metrics.find(m => m.label === 'Env-SPS (aggregate)')?.value ?? 0);
-        const maxIdx = envSpsValues.indexOf(Math.max(...envSpsValues));
-        print(`  Peak aggregate throughput: ${fmtNum(envSpsValues[maxIdx])} env-steps/sec at N=${envCounts[maxIdx]}`, colors.dim);
-        const n16 = getMetric(layer4.suite.results, 'WorkerPool.step() N=16', 'SPS (per-env)');
-        if (n16) print(`  Per-env SPS at N=16: ${n16.toLocaleString()} (serial Atomics.wait overhead visible)`, colors.dim);
+        const workerCounts = scalingResults.map(b => b.metrics.find(m => m.label === 'Workers')!.value);
+        const envSpsValues = scalingResults.map(b => b.metrics.find(m => m.label === 'Env-SPS (aggregate)')?.value ?? 0);
+        if (envSpsValues.length > 0) {
+            const maxIdx = envSpsValues.indexOf(Math.max(...envSpsValues));
+            print(`  Peak aggregate throughput: ${fmtNum(envSpsValues[maxIdx])} env-steps/sec at N=${workerCounts[maxIdx]}`, colors.dim);
+        }
     }
 
     console.log();
@@ -403,7 +406,7 @@ function printConsolidatedSummary(results: SuiteRunResult[]) {
     if (layer2 && layer3 && layer4_1) {
         const rawTps = getMetric(layer2.suite!.results, 'PhysicsEngine.tick() (2 players, applyInput + tick)', 'TPS');
         const envSps = getMetric(layer3.suite!.results, 'BonkEnvironment.step() (1 AI + 1 opponent)', 'SPS');
-        const poolSps = getMetric(layer4_1.suite!.results, 'WorkerPool.step() N=1', 'SPS (per-env)');
+        const poolSps = getMetric(layer4_1.suite!.results, 'WorkerPool.step() N=1', 'Batch SPS');
 
         if (rawTps && envSps && poolSps) {
             // Note: L2 simulates 2 players, L3 simulates 1 AI + 1 opponent.

--- a/benchmarks/runner.ts
+++ b/benchmarks/runner.ts
@@ -347,6 +347,10 @@ function printConsolidatedSummary(results: SuiteRunResult[]) {
         print(hr);
 
         const n1Sps = getMetric(scalingResults, 'WorkerPool.step() N=1', 'Batch SPS') ?? 0;
+        const baselineAvailable = n1Sps > 0;
+        if (!baselineAvailable) {
+            print('  N=1 baseline unavailable — speedup/efficiency columns omitted', colors.yellow);
+        }
 
         const scHeader =
             '  ' + pad('N', 4) + ' ' +
@@ -369,15 +373,17 @@ function printConsolidatedSummary(results: SuiteRunResult[]) {
             const sps = bench.metrics.find(m => m.label === 'Batch SPS')?.value ?? 0;
             const envSps = bench.metrics.find(m => m.label === 'Env-SPS (aggregate)')?.value ?? 0;
             const latency = bench.metrics.find(m => m.label === 'Median latency')?.value ?? 0;
-            const speedup = n1Sps > 0 ? (envSps / n1Sps) : 0;
-            const efficiency = n > 0 ? (speedup / n) * 100 : 0;
+            const speedup = baselineAvailable ? (envSps / n1Sps) : 0;
+            const efficiency = baselineAvailable && n > 0 ? (speedup / n) * 100 : 0;
+            const speedupText = baselineAvailable ? speedup.toFixed(2) + 'x' : 'n/a';
+            const efficiencyText = baselineAvailable ? efficiency.toFixed(1) + '%' : 'n/a';
 
             const row =
                 '  ' + pad(String(n), 4) + ' ' +
                 padLeft(sps.toLocaleString(), 10) + ' ' +
                 padLeft(envSps.toLocaleString(), 12) + ' ' +
-                padLeft(speedup.toFixed(2) + 'x', 10) + ' ' +
-                padLeft(efficiency.toFixed(1) + '%', 12) + ' ' +
+                padLeft(speedupText, 10) + ' ' +
+                padLeft(efficiencyText, 12) + ' ' +
                 padLeft(latency.toFixed(3) + 'ms', 10);
             print(row);
         }


### PR DESCRIPTION
## Summary

- replaces the misleading environment-count sweep with exact 1/2/4/8-worker measurements
- uses one environment per worker, deterministic actions/seeds, warmup, balanced sample order, and median/P25/P75 latency
- reports batch throughput, aggregate environment throughput, speedup, and efficiency using consistent metric names
- adds scaling regression gates and updates consolidated reporting/documentation
- retries transient sample failures (up to 3 attempts), closes failed pools before retrying, and retains valid samples when a single order fails; both per-count results and the N=1 baseline gate require at least half of the 8-sample design so one broken order can't discard good measurements
- intentionally leaves production synchronization unchanged because controlled A/B tests did not justify padding or per-worker flags

## Measurements

Latest rerun on this branch:

| Workers | Median batch latency | Aggregate Env-SPS |
|---:|---:|---:|
| 1 | 0.049 ms | 20,450 |
| 2 | 0.069 ms | 28,881 |
| 4 | 0.108 ms | 37,209 |
| 8 | 0.144 ms | 55,672 |

Aggregate throughput increased 2.72x at eight workers. The reported catastrophic 3-10x throughput loss was not reproduced.

## Validation

- `npx tsx benchmarks/runner.ts 4` (4/4 passed, 8/8 samples per worker count)
- delegated full suite run: 1,111 passed, 19 skipped
- focused shared-memory tests: 97 passed
- `git diff --check`
- `npm run typecheck` remains blocked by pre-existing project configuration/type errors also present on `main` (unchanged by this PR)

Refs #137
Refs #139
