### PR TITLE
fix(core): return caller-owned observations by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ const env = await init({
 
 If SharedArrayBuffer is not available (or headers not set), the system automatically falls back to standard `postMessage` communication.
 
+### Result Ownership
+
+SharedArrayBuffer transport still uses pooled internal buffers, but public
+`WorkerPool`, `BonkEnv`, and `EnvManager` reset/step results are caller-owned by
+default. Retained observations therefore remain unchanged after later steps.
+
+Allocation-sensitive code that consumes a result immediately can opt into the
+pooled path with `{ ownership: 'borrowed' }`. Borrowed results must not be
+retained or mutated and are invalidated by the next reset or step on that pool.
+This option changes only result materialization; worker transport remains on
+the same SharedArrayBuffer.
+
 ## Telemetry System
 
 The Manifold Server includes a comprehensive telemetry system for monitoring performance, debugging issues, and analyzing simulation behavior. The system is designed with a **zero-overhead default** - telemetry is disabled by default and only activates when explicitly enabled.

--- a/benchmarks/layer4-worker-pool.ts
+++ b/benchmarks/layer4-worker-pool.ts
@@ -94,16 +94,16 @@ async function createPool(numWorkers: number): Promise<WorkerPool> {
  */
 async function measureSample(pool: WorkerPool, actions: number[]): Promise<number[]> {
     const seeds = actions.map((_, index) => index + 1);
-    await pool.reset(seeds);
+    await pool.reset(seeds, { ownership: 'borrowed' });
 
     for (let i = 0; i < WARMUP_STEPS; i++) {
-        await pool.step(actions);
+        await pool.step(actions, { ownership: 'borrowed' });
     }
 
     const stepLatencies = new Array<number>(STEPS_PER_SAMPLE);
     let prev = performance.now();
     for (let i = 0; i < STEPS_PER_SAMPLE; i++) {
-        await pool.step(actions);
+        await pool.step(actions, { ownership: 'borrowed' });
         const now = performance.now();
         stepLatencies[i] = now - prev;
         prev = now;

--- a/benchmarks/layer6-stability.ts
+++ b/benchmarks/layer6-stability.ts
@@ -96,7 +96,7 @@ function benchNativeStability(): BenchmarkResult {
 async function benchPoolStability(numEnvs: number): Promise<BenchmarkResult> {
     const pool = new WorkerPool();
     await pool.init(numEnvs, {}, true);
-    await pool.reset();
+    await pool.reset(undefined, { ownership: 'borrowed' });
 
     const actions: any[] = [];
     for (let i = 0; i < numEnvs; i++) {
@@ -104,7 +104,7 @@ async function benchPoolStability(numEnvs: number): Promise<BenchmarkResult> {
     }
 
     for (let i = 0; i < Math.min(WARMUP, 500); i++) {
-        await pool.step(actions);
+        await pool.step(actions, { ownership: 'borrowed' });
     }
 
     const segments: SegmentResult[] = [];
@@ -112,7 +112,7 @@ async function benchPoolStability(numEnvs: number): Promise<BenchmarkResult> {
     let segmentStart = totalStart;
 
     for (let i = 0; i < STEPS; i++) {
-        await pool.step(actions);
+        await pool.step(actions, { ownership: 'borrowed' });
         if ((i + 1) % REPORT_INTERVAL === 0) {
             const now = performance.now();
             const segElapsed = now - segmentStart;

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -29,8 +29,8 @@ The physics engine itself is fast — **38.6 µs per tick** on a single thread. 
 ### 2.1 Component Stack
 
 ```
-┌──────────────────────────────────────────────────────────────┐
-│  Python Client (Gymnasium)  ←── ZeroMQ (zmq.Router) ──→     │
+┌──────────────────────────────────────────────────────────────┝
+│  Python Client (Gymnasium)  ↝── ZeroMQ (zmq.Router) ──→     │
 ├──────────────────────────────────────────────────────────────┤
 │  IpcBridge  (src/ipc/ipc-bridge.ts)                         │
 │    • JSON serialization over ZMQ                            │
@@ -82,15 +82,16 @@ encodeActions(actions) → Uint8Array
 writeActionsQuiet(encoded)
 sendCommand(STEP)
 Atomics.notify(workerReady)
-                                          Atomics.wait(workerReady) ← wakes
+                                          Atomics.wait(workerReady) ↝ wakes
                                           readActions(slot)
                                           BonkEnvironment.step() × numEnvs
                                           writeObservation/reward/done/tick
                                           signalWorkerConsumed()
                                           signalMainReady()
-Atomics.wait(mainReady) ← wakes
+Atomics.wait(mainReady) ↝ wakes
 readResults() → observations, rewards…
-extractObservation() per env
+extractObservation() per env (pooled internally)
+snapshot caller-owned results (default) or return borrowed pools (opt-in)
 ```
 
 ---
@@ -191,7 +192,7 @@ For maximum throughput, **N=16** offers 43,487 env-steps/sec at 0.368 ms latency
 
 ```
 Worker Step (total ~38-55 µs per env at N=1)
-├── box2d Step()              ~25-30 µs  (65-75%)  ← DOMINANT
+├── box2d Step()              ~25-30 µs  (65-75%)  ↝ DOMINANT
 ├── applyInput() × 2          ~2-4 µs    (5-10%)
 ├── getObservation() × 2      ~3-5 µs    (8-13%)
 ├── reward calculation        ~1-2 µs    (2-5%)
@@ -243,12 +244,21 @@ The main thread **serially** waits on each worker. At N=128, this means up to 12
 
 **Location**: `src/core/worker-pool.ts:481-524`
 
-The `extractObservation()` method uses a pre-allocated object pool (`_obsPool`) to avoid creating new objects per step. However:
-- When the pool misses (index out of range), it falls back to allocating a new object with nested `opponents` array
-- The `stepSharedMemory()` method at line 378-409 creates a new `convertedResults` array per step, which contains N objects
-- Each result object has `observation`, `reward`, `done`, `truncated`, `info` fields — 5 new objects per env per step
+The shared-memory extraction path keeps `_obsPool`, `_terminalObsPool`,
+`_resultPool`, and `_convertedResults` pre-allocated. Public `reset()` and
+`step()` calls snapshot those pools by default so callers can retain results
+without later steps mutating them.
 
-At N=128, this is **640 new objects per step** (128 × 5), generating GC pressure at ~600 steps/sec = ~384,000 objects/sec.
+- A normal owned step allocates one result array and five objects per env:
+  result, info, observation, opponents array, and opponent object.
+- A terminal observation adds three objects for each terminal env.
+- An owned reset allocates one result array and three objects per env.
+- `{ ownership: 'borrowed' }` returns the pooled graph directly and avoids the
+  snapshot allocations. It is valid only until the next reset or step.
+
+The SharedArrayBuffer layout, worker writes, synchronization, and pooled
+extraction are identical in both ownership modes. The allocation tradeoff is
+confined to the caller boundary.
 
 ### 5.5 Action Encoding
 
@@ -275,7 +285,8 @@ Bit-flag encoding into a single `Uint8` is extremely cheap (~50 ns per action). 
 |---------------------------------------|-------------------------------|----------|
 | SharedArrayBuffer zero-copy IPC       | 1.5-2x vs message passing     | `src/ipc/shared-memory.ts` |
 | Action buffer pool (pre-allocated)    | Eliminates per-step allocation | `src/core/worker-pool.ts:168-170` |
-| Observation object pool               | Reduces GC on hot path         | `src/core/worker-pool.ts:56-88` |
+| Internal observation/result pools     | Zero-GC extraction; borrowed-result fast path | `src/core/worker-pool.ts` |
+| Caller-owned result snapshots         | Safe replay-buffer retention by default | `src/core/worker-pool.ts` |
 | Bit-flag action encoding (Uint8)      | Minimal serialization cost     | `src/core/worker-pool.ts:462-474` |
 | Float32Array observation buffer       | Zero-allocation obs→mem write  | `src/core/worker.ts:27-55` |
 | Ring buffer for action pipelining     | Reduces contention             | `src/ipc/shared-memory.ts:111-127` |
@@ -316,11 +327,16 @@ Bit-flag encoding into a single `Uint8` is extremely cheap (~50 ns per action). 
 | Throughput (N=8)        | 38,238 env-steps/sec  | ~15,000-20,000 (est.) |
 | Latency (N=8)           | 0.209 ms              | ~0.5-0.8 ms (est.)    |
 | Memory overhead         | Pre-allocated SAB     | Per-step allocations  |
-| GC pressure             | Low (pooled objects)  | High (structured clone) |
+| GC pressure             | Moderate (owned default), low (borrowed opt-in) | High (structured clone) |
 | Implementation complexity| Moderate             | Low                   |
 | Platform requirements   | SharedArrayBuffer support | None               |
 
-**Use shared memory** for any production training workload. The throughput advantage is 1.5-2x with significantly lower GC pressure.
+**Use shared memory** for any production training workload. It avoids
+structured-clone transport in both ownership modes. Use the caller-owned
+default when retaining trajectories or replay data; use borrowed results only
+when each batch is consumed synchronously before the next call. The Layer 4
+transport benchmark uses borrowed results so its historical measurements remain
+focused on SharedArrayBuffer transport rather than caller snapshot policy.
 
 **Use message passing** only for debugging, development, or environments where `SharedArrayBuffer` is unavailable (e.g., non-isolated browser contexts).
 
@@ -336,6 +352,17 @@ Reaching closer to linear scaling would require architectural changes (e.g., bat
 ---
 
 ## 8. Performance Log
+
+### 2026-08-04 � Caller-owned observation results
+
+- SharedArrayBuffer extraction remains internally pooled, while public
+  `reset`/`step` results are snapshotted by default so retained observations do
+  not mutate on later calls.
+- `{ ownership: 'borrowed' }` preserves the prior pooled, zero-allocation return
+  path for immediate consumers. The JSON IPC bridge uses it because
+  serialization is already an ownership boundary.
+- Default owned steps allocate `1 + 5N` objects/arrays, plus three per terminal
+  observation; borrowed steps add no result-materialization allocations.
 
 ### 2026-07-29 � Contact-rule and tick-loop optimizations
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -29,8 +29,8 @@ The physics engine itself is fast — **38.6 µs per tick** on a single thread. 
 ### 2.1 Component Stack
 
 ```
-┌──────────────────────────────────────────────────────────────┝
-│  Python Client (Gymnasium)  ↝── ZeroMQ (zmq.Router) ──→     │
+┌──────────────────────────────────────────────────────────────┐
+│  Python Client (Gymnasium)  ←── ZeroMQ (zmq.Router) ──→     │
 ├──────────────────────────────────────────────────────────────┤
 │  IpcBridge  (src/ipc/ipc-bridge.ts)                         │
 │    • JSON serialization over ZMQ                            │
@@ -82,13 +82,13 @@ encodeActions(actions) → Uint8Array
 writeActionsQuiet(encoded)
 sendCommand(STEP)
 Atomics.notify(workerReady)
-                                          Atomics.wait(workerReady) ↝ wakes
+                                          Atomics.wait(workerReady) ← wakes
                                           readActions(slot)
                                           BonkEnvironment.step() × numEnvs
                                           writeObservation/reward/done/tick
                                           signalWorkerConsumed()
                                           signalMainReady()
-Atomics.wait(mainReady) ↝ wakes
+Atomics.wait(mainReady) ← wakes
 readResults() → observations, rewards…
 extractObservation() per env (pooled internally)
 snapshot caller-owned results (default) or return borrowed pools (opt-in)
@@ -192,7 +192,7 @@ For maximum throughput, **N=16** offers 43,487 env-steps/sec at 0.368 ms latency
 
 ```
 Worker Step (total ~38-55 µs per env at N=1)
-├── box2d Step()              ~25-30 µs  (65-75%)  ↝ DOMINANT
+├── box2d Step()              ~25-30 µs  (65-75%)  ← DOMINANT
 ├── applyInput() × 2          ~2-4 µs    (5-10%)
 ├── getObservation() × 2      ~3-5 µs    (8-13%)
 ├── reward calculation        ~1-2 µs    (2-5%)
@@ -353,7 +353,7 @@ Reaching closer to linear scaling would require architectural changes (e.g., bat
 
 ## 8. Performance Log
 
-### 2026-08-04 � Caller-owned observation results
+### 2026-08-04 — Caller-owned observation results
 
 - SharedArrayBuffer extraction remains internally pooled, while public
   `reset`/`step` results are snapshotted by default so retained observations do
@@ -364,7 +364,7 @@ Reaching closer to linear scaling would require architectural changes (e.g., bat
 - Default owned steps allocate `1 + 5N` objects/arrays, plus three per terminal
   observation; borrowed steps add no result-materialization allocations.
 
-### 2026-07-29 � Contact-rule and tick-loop optimizations
+### 2026-07-29 — Contact-rule and tick-loop optimizations
 
 | Change | File | Impact |
 |---|---|---|
@@ -393,7 +393,7 @@ Reaching closer to linear scaling would require architectural changes (e.g., bat
   try/catch per call in the physics step; worth measuring whether the guard can
   be applied only around the known-corrupt destroy path.
 
-### 2026-07-29 � Test-runner native-crash fix (vitest pool)
+### 2026-07-29 — Test-runner native-crash fix (vitest pool)
 
 - Root cause: `zeromq` (native addon) access-violates during vitest **thread**
   worker teardown; every full-suite run died with `0xC0000005` after tests
@@ -401,7 +401,7 @@ Reaching closer to linear scaling would require architectural changes (e.g., bat
 - Effect: full suite now completes (44 files / 1094 passed / 0 failed, ~8.7s),
   making entire-suite regression checks practical instead of targeted subsets.
 
-### 2026-07-29 � Review-driven hot-path allocations removed
+### 2026-07-29 — Review-driven hot-path allocations removed
 
 - `listener.Persist` early-exits before any extraction when the map has no
   cap-zone sensors (eliminates per-contact-point work on every standard map).

--- a/docs/typescript/src/core/worker-pool.md
+++ b/docs/typescript/src/core/worker-pool.md
@@ -116,6 +116,10 @@ affecting later steps. Borrowed results avoid snapshot allocations but expose
 pooled objects: consume them before the next `reset` or `step`, do not retain
 or mutate them, and do not overlap calls on the same pool.
 
+`ownership` only affects the shared-memory transport. In message-passing mode
+results are structured-cloned by the worker transport and are always
+caller-owned, so `borrowed` is a no-op there (accepted for a symmetric API).
+
 ---
 
 ##### `getTelemetrySnapshots`

--- a/docs/typescript/src/core/worker-pool.md
+++ b/docs/typescript/src/core/worker-pool.md
@@ -83,30 +83,38 @@ Initializes the worker pool with the specified number of environments.
 ##### `reset`
 
 ```typescript
-async reset(seeds: number[]): Promise<any[]>
+async reset(seeds?: number[], options?: ResultOwnershipOptions): Promise<any[]>
 ```
 
 Resets all environments with the given seeds.
 
 **Parameters**:
 - `seeds`: Array of random seeds for each environment
+- `options.ownership`: `owned` (default) or `borrowed`
 
-**Returns**: Array of initial observations
+**Returns**: Array of initial observations. Owned observations remain stable
+across later calls.
 
 ---
 
 ##### `step`
 
 ```typescript
-async step(actions: number[]): Promise<any[]>
+async step(actions: number[], options?: ResultOwnershipOptions): Promise<any[]>
 ```
 
 Executes one step in all environments.
 
 **Parameters**:
 - `actions`: Array of actions for each environment
+- `options.ownership`: `owned` (default) or `borrowed`
 
 **Returns**: Array of step results (observations, rewards, dones, infos)
+
+Owned results are caller snapshots and may be retained or mutated without
+affecting later steps. Borrowed results avoid snapshot allocations but expose
+pooled objects: consume them before the next `reset` or `step`, do not retain
+or mutate them, and do not overlap calls on the same pool.
 
 ---
 
@@ -163,6 +171,9 @@ const obs = await pool.reset([1, 2, 3, ..., 64]);
 // Step
 const actions = [0, 1, 2, ..., 63]; // Actions for each env
 const results = await pool.step(actions);
+
+// Allocation-sensitive consumers may opt into pooled, short-lived results.
+const borrowed = await pool.step(actions, { ownership: 'borrowed' });
 
 // Get telemetry
 const telemetry = await pool.getTelemetrySnapshots();

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -673,11 +673,16 @@ export class WorkerPool {
     }
 
     /**
-     * Manual deep-copy fallback for runtimes without `structuredClone`.
-     * Preserves shared references and cycles via the `seen` map and handles
-     * the common non-plain structured-cloneable types (Date, RegExp, Map, Set,
-     * typed arrays, DataView, ArrayBuffer) so behavior matches
-     * `structuredClone()` for snapshot inputs.
+     * Deep-copies a pooled observation/result graph so the caller owns every
+     * nested mutable field and buffer.
+     *
+     * Used rather than the global `structuredClone`: `structuredClone`
+     * preserves SharedArrayBuffer-backed views by sharing the underlying
+     * buffer, while this copy re-slices every buffer so the snapshot is fully
+     * independent. It handles plain objects and arrays plus the common
+     * structured-cloneable types (Date, RegExp, Map, Set, typed arrays,
+     * DataView, ArrayBuffer, SharedArrayBuffer) without silent degradation,
+     * and preserves shared references and cycles via the `seen` map.
      */
     private deepCopy(value: any, seen: Map<any, any> = new Map()): any {
         if (value === null || typeof value !== 'object') return value;
@@ -700,9 +705,15 @@ export class WorkerPool {
             if (value instanceof DataView) {
                 return new DataView(value.buffer.slice(0), value.byteOffset, value.byteLength);
             }
-            return value.slice(); // typed arrays
+            // .slice() copies into a fresh buffer, so SharedArrayBuffer-backed
+            // views become owned instead of sharing the pool's SAB.
+            return value.slice();
         }
         if (value instanceof ArrayBuffer) {
+            return value.slice(0);
+        }
+        const sabCtor = (globalThis as any).SharedArrayBuffer;
+        if (sabCtor && value instanceof sabCtor) {
             return value.slice(0);
         }
 
@@ -718,14 +729,11 @@ export class WorkerPool {
 
     /**
      * Materializes a caller-owned snapshot of a pooled observation/result
-     * graph. Prefers the global `structuredClone` (Node 20+) so non-plain
-     * members (Date, Map, Set, typed arrays) survive snapshotting; falls back
-     * to {@link deepCopy} on runtimes without it.
+     * graph. Delegates to {@link deepCopy}, which copies every nested buffer
+     * (including SharedArrayBuffer-backed views) instead of sharing them as
+     * `structuredClone` would.
      */
     private snapshotCopy(value: any): any {
-        if (typeof (globalThis as any).structuredClone === 'function') {
-            return (globalThis as any).structuredClone(value);
-        }
         return this.deepCopy(value);
     }
 

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -683,8 +683,14 @@ export class WorkerPool {
      * (re-sliced into owned buffers, unlike `structuredClone`, which shares
      * SABs). Other exotic structured-cloneable values (Error, URL, Blob, ...)
      * are outside the contract: the pooled observation/result graphs are plain
-     * data, and such members degrade to `{}`. Shared references and cycles are
-     * preserved via the `seen` map.
+     * data, and such members degrade to `{}`.
+     *
+     * Plain objects and arrays preserve shared references and cycles via the
+     * `seen` map. Buffer, Date, RegExp, Map, Set, typed-array, DataView,
+     * ArrayBuffer, and SAB members are copied per occurrence (each occurrence
+     * gets an independent copy). A self-referential Map/Set resolves its
+     * back-reference to the in-progress copy instead of recursing, so
+     * self-referential Map/Set graphs terminate.
      */
     private deepCopy(value: any, seen: Map<any, any> = new Map()): any {
         if (value === null || typeof value !== 'object') return value;
@@ -692,15 +698,21 @@ export class WorkerPool {
         if (value instanceof Date) return new Date(value.getTime());
         if (value instanceof RegExp) return new RegExp(value.source, value.flags);
         if (value instanceof Map) {
+            const inProgress = seen.get(value);
+            if (inProgress) return inProgress;
             const copy = new Map();
             seen.set(value, copy);
             for (const [k, v] of value) copy.set(k, this.deepCopy(v, seen));
+            seen.delete(value);
             return copy;
         }
         if (value instanceof Set) {
+            const inProgress = seen.get(value);
+            if (inProgress) return inProgress;
             const copy = new Set();
             seen.set(value, copy);
             for (const v of value) copy.add(this.deepCopy(v, seen));
+            seen.delete(value);
             return copy;
         }
         if (ArrayBuffer.isView(value)) {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -676,13 +676,15 @@ export class WorkerPool {
      * Deep-copies a pooled observation/result graph so the caller owns every
      * nested mutable field and buffer.
      *
-     * Used rather than the global `structuredClone`: `structuredClone`
-     * preserves SharedArrayBuffer-backed views by sharing the underlying
-     * buffer, while this copy re-slices every buffer so the snapshot is fully
-     * independent. It handles plain objects and arrays plus the common
-     * structured-cloneable types (Date, RegExp, Map, Set, typed arrays,
-     * DataView, ArrayBuffer, SharedArrayBuffer) without silent degradation,
-     * and preserves shared references and cycles via the `seen` map.
+     * Supported value contract: primitives; plain objects; arrays; Date,
+     * RegExp, Map, Set; typed arrays; Node Buffers (copied byte-for-byte via
+     * `Buffer.from`, because `Buffer.prototype.slice` aliases the source
+     * memory); DataView; ArrayBuffer; and SharedArrayBuffer-backed views
+     * (re-sliced into owned buffers, unlike `structuredClone`, which shares
+     * SABs). Other exotic structured-cloneable values (Error, URL, Blob, ...)
+     * are outside the contract: the pooled observation/result graphs are plain
+     * data, and such members degrade to `{}`. Shared references and cycles are
+     * preserved via the `seen` map.
      */
     private deepCopy(value: any, seen: Map<any, any> = new Map()): any {
         if (value === null || typeof value !== 'object') return value;
@@ -705,8 +707,15 @@ export class WorkerPool {
             if (value instanceof DataView) {
                 return new DataView(value.buffer.slice(0), value.byteOffset, value.byteLength);
             }
-            // .slice() copies into a fresh buffer, so SharedArrayBuffer-backed
-            // views become owned instead of sharing the pool's SAB.
+            const bufferCtor = (globalThis as any).Buffer;
+            if (bufferCtor && value instanceof bufferCtor) {
+                // Node Buffer#slice aliases the source memory, so copy the
+                // bytes into a fresh Buffer instead of slicing.
+                return bufferCtor.from(value);
+            }
+            // TypedArray#slice copies into a fresh buffer, so
+            // SharedArrayBuffer-backed views become owned rather than sharing
+            // the pool's SAB.
             return value.slice();
         }
         if (value instanceof ArrayBuffer) {

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -673,12 +673,39 @@ export class WorkerPool {
     }
 
     /**
-     * Deep-copies plain objects and arrays, preserving shared references and
-     * cycles via the `seen` map. Used to materialize caller-owned snapshots of
-     * the pooled observation/result graphs.
+     * Manual deep-copy fallback for runtimes without `structuredClone`.
+     * Preserves shared references and cycles via the `seen` map and handles
+     * the common non-plain structured-cloneable types (Date, RegExp, Map, Set,
+     * typed arrays, DataView, ArrayBuffer) so behavior matches
+     * `structuredClone()` for snapshot inputs.
      */
     private deepCopy(value: any, seen: Map<any, any> = new Map()): any {
         if (value === null || typeof value !== 'object') return value;
+
+        if (value instanceof Date) return new Date(value.getTime());
+        if (value instanceof RegExp) return new RegExp(value.source, value.flags);
+        if (value instanceof Map) {
+            const copy = new Map();
+            seen.set(value, copy);
+            for (const [k, v] of value) copy.set(k, this.deepCopy(v, seen));
+            return copy;
+        }
+        if (value instanceof Set) {
+            const copy = new Set();
+            seen.set(value, copy);
+            for (const v of value) copy.add(this.deepCopy(v, seen));
+            return copy;
+        }
+        if (ArrayBuffer.isView(value)) {
+            if (value instanceof DataView) {
+                return new DataView(value.buffer.slice(0), value.byteOffset, value.byteLength);
+            }
+            return value.slice(); // typed arrays
+        }
+        if (value instanceof ArrayBuffer) {
+            return value.slice(0);
+        }
+
         const cached = seen.get(value);
         if (cached) return cached;
         const copy: any = Array.isArray(value) ? [] : {};
@@ -690,6 +717,19 @@ export class WorkerPool {
     }
 
     /**
+     * Materializes a caller-owned snapshot of a pooled observation/result
+     * graph. Prefers the global `structuredClone` (Node 20+) so non-plain
+     * members (Date, Map, Set, typed arrays) survive snapshotting; falls back
+     * to {@link deepCopy} on runtimes without it.
+     */
+    private snapshotCopy(value: any): any {
+        if (typeof (globalThis as any).structuredClone === 'function') {
+            return (globalThis as any).structuredClone(value);
+        }
+        return this.deepCopy(value);
+    }
+
+    /**
      * Copies a pooled observation graph so the caller owns every nested
      * mutable field (the `opponents` array and its objects today, and any
      * nested objects `extractObservation` adds later). The structural guard in
@@ -697,11 +737,11 @@ export class WorkerPool {
      * a pooled template.
      */
     private snapshotObservation(observation: any): any {
-        return this.deepCopy(observation);
+        return this.snapshotCopy(observation);
     }
 
     private snapshotResult(result: any): any {
-        return this.deepCopy(result);
+        return this.snapshotCopy(result);
     }
 
     /**

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -32,6 +32,11 @@ export interface ResultOwnershipOptions {
      * `owned` returns caller-owned snapshots that remain stable across later
      * calls. `borrowed` exposes the shared-memory extraction pools and is only
      * valid until the next reset or step.
+     *
+     * Only the shared-memory transport is affected: message-passing results
+     * are structured-cloned by the worker transport and are always
+     * caller-owned, so the option is a no-op there (accepted for a symmetric
+     * API).
      */
     ownership?: 'owned' | 'borrowed';
 }
@@ -315,6 +320,9 @@ export class WorkerPool {
      * Reset all environments. Results are caller-owned by default.
      * Borrowed results must be consumed before the next reset or step and must
      * not be retained or mutated.
+     *
+     * Message-passing mode always returns caller-owned results; `ownership`
+     * only affects the shared-memory extraction path.
      */
     async reset(seeds?: number[], options: ResultOwnershipOptions = {}): Promise<any[]> {
         this.assertReady('reset');
@@ -388,6 +396,9 @@ export class WorkerPool {
                 promises.push(this.sendMessage(this.workers[i], { type: 'reset', seeds: wSeeds }));
                 seedIdx += wEnvs;
             }
+            // Message-passing results are already caller-owned structured clones,
+            // so the ownership option only affects the shared-memory extraction
+            // path above.
             const results = await this.settleMessageBatch(promises);
             return results.flat();
         } catch (error) {
@@ -411,15 +422,19 @@ export class WorkerPool {
      * Step all environments. Results are caller-owned by default.
      * Borrowed results preserve the zero-allocation extraction path but the
      * entire returned graph is invalidated by the next reset or step.
+     *
+     * Message-passing mode always returns caller-owned structured clones, so
+     * `ownership` is a no-op there (accepted for a symmetric API).
      */
     async step(actions: any[], options: ResultOwnershipOptions = {}): Promise<any[]> {
         this.assertReady('step');
         try {
-            // Use shared memory mode if enabled
+            // Shared memory mode honors `ownership`; message-passing mode always
+            // returns caller-owned structured clones.
             if (this.useSharedMemory) {
                 return await this.stepSharedMemory(actions, options);
             }
-            return await this.stepMessagePassing(actions);
+            return await this.stepMessagePassing(actions, options);
         } catch (error) {
             if (this.state === 'closed') {
                 throw error;
@@ -578,9 +593,14 @@ export class WorkerPool {
     }
 
     /**
-     * Step using message passing (fallback mode)
+     * Step using message passing (fallback mode).
+     *
+     * Results are structured-cloned by the worker transport, so they are
+     * already caller-owned in both `owned` and `borrowed` modes. `options` is
+     * accepted for API symmetry with the shared-memory path and has no effect
+     * on allocation or retention semantics here.
      */
-    private async stepMessagePassing(actions: any[]): Promise<any[]> {
+    private async stepMessagePassing(actions: any[], options: ResultOwnershipOptions): Promise<any[]> {
         const batchStart = process.hrtime.bigint();
         const returnTimes: bigint[] = [];
 
@@ -652,30 +672,36 @@ export class WorkerPool {
         return encoded;
     }
 
-    private snapshotObservation(observation: any): any {
-        if (observation == null) return observation;
+    /**
+     * Deep-copies plain objects and arrays, preserving shared references and
+     * cycles via the `seen` map. Used to materialize caller-owned snapshots of
+     * the pooled observation/result graphs.
+     */
+    private deepCopy(value: any, seen: Map<any, any> = new Map()): any {
+        if (value === null || typeof value !== 'object') return value;
+        const cached = seen.get(value);
+        if (cached) return cached;
+        const copy: any = Array.isArray(value) ? [] : {};
+        seen.set(value, copy);
+        for (const key of Object.keys(value)) {
+            copy[key] = this.deepCopy(value[key], seen);
+        }
+        return copy;
+    }
 
-        // Keep this in sync with nested mutable fields populated by
-        // extractObservation(). Scalar fields are copied by the spread.
-        return {
-            ...observation,
-            opponents: Array.isArray(observation.opponents)
-                ? observation.opponents.map((opponent: any) => ({ ...opponent }))
-                : observation.opponents,
-        };
+    /**
+     * Copies a pooled observation graph so the caller owns every nested
+     * mutable field (the `opponents` array and its objects today, and any
+     * nested objects `extractObservation` adds later). The structural guard in
+     * worker-pool-sharedmem-regression.test.ts fails if a nested field aliases
+     * a pooled template.
+     */
+    private snapshotObservation(observation: any): any {
+        return this.deepCopy(observation);
     }
 
     private snapshotResult(result: any): any {
-        const info = { ...result.info };
-        if (info.terminal_observation != null) {
-            info.terminal_observation = this.snapshotObservation(info.terminal_observation);
-        }
-
-        return {
-            ...result,
-            observation: this.snapshotObservation(result.observation),
-            info,
-        };
+        return this.deepCopy(result);
     }
 
     /**

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -27,6 +27,15 @@ interface SharedObservation {
     tick: number;
 }
 
+export interface ResultOwnershipOptions {
+    /**
+     * `owned` returns caller-owned snapshots that remain stable across later
+     * calls. `borrowed` exposes the shared-memory extraction pools and is only
+     * valid until the next reset or step.
+     */
+    ownership?: 'owned' | 'borrowed';
+}
+
 type WorkerPoolState = 'idle' | 'initializing' | 'ready' | 'failed' | 'closed';
 
 const SYNC_COMPLETED_INDEX = 0;
@@ -302,7 +311,12 @@ export class WorkerPool {
         });
     }
 
-    async reset(seeds?: number[]): Promise<any[]> {
+    /**
+     * Reset all environments. Results are caller-owned by default.
+     * Borrowed results must be consumed before the next reset or step and must
+     * not be retained or mutated.
+     */
+    async reset(seeds?: number[], options: ResultOwnershipOptions = {}): Promise<any[]> {
         this.assertReady('reset');
 
         if (this.useSharedMemory && seeds) {
@@ -356,7 +370,10 @@ export class WorkerPool {
                     const wEnvs = this.workerEnvs[i];
                     const res = this.requireSharedMemoryManager(i).readResults();
                     for (let j = 0; j < wEnvs; j++) {
-                        observations.push(this.extractObservation(res.observations, j, globalEnvIdx));
+                        const observation = this.extractObservation(res.observations, j, globalEnvIdx);
+                        observations.push(options.ownership === 'borrowed'
+                            ? observation
+                            : this.snapshotObservation(observation));
                         globalEnvIdx++;
                     }
                 }
@@ -390,12 +407,17 @@ export class WorkerPool {
         }
     }
 
-    async step(actions: any[]): Promise<any[]> {
+    /**
+     * Step all environments. Results are caller-owned by default.
+     * Borrowed results preserve the zero-allocation extraction path but the
+     * entire returned graph is invalidated by the next reset or step.
+     */
+    async step(actions: any[], options: ResultOwnershipOptions = {}): Promise<any[]> {
         this.assertReady('step');
         try {
             // Use shared memory mode if enabled
             if (this.useSharedMemory) {
-                return await this.stepSharedMemory(actions);
+                return await this.stepSharedMemory(actions, options);
             }
             return await this.stepMessagePassing(actions);
         } catch (error) {
@@ -419,7 +441,7 @@ export class WorkerPool {
      * Step using shared memory (zero-copy IPC)
      * Writes actions to shared memory, signals workers, and waits for results
      */
-    private async stepSharedMemory(actions: any[]): Promise<any[]> {
+    private async stepSharedMemory(actions: any[], options: ResultOwnershipOptions): Promise<any[]> {
         const batchStart = process.hrtime.bigint();
         this._returnTimes.fill(BigInt(0));
         const returnTimes = this._returnTimes;
@@ -544,7 +566,15 @@ export class WorkerPool {
             actionIdx += wEnvs;
         }
 
-        return this._convertedResults;
+        if (options.ownership === 'borrowed') {
+            return this._convertedResults;
+        }
+
+        const ownedResults = new Array(this._convertedResults.length);
+        for (let i = 0; i < this._convertedResults.length; i++) {
+            ownedResults[i] = this.snapshotResult(this._convertedResults[i]);
+        }
+        return ownedResults;
     }
 
     /**
@@ -620,6 +650,32 @@ export class WorkerPool {
         if (action.heavy) encoded |= 16;
         if (action.grapple) encoded |= 32;
         return encoded;
+    }
+
+    private snapshotObservation(observation: any): any {
+        if (observation == null) return observation;
+
+        // Keep this in sync with nested mutable fields populated by
+        // extractObservation(). Scalar fields are copied by the spread.
+        return {
+            ...observation,
+            opponents: Array.isArray(observation.opponents)
+                ? observation.opponents.map((opponent: any) => ({ ...opponent }))
+                : observation.opponents,
+        };
+    }
+
+    private snapshotResult(result: any): any {
+        const info = { ...result.info };
+        if (info.terminal_observation != null) {
+            info.terminal_observation = this.snapshotObservation(info.terminal_observation);
+        }
+
+        return {
+            ...result,
+            observation: this.snapshotObservation(result.observation),
+            info,
+        };
     }
 
     /**

--- a/src/env/README.md
+++ b/src/env/README.md
@@ -58,3 +58,7 @@ Callers that consume a batch synchronously and discard it before the next
 the internal shared-memory extraction pools, must not be mutated, and become
 invalid after the next call. This opt-in avoids the caller snapshot allocations
 without changing the SharedArrayBuffer transport itself.
+
+`ownership` only affects the SharedArrayBuffer path. Message-passing results are
+structured-cloned by the worker transport and are always caller-owned, so
+`borrowed` is accepted for API symmetry but has no allocation effect there.

--- a/src/env/README.md
+++ b/src/env/README.md
@@ -18,8 +18,8 @@ class BonkEnv {
 
   async start(): Promise<void>;
   async stop(): Promise<void>;
-  async reset(seeds?: number[]): Promise<any>;
-  async step(actions: any[]): Promise<StepResult | StepResult[]>;
+  async reset(seeds?: number[], options?: ResultOwnershipOptions): Promise<any>;
+  async step(actions: any[], options?: ResultOwnershipOptions): Promise<StepResult | StepResult[]>;
   isActive(): boolean;
 }
 ```
@@ -32,8 +32,8 @@ class EnvManager {
   async createPool(size: number, config?: BonkEnvConfig): Promise<BonkEnv[]>;
   async destroyEnv(id: string): Promise<void>;
   async shutdownAll(): Promise<void>;
-  async resetAll(seeds?: number[]): Promise<any[]>;
-  async stepAll(actions: any[]): Promise<any[]>;
+  async resetAll(seeds?: number[], options?: ResultOwnershipOptions): Promise<any[]>;
+  async stepAll(actions: any[], options?: ResultOwnershipOptions): Promise<any[]>;
   getEnv(id: string): BonkEnv | undefined;
   getAllEnvs(): BonkEnv[];
   getEnvCount(): number;
@@ -46,3 +46,15 @@ class EnvManager {
 - `EnvManager` provides lifecycle management for parallel environment pools
 - Port allocation range: 6000–7000 (configurable)
 - Environments run in separate processes for true parallelism
+
+## Result Ownership
+
+`reset` and `step` return caller-owned object graphs by default. Retaining an
+observation or step result across later calls is safe in both message-passing
+and SharedArrayBuffer modes.
+
+Callers that consume a batch synchronously and discard it before the next
+`reset` or `step` may pass `{ ownership: 'borrowed' }`. Borrowed results expose
+the internal shared-memory extraction pools, must not be mutated, and become
+invalid after the next call. This opt-in avoids the caller snapshot allocations
+without changing the SharedArrayBuffer transport itself.

--- a/src/env/bonk-env.ts
+++ b/src/env/bonk-env.ts
@@ -6,7 +6,7 @@
  * RL training.
  */
 
-import { WorkerPool } from '../core/worker-pool';
+import { WorkerPool, type ResultOwnershipOptions } from '../core/worker-pool';
 import { PortManager, getGlobalPortManager } from '../utils/port-manager';
 import { getConfig } from '../config/config-loader';
 
@@ -128,27 +128,29 @@ export class BonkEnv {
     /**
      * Reset the environment to initial state.
      * @param seeds Optional seeds for environment reset
+     * @param options Result ownership mode; caller-owned by default
      * @returns Initial observation(s)
      */
-    async reset(seeds?: number[]): Promise<any> {
+    async reset(seeds?: number[], options?: ResultOwnershipOptions): Promise<any> {
         if (!this.isRunning || !this.pool) {
             throw new Error(`Environment ${this.id} is not running`);
         }
         
-        return this.pool.reset(seeds);
+        return this.pool.reset(seeds, options);
     }
 
     /**
      * Take a step in the environment with the given action(s).
      * @param actions Action(s) to apply
+     * @param options Result ownership mode; caller-owned by default
      * @returns Step result(s) containing observation, reward, done, truncated, info
      */
-    async step(actions: any[]): Promise<StepResult | StepResult[]> {
+    async step(actions: any[], options?: ResultOwnershipOptions): Promise<StepResult | StepResult[]> {
         if (!this.isRunning || !this.pool) {
             throw new Error(`Environment ${this.id} is not running`);
         }
         
-        return this.pool.step(actions);
+        return this.pool.step(actions, options);
     }
 
     /**

--- a/src/env/env-manager.ts
+++ b/src/env/env-manager.ts
@@ -7,6 +7,7 @@
 
 import { BonkEnv, BonkEnvConfig } from './bonk-env';
 import { PortManager } from '../utils/port-manager';
+import type { ResultOwnershipOptions } from '../core/worker-pool';
 
 export interface EnvManagerOptions {
     /** Port manager options */
@@ -186,16 +187,17 @@ export class EnvManager {
     /**
      * Reset all environments.
      * @param seeds Optional seeds for each environment
+     * @param options Result ownership mode; caller-owned by default
      * @returns Array of initial observations
      */
-    async resetAll(seeds?: number[]): Promise<any[]> {
+    async resetAll(seeds?: number[], options?: ResultOwnershipOptions): Promise<any[]> {
         const envs = this.getAllEnvs();
         const results: any[] = [];
         
         // Reset all environments in parallel, each with its own seed
         const resetPromises = envs.map((env, idx) => {
             const envSeed = seeds?.[idx];
-            return env.reset(envSeed !== undefined ? [envSeed] : undefined);
+            return env.reset(envSeed !== undefined ? [envSeed] : undefined, options);
         });
         
         const resetResults = await Promise.all(resetPromises);
@@ -214,15 +216,16 @@ export class EnvManager {
     /**
      * Step all environments with the given actions.
      * @param actions Actions for each environment
+     * @param options Result ownership mode; caller-owned by default
      * @returns Array of step results
      */
-    async stepAll(actions: any[]): Promise<any[]> {
+    async stepAll(actions: any[], options?: ResultOwnershipOptions): Promise<any[]> {
         const envs = this.getAllEnvs();
         
         // Step all environments in parallel, each with exactly one action
         const stepPromises = envs.map((env, idx) => {
             const action = actions[idx];
-            return env.step(action !== undefined ? [action] : []);
+            return env.step(action !== undefined ? [action] : [], options);
         });
         
         return Promise.all(stepPromises);

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -51,6 +51,9 @@ export class IpcBridge {
 
     async handleRequest(identity: Buffer, rawMsg: string) {
         let response: any;
+        // Step responses are serialized eagerly so the borrowed pool graph is
+        // consumed before the telemetry branch awaits worker replies.
+        let serialized: string | null = null;
         try {
             const payload = parseJson(rawMsg);
             const command = payload.command;
@@ -93,9 +96,16 @@ export class IpcBridge {
                 } else if (!this._initialized) {
                     response = { status: "error", error: "Worker pool not initialized" };
                 } else {
-                    // Requests are serialized by the server loop, and JSON
-                    // serialization below owns the data before another step.
+                    // Requests are serialized by the server loop, and the
+                    // borrowed graph below is only valid until the next pool
+                    // call, so serialize it before the telemetry branch awaits.
                     const results = await this.pool.step(actions, { ownership: 'borrowed' });
+
+                    // JSON.stringify is the ownership boundary: it consumes the
+                    // borrowed `_convertedResults` graph immediately, before any
+                    // await in the telemetry branch below could let another
+                    // request (or a future pool reset/step there) mutate it.
+                    serialized = JSON.stringify({ status: "ok", data: results });
 
                     this.stepCount++;
                     globalProfiler.tick();
@@ -110,11 +120,6 @@ export class IpcBridge {
                             globalProfiler.report(5000);
                         }
                     }
-
-                    response = {
-                        status: "ok",
-                        data: results
-                    };
                 }
             } else if (command === "close") {
                 if (payload.shutdown === true) {
@@ -135,10 +140,11 @@ export class IpcBridge {
         } catch (e: any) {
             console.error("[IPC] Error handling request:", e);
             response = { status: "error", error: e.message };
+            serialized = null;
         }
 
         try {
-            await this._wrappedSend([identity, JSON.stringify(response)]);
+            await this._wrappedSend([identity, serialized ?? JSON.stringify(response)]);
         } catch (sendError) {
             console.error("[IPC] Error sending response:", sendError);
         }

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -73,7 +73,9 @@ export class IpcBridge {
                     response = { status: "error", error: "Worker pool not initialized" };
                 } else {
                     console.log(`[IPC] Reset request: seeds=${payload.seeds ? payload.seeds.length : 0}`);
-                    const obs = await this.pool.reset(payload.seeds);
+                    // JSON serialization below is the ownership boundary, so
+                    // avoid an otherwise redundant snapshot allocation here.
+                    const obs = await this.pool.reset(payload.seeds, { ownership: 'borrowed' });
                     console.log(`[IPC] Reset response: obs is ${Array.isArray(obs) ? 'array of length ' + obs.length : obs}`);
                     response = {
                         status: "ok",
@@ -91,7 +93,9 @@ export class IpcBridge {
                 } else if (!this._initialized) {
                     response = { status: "error", error: "Worker pool not initialized" };
                 } else {
-                    const results = await this.pool.step(actions);
+                    // Requests are serialized by the server loop, and JSON
+                    // serialization below owns the data before another step.
+                    const results = await this.pool.step(actions, { ownership: 'borrowed' });
 
                     this.stepCount++;
                     globalProfiler.tick();

--- a/tests/integration/worker-pool-sharedmem-regression.test.ts
+++ b/tests/integration/worker-pool-sharedmem-regression.test.ts
@@ -223,33 +223,25 @@ describe('WorkerPool shared-memory result ownership', () => {
     }
   });
 
-  it('deep-copies nested plain objects, arrays, and SAB-backed members (fallback path)', async () => {
+  it('pins the documented snapshot value contract (plain, arrays, Date/Map/Set, typed arrays, Buffers, SAB-backed views)', async () => {
     if (!WorkerPool.isSupported()) return;
+
+    const BufferCtor = (globalThis as any).Buffer;
+    const SABCtor = (globalThis as any).SharedArrayBuffer;
 
     const pool = new WorkerPool(1);
     try {
       await pool.init(1, {}, true);
       await pool.reset([1]);
 
-      // Force the manual deep-copy path even on runtimes where the global
-      // structuredClone exists, so the fallback branches are genuinely
-      // exercised rather than always bypassed on Node 20+.
-      const scDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'structuredClone');
-      if (scDescriptor && scDescriptor.configurable) {
-        Object.defineProperty(globalThis, 'structuredClone', {
-          value: undefined,
-          writable: true,
-          configurable: true,
-        });
-      }
-
-      const sab = new SharedArrayBuffer(8);
+      const sab = new SABCtor(8);
       const sabView = new Float64Array(sab);
       sabView[0] = 3.5;
-      const sab2 = new SharedArrayBuffer(8);
+      const sab2 = new SABCtor(8);
       const sabDataView = new DataView(sab2);
       sabDataView.setFloat32(0, 1.25);
-      const bareSab = new SharedArrayBuffer(8);
+      const bareSab = new SABCtor(8);
+      const buf = BufferCtor.from([1, 2, 3]);
 
       const fixture = {
         playerX: 1,
@@ -259,59 +251,64 @@ describe('WorkerPool shared-memory result ownership', () => {
         tags: new Set(['x']),
         lookup: new Map([['k', 1]]),
         samples: new Float64Array([1.5, 2.5]),
+        bytes: buf,
         sabView,
         sabDataView,
-        bareSab: sab,
+        bareSab,
       };
 
-      try {
-        const snapshot = (pool as any).snapshotObservation(fixture);
+      const snapshot = (pool as any).snapshotObservation(fixture);
 
-        // Nested plain objects and arrays are fully owned.
-        expect(snapshot).not.toBe(fixture);
-        expect(snapshot.nested).toEqual(fixture.nested);
-        expect(snapshot.nested).not.toBe(fixture.nested);
-        expect(snapshot.nested.depth).not.toBe(fixture.nested.depth);
-        expect(snapshot.nested.depth[2]).not.toBe(fixture.nested.depth[2]);
-        expect(snapshot.labels).toEqual(fixture.labels);
-        expect(snapshot.labels).not.toBe(fixture.labels);
+      // Plain objects and arrays are fully owned.
+      expect(snapshot).not.toBe(fixture);
+      expect(snapshot.nested).toEqual(fixture.nested);
+      expect(snapshot.nested).not.toBe(fixture.nested);
+      expect(snapshot.nested.depth).not.toBe(fixture.nested.depth);
+      expect(snapshot.nested.depth[2]).not.toBe(fixture.nested.depth[2]);
+      expect(snapshot.labels).toEqual(fixture.labels);
+      expect(snapshot.labels).not.toBe(fixture.labels);
 
-        // Non-plain members survive as their real types.
-        expect(snapshot.observedAt).toBeInstanceOf(Date);
-        expect(snapshot.observedAt.getTime()).toBe(fixture.observedAt.getTime());
-        expect(snapshot.tags).toBeInstanceOf(Set);
-        expect(snapshot.tags).toEqual(fixture.tags);
-        expect(snapshot.lookup).toBeInstanceOf(Map);
-        expect(snapshot.lookup).toEqual(fixture.lookup);
-        expect(snapshot.samples).toBeInstanceOf(Float64Array);
-        expect(snapshot.samples).toEqual(fixture.samples);
-        expect(snapshot.samples.buffer).not.toBe(fixture.samples.buffer);
+      // Documented non-plain types survive as their real types.
+      expect(snapshot.observedAt).toBeInstanceOf(Date);
+      expect(snapshot.observedAt.getTime()).toBe(fixture.observedAt.getTime());
+      expect(snapshot.tags).toBeInstanceOf(Set);
+      expect(snapshot.tags).toEqual(fixture.tags);
+      expect(snapshot.lookup).toBeInstanceOf(Map);
+      expect(snapshot.lookup).toEqual(fixture.lookup);
+      expect(snapshot.samples).toBeInstanceOf(Float64Array);
+      expect(snapshot.samples).toEqual(fixture.samples);
+      expect(snapshot.samples.buffer).not.toBe(fixture.samples.buffer);
 
-        // SharedArrayBuffer-backed views must be copied, not shared: this is
-        // exactly where structuredClone would re-alias the pool's SAB.
-        expect(snapshot.sabView).toBeInstanceOf(Float64Array);
-        expect(snapshot.sabView[0]).toBe(3.5);
-        expect(snapshot.sabView.buffer).not.toBe(sab);
-        expect(snapshot.sabDataView).toBeInstanceOf(DataView);
-        expect(snapshot.sabDataView.getFloat32(0)).toBe(1.25);
-        expect(snapshot.sabDataView.buffer).not.toBe(sab2);
-        expect(snapshot.bareSab).toBeInstanceOf((globalThis as any).SharedArrayBuffer);
-        expect(snapshot.bareSab).not.toBe(bareSab);
+      // Buffers are copied byte-for-byte (Node Buffer#slice would alias the
+      // source memory; Buffer.from copies). Node pools small Buffers into one
+      // backing ArrayBuffer, so instance/buffer identity is not a proxy for
+      // independence here — it is asserted by the mutation isolation below.
+      expect(snapshot.bytes).toBeInstanceOf(BufferCtor);
+      expect(snapshot.bytes).toEqual(buf);
+      expect(snapshot.bytes).not.toBe(buf);
 
-        // Mutating the snapshot must not leak into the source graph.
-        snapshot.playerX = 99;
-        snapshot.nested.depth[0] = 99;
-        snapshot.samples[0] = 99;
-        snapshot.sabView[0] = 99;
-        expect(fixture.playerX).toBe(1);
-        expect(fixture.nested.depth[0]).toBe(1);
-        expect(fixture.samples[0]).toBe(1.5);
-        expect(sabView[0]).toBe(3.5);
-      } finally {
-        if (scDescriptor) {
-          Object.defineProperty(globalThis, 'structuredClone', scDescriptor);
-        }
-      }
+      // SharedArrayBuffer-backed views are copied, not shared: this is
+      // exactly where structuredClone would re-alias the pool's SAB.
+      expect(snapshot.sabView).toBeInstanceOf(Float64Array);
+      expect(snapshot.sabView[0]).toBe(3.5);
+      expect(snapshot.sabView.buffer).not.toBe(sab);
+      expect(snapshot.sabDataView).toBeInstanceOf(DataView);
+      expect(snapshot.sabDataView.getFloat32(0)).toBe(1.25);
+      expect(snapshot.sabDataView.buffer).not.toBe(sab2);
+      expect(snapshot.bareSab).toBeInstanceOf(SABCtor);
+      expect(snapshot.bareSab).not.toBe(bareSab);
+
+      // Mutating the source graph must not leak into the snapshot.
+      snapshot.playerX = 99;
+      snapshot.nested.depth[0] = 99;
+      snapshot.samples[0] = 99;
+      snapshot.sabView[0] = 99;
+      buf[0] = 99;
+      expect(fixture.playerX).toBe(1);
+      expect(fixture.nested.depth[0]).toBe(1);
+      expect(fixture.samples[0]).toBe(1.5);
+      expect(sabView[0]).toBe(3.5);
+      expect(snapshot.bytes[0]).toBe(1);
     } finally {
       await pool.close();
     }

--- a/tests/integration/worker-pool-sharedmem-regression.test.ts
+++ b/tests/integration/worker-pool-sharedmem-regression.test.ts
@@ -131,4 +131,70 @@ describe('WorkerPool shared-memory result ownership', () => {
       await pool.close();
     }
   });
+
+  it('snapshots every nested field of the pooled result graph (structural guard)', async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    const collectRefs = (value: any, into: Set<any>): void => {
+      if (value === null || typeof value !== 'object') return;
+      if (into.has(value)) return;
+      into.add(value);
+      for (const key of Object.keys(value)) collectRefs(value[key], into);
+    };
+
+    // Walks the snapshot and fails if any node aliases the pooled source. This
+    // is the guard that breaks when a future nested mutable field added to
+    // extractObservation() is not deep-copied by snapshotObservation().
+    const expectGraphIndependent = (source: any, snapshot: any): void => {
+      const sourceRefs = new Set<any>();
+      collectRefs(source, sourceRefs);
+
+      const walk = (value: any): void => {
+        if (value === null || typeof value !== 'object') return;
+        expect(sourceRefs.has(value)).toBe(false);
+        for (const key of Object.keys(value)) walk(value[key]);
+      };
+
+      walk(snapshot);
+      expect(snapshot).toEqual(source);
+    };
+
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(1, {}, true);
+      await pool.reset([1]);
+      const borrowed = (await pool.step([{ right: true }], { ownership: 'borrowed' }))[0];
+      expectGraphIndependent(borrowed, (pool as any).snapshotResult(borrowed));
+
+      await pool.close();
+      await pool.init(1, { maxTicks: 1 }, true);
+      await pool.reset([1]);
+      const terminalBorrowed = (await pool.step([0], { ownership: 'borrowed' }))[0];
+      expect(terminalBorrowed.info.terminal_observation).toBeDefined();
+      expectGraphIndependent(terminalBorrowed, (pool as any).snapshotResult(terminalBorrowed));
+    } finally {
+      await pool.close();
+    }
+  });
+});
+
+describe('WorkerPool message-passing result ownership', () => {
+  it('keeps retained step results stable regardless of the ownership option', async () => {
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(1, {}, false); // message passing (structured clone)
+      await pool.reset([1]);
+
+      // `borrowed` is a no-op in message-passing mode: worker transport
+      // already structured-clones every result, so retaining is safe.
+      const retained = (await pool.step([{ right: true }], { ownership: 'borrowed' }))[0];
+      const snapshot = structuredClone(retained);
+
+      await pool.step([{ left: true }], { ownership: 'owned' });
+
+      expect(retained).toEqual(snapshot);
+    } finally {
+      await pool.close();
+    }
+  });
 });

--- a/tests/integration/worker-pool-sharedmem-regression.test.ts
+++ b/tests/integration/worker-pool-sharedmem-regression.test.ts
@@ -73,3 +73,62 @@ describe('WorkerPool extractObservation regression (unit-level)', () => {
     expect(o.playerX).toBe(5);
   });
 });
+
+describe('WorkerPool shared-memory result ownership', () => {
+  it('keeps retained step results unchanged across later steps', async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(1, {}, true);
+      const resetBatch = await pool.reset([1]);
+      const resetObservation = resetBatch[0];
+      const resetSnapshot = structuredClone(resetObservation);
+
+      const retainedBatch = await pool.step([{ right: true }]);
+      const retainedResult = retainedBatch[0];
+      const retainedInfo = retainedResult.info;
+      const retainedObservation = retainedResult.observation;
+      const retainedOpponent = retainedObservation.opponents[0];
+      const snapshot = structuredClone(retainedResult);
+
+      expect(retainedObservation).not.toBe(resetObservation);
+      expect(resetObservation).toEqual(resetSnapshot);
+
+      const nextBatch = await pool.step([{ left: true }]);
+
+      expect(nextBatch).not.toBe(retainedBatch);
+      expect(nextBatch[0]).not.toBe(retainedResult);
+      expect(nextBatch[0].info).not.toBe(retainedInfo);
+      expect(nextBatch[0].observation).not.toBe(retainedObservation);
+      expect(nextBatch[0].observation.opponents[0]).not.toBe(retainedOpponent);
+      expect(retainedResult).toEqual(snapshot);
+    } finally {
+      await pool.close();
+    }
+  });
+
+  it('keeps retained terminal observations unchanged across later steps', async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(1, { maxTicks: 1 }, true);
+      await pool.reset([1]);
+
+      const retainedResult = (await pool.step([0]))[0];
+      const retainedTerminal = retainedResult.info.terminal_observation;
+      const retainedOpponent = retainedTerminal.opponents[0];
+      const snapshot = structuredClone(retainedTerminal);
+
+      const nextResult = (await pool.step([0]))[0];
+
+      expect(retainedResult.done).toBe(true);
+      expect(nextResult.info.terminal_observation).not.toBe(retainedTerminal);
+      expect(nextResult.info.terminal_observation.opponents[0]).not.toBe(retainedOpponent);
+      expect(retainedTerminal).toEqual(snapshot);
+    } finally {
+      await pool.close();
+    }
+  });
+});

--- a/tests/integration/worker-pool-sharedmem-regression.test.ts
+++ b/tests/integration/worker-pool-sharedmem-regression.test.ts
@@ -176,6 +176,52 @@ describe('WorkerPool shared-memory result ownership', () => {
       await pool.close();
     }
   });
+
+  it('preserves non-plain members (Date/Map/Set/typed array) through the snapshot boundary', async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(1, {}, true);
+      await pool.reset([1]);
+
+      const fixture = {
+        playerX: 1,
+        opponents: [{ x: 2, alive: true }],
+        observedAt: new Date(1700000000000),
+        tags: new Set(['a', 'b']),
+        lookup: new Map([['k', 5]]),
+        samples: new Float64Array([1.5, 2.5]),
+      };
+
+      const snapshot = (pool as any).snapshotObservation(fixture);
+
+      // Plain graph members must remain fully owned, as before.
+      expect(snapshot).not.toBe(fixture);
+      expect(snapshot.opponents).not.toBe(fixture.opponents);
+      expect(snapshot.opponents[0]).not.toBe(fixture.opponents[0]);
+
+      // Non-plain members must survive snapshotting as their real types
+      // instead of degrading to {} (guards structuredClone in the snapshot
+      // boundary and the fallback deep copy).
+      expect(snapshot.observedAt).toBeInstanceOf(Date);
+      expect(snapshot.observedAt).toEqual(fixture.observedAt);
+      expect(snapshot.observedAt).not.toBe(fixture.observedAt);
+      expect(snapshot.tags).toBeInstanceOf(Set);
+      expect(snapshot.tags).toEqual(fixture.tags);
+      expect(snapshot.tags).not.toBe(fixture.tags);
+      expect(snapshot.lookup).toBeInstanceOf(Map);
+      expect(snapshot.lookup).toEqual(fixture.lookup);
+      expect(snapshot.lookup).not.toBe(fixture.lookup);
+      expect(snapshot.samples).toBeInstanceOf(Float64Array);
+      expect(snapshot.samples).toEqual(fixture.samples);
+      expect(snapshot.samples).not.toBe(fixture.samples);
+
+      expect(snapshot).toEqual(fixture);
+    } finally {
+      await pool.close();
+    }
+  });
 });
 
 describe('WorkerPool message-passing result ownership', () => {

--- a/tests/integration/worker-pool-sharedmem-regression.test.ts
+++ b/tests/integration/worker-pool-sharedmem-regression.test.ts
@@ -202,8 +202,8 @@ describe('WorkerPool shared-memory result ownership', () => {
       expect(snapshot.opponents[0]).not.toBe(fixture.opponents[0]);
 
       // Non-plain members must survive snapshotting as their real types
-      // instead of degrading to {} (guards structuredClone in the snapshot
-      // boundary and the fallback deep copy).
+      // instead of degrading to {} (guards the snapshot deep copy, which
+      // preserves Date/Map/Set/typed-array members).
       expect(snapshot.observedAt).toBeInstanceOf(Date);
       expect(snapshot.observedAt).toEqual(fixture.observedAt);
       expect(snapshot.observedAt).not.toBe(fixture.observedAt);
@@ -218,6 +218,100 @@ describe('WorkerPool shared-memory result ownership', () => {
       expect(snapshot.samples).not.toBe(fixture.samples);
 
       expect(snapshot).toEqual(fixture);
+    } finally {
+      await pool.close();
+    }
+  });
+
+  it('deep-copies nested plain objects, arrays, and SAB-backed members (fallback path)', async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(1, {}, true);
+      await pool.reset([1]);
+
+      // Force the manual deep-copy path even on runtimes where the global
+      // structuredClone exists, so the fallback branches are genuinely
+      // exercised rather than always bypassed on Node 20+.
+      const scDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'structuredClone');
+      if (scDescriptor && scDescriptor.configurable) {
+        Object.defineProperty(globalThis, 'structuredClone', {
+          value: undefined,
+          writable: true,
+          configurable: true,
+        });
+      }
+
+      const sab = new SharedArrayBuffer(8);
+      const sabView = new Float64Array(sab);
+      sabView[0] = 3.5;
+      const sab2 = new SharedArrayBuffer(8);
+      const sabDataView = new DataView(sab2);
+      sabDataView.setFloat32(0, 1.25);
+      const bareSab = new SharedArrayBuffer(8);
+
+      const fixture = {
+        playerX: 1,
+        nested: { depth: [1, 2, { inner: 'x' }] },
+        labels: ['a', 'b'],
+        observedAt: new Date(1700000000000),
+        tags: new Set(['x']),
+        lookup: new Map([['k', 1]]),
+        samples: new Float64Array([1.5, 2.5]),
+        sabView,
+        sabDataView,
+        bareSab: sab,
+      };
+
+      try {
+        const snapshot = (pool as any).snapshotObservation(fixture);
+
+        // Nested plain objects and arrays are fully owned.
+        expect(snapshot).not.toBe(fixture);
+        expect(snapshot.nested).toEqual(fixture.nested);
+        expect(snapshot.nested).not.toBe(fixture.nested);
+        expect(snapshot.nested.depth).not.toBe(fixture.nested.depth);
+        expect(snapshot.nested.depth[2]).not.toBe(fixture.nested.depth[2]);
+        expect(snapshot.labels).toEqual(fixture.labels);
+        expect(snapshot.labels).not.toBe(fixture.labels);
+
+        // Non-plain members survive as their real types.
+        expect(snapshot.observedAt).toBeInstanceOf(Date);
+        expect(snapshot.observedAt.getTime()).toBe(fixture.observedAt.getTime());
+        expect(snapshot.tags).toBeInstanceOf(Set);
+        expect(snapshot.tags).toEqual(fixture.tags);
+        expect(snapshot.lookup).toBeInstanceOf(Map);
+        expect(snapshot.lookup).toEqual(fixture.lookup);
+        expect(snapshot.samples).toBeInstanceOf(Float64Array);
+        expect(snapshot.samples).toEqual(fixture.samples);
+        expect(snapshot.samples.buffer).not.toBe(fixture.samples.buffer);
+
+        // SharedArrayBuffer-backed views must be copied, not shared: this is
+        // exactly where structuredClone would re-alias the pool's SAB.
+        expect(snapshot.sabView).toBeInstanceOf(Float64Array);
+        expect(snapshot.sabView[0]).toBe(3.5);
+        expect(snapshot.sabView.buffer).not.toBe(sab);
+        expect(snapshot.sabDataView).toBeInstanceOf(DataView);
+        expect(snapshot.sabDataView.getFloat32(0)).toBe(1.25);
+        expect(snapshot.sabDataView.buffer).not.toBe(sab2);
+        expect(snapshot.bareSab).toBeInstanceOf((globalThis as any).SharedArrayBuffer);
+        expect(snapshot.bareSab).not.toBe(bareSab);
+
+        // Mutating the snapshot must not leak into the source graph.
+        snapshot.playerX = 99;
+        snapshot.nested.depth[0] = 99;
+        snapshot.samples[0] = 99;
+        snapshot.sabView[0] = 99;
+        expect(fixture.playerX).toBe(1);
+        expect(fixture.nested.depth[0]).toBe(1);
+        expect(fixture.samples[0]).toBe(1.5);
+        expect(sabView[0]).toBe(3.5);
+      } finally {
+        if (scDescriptor) {
+          Object.defineProperty(globalThis, 'structuredClone', scDescriptor);
+        }
+      }
     } finally {
       await pool.close();
     }

--- a/tests/integration/worker-pool-sharedmem-regression.test.ts
+++ b/tests/integration/worker-pool-sharedmem-regression.test.ts
@@ -313,6 +313,32 @@ describe('WorkerPool shared-memory result ownership', () => {
       await pool.close();
     }
   });
+
+  it('terminates on a self-referential Map (recursion guard)', async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(1, {}, true);
+      await pool.reset([1]);
+
+      // A Map that references itself must not recurse unbounded through the
+      // snapshot deep copy; its back-reference resolves to the in-progress
+      // copy, so the snapshot graph is a real, owned cycle.
+      const selfRef = new Map([['k', 1]]);
+      selfRef.set('self', selfRef);
+
+      const snapshot = (pool as any).snapshotObservation({ selfRef });
+
+      expect(snapshot.selfRef).toBeInstanceOf(Map);
+      expect(snapshot.selfRef.get('self')).toBe(snapshot.selfRef);
+      expect(snapshot.selfRef.get('k')).toBe(1);
+      expect(snapshot.selfRef).not.toBe(selfRef);
+      expect(snapshot.selfRef.get('self')).not.toBe(selfRef);
+    } finally {
+      await pool.close();
+    }
+  });
 });
 
 describe('WorkerPool message-passing result ownership', () => {


### PR DESCRIPTION
��Closes #67
Closes #92
Closes #109
Closes #121

## Summary

Public `WorkerPool`/`BonkEnv`/`EnvManager` `reset` and `step` calls returned references directly into the internal shared-memory extraction pools (`_obsPool`, `_resultPool`, `_convertedResults`). Those pooled objects were overwritten in place on the next call, silently mutating any observations, results, and terminal observations that callers retained across step boundaries. This corrupted replay buffers, trajectory logs, and training data for any algorithm that stored past observations.

## Safe-default ownership contract

`reset` and `step` now return **caller-owned snapshots by default**. Retained observations, step results, terminal observations, and their nested `opponents` arrays remain stable across later calls; callers may retain or mutate them safely. This matches the follow-ups in all four issues:

- #67   no premature pool reuse mutating held values
- #92   no in-place mutation of in-use buffers during batch processing
- #109   pooled objects are no longer overwritten while held by users
- #121   `extractObservation()` references are snapshot before leaving the pool boundary

Result ownership semantics are documented in `README.md`, `src/env/README.md`, `docs/typescript/src/core/worker-pool.md`, and `docs/PERFORMANCE.md`.

## Explicit borrowed opt-in

Allocation-sensitive callers that consume a batch synchronously and discard it before the next `reset`/`step` can opt back into the zero-allocation pooled return via `{ ownership: 'borrowed' }` (in `WorkerPool.step`/`reset`, threaded through `BonkEnv` and `EnvManager`). Borrowed results expose the shared-memory extraction pool, must not be retained or mutated, and are invalidated by the next call on that pool. The JSON IPC bridge and the Layer 4/6 benchmarks use this mode because serialization/consumption is already the ownership boundary.

`ownership` only affects the shared-memory transport: message-passing results are structured-cloned by the worker transport and are always caller-owned, so `borrowed` is a no-op there.

## Allocation tradeoff

- Default owned step: one result array + five objects per env (result, info, observation, opponents array, opponent object); plus three objects per terminal observation.
- Default owned reset: one result array + three objects per env.
- Borrowed: no result-materialization allocations; returns the pooled graph.
- SharedArrayBuffer layout, worker writes, synchronization, and pooled extraction are identical in both modes; only the caller boundary differs.

## Snapshot boundary

Owned snapshots are materialized with a manual deep copy that copies every nested buffer instead of sharing it: SharedArrayBuffer-backed views are re-sliced into owned buffers (the global `structuredClone` shares SAB-backed views and is therefore not used), and Node Buffers are copied byte-for-byte via `Buffer.from` (Buffer#slice would alias the source memory). The documented value contract covers primitives, plain objects, arrays, Date, RegExp, Map, Set, typed arrays, Buffers, DataView, ArrayBuffer, and SAB-backed views; other exotic structured-cloneable values (Error, URL, Blob, ...) are outside the contract. Plain objects and arrays preserve shared references and cycles via a `seen` map, while Buffer/Date/RegExp/Map/Set/typed-array/DataView/ArrayBuffer/SAB members are copied per occurrence; a self-referential Map/Set resolves its back-reference to the in-progress copy (recursion guard) instead of overflowing the stack. The IPC bridge consumes the borrowed graph immediately via `JSON.stringify` after `step()` so the response cannot be serialized after a later pool call.

## Validation

### Focused integration

`worker-pool-sharedmem-regression.test.ts` gains end-to-end ownership tests covering retained step results, retained terminal observations, a structural snapshot-independence guard, non-plain snapshot members (Date/Map/Set/typed array), a contract-pinning test (plain objects, arrays, Date/Map/Set, typed arrays, Buffers, and SAB-backed views, including source-mutation isolation), a self-referential-Map recursion-guard test, and message-passing retention; the focused WorkerPool/BonkEnv/EnvManager/IPC subset passes:

| Suite | Files | Tests |
|---|---|---|
| worker-pool sharedmem regression + bonk-env + env-manager + env-manager coverage + ipc-bridge bypass + ipc-bridge unit + ipc-bridge constructor (ipc-bridge e2e is excluded by the vitest config) | 7 | 145 passed / 0 failed |

### Full suite

```
npm test   47 files passed (47), 1160 passed, 19 skipped, 0 failed
```

The branch was rebased onto `origin/main` after #170 (worker protocol hardening: uint32 message IDs/action-publication ordering) and #173 (worker pool resilience: fail-stop lifecycle/status-slot/wake-counter logic) merged into `worker-pool.ts`. The rebase preserves both main-side changes and the caller-owned snapshot default + borrowed opt-in + `snapshotObservation`/`snapshotResult`/`deepCopy` helpers. The worker-pool failure/protocol suites (failures + protocol + worker-shared-error + errors + shared-memory) pass 40/40, and the focused ownership/IPC subset passes 145/145 across 7 files (`ipc-bridge-e2e` remains excluded by the vitest config, pre-existing).

`git diff --check` is clean across the branch diff (`origin/main...HEAD`).

### Typecheck baseline (honest)

`npm run typecheck` is **not a passing gate** in this repository on this branch or upstream:

- Branch worktree: exits `2` with **591** pre-existing TypeScript errors, all in systemic repo-wide categories: missing `@types/node` (`process`/`Buffer`/`require`/`__dirname`, `worker_threads`/`path`/`os` module declarations), missing ES lib targets (`SharedArrayBuffer`, `Atomics` require `es2017+`; `BigInt`/`BigUint64Array` require `es2020+`), and legacy test typing patterns. The same categories appear across many unchanged files (config-loader-env, telemetry, profiler).
- The changed production files (`worker-pool.ts`, `bonk-env.ts`, `env-manager.ts`, `ipc-bridge.ts`) only surface these systemic errors; no branch-specific logic/typing errors were observed.
- The `main` worktree cannot run `tsc` at all (`node_modules` not installed), so no byte-identical upstream baseline is available locally.


