### PR TITLE
fix(physics): rebuild world on episode reset and apply force at center of mass

### DIFF
--- a/benchmarks/runner.ts
+++ b/benchmarks/runner.ts
@@ -461,8 +461,8 @@ function printConsolidatedSummary(results: SuiteRunResult[]) {
             print(`\n  ${tagColor}${tag} Reset cycle leak test (200 resets)${colors.reset}`);
             print(`    Heap growth: ${fmtNum(growth)} MB — ${growth >= 10 ? 'LEAK: PhysicsEngine objects not fully GC\'d' : 'no significant leak'}`, colors.dim);
             if (growth >= 10) {
-                print(`    Root cause: environment.ts reset() creates new PhysicsEngine + PRNG each call`, colors.gray);
-                print(`    Recommendation: reuse engine via destroyAllBodies() instead of new instance`, colors.gray);
+                print(`    Root cause: discarded Box2D worlds are not reclaimed promptly`, colors.gray);
+                print(`    Recommendation: profile retained world references; do not destroy bodies in-place`, colors.gray);
             }
         }
     }
@@ -533,8 +533,8 @@ function printConsolidatedSummary(results: SuiteRunResult[]) {
                 rootCause = 'Cross-thread Atomics.wait round-trip is inherently expensive (~40ms per ping-pong)';
                 recommendation = 'This is expected; blocking Atomics.wait is for synchronization, not throughput. Accept the cost.';
             } else if (bench.name.includes('Reset cycles')) {
-                rootCause = 'BonkEnvironment.reset() allocates new PhysicsEngine + PRNG each call instead of reusing';
-                recommendation = 'Implement destroyAllBodies() in PhysicsEngine to clear and reuse the existing world';
+                rootCause = 'Fresh-world episode resets retain more heap than the benchmark threshold';
+                recommendation = 'Profile retained b2World references without reintroducing unsafe body-by-body teardown';
             } else if (bench.name.includes('stability')) {
                 rootCause = 'High coefficient of variation even after excluding JIT warmup segment';
                 recommendation = 'GC pauses or straggler workers causing intermittent slowdowns; consider --expose-gc flag';

--- a/docs/DEOBFUSCATION_FIX_TRACKER.md
+++ b/docs/DEOBFUSCATION_FIX_TRACKER.md
@@ -795,3 +795,27 @@ source level — see `DEOBFUSCATION.md` §31 for line-numbered evidence:
   implementation work: authenticated target-map capture, server-provided
   `ms.fl` coverage, football host state, imported Box2D CCD parity, and the
   local native-map converter/physics-port backlog.
+
+### 2026-08-04 — Fresh-world episode lifecycle and force-point alignment
+
+- Replaced the episode-boundary `destroyAllBodies()` path with the existing
+  fresh-world `PhysicsEngine.reset()`. The unsafe body-by-body teardown API and
+  broadphase exception-swallowing monkey patches were removed, so corrupted
+  broadphase operations can no longer be silently treated as valid physics.
+- The lifecycle choice follows the 2026-07-29 client trace: `novakReset`,
+  contact-listener reattachment, and the full `CreateBody`/`CreateFixture` pass
+  rebuild world state from serialized bodies (client lines 6996-7237,
+  7536-7647, 8313-8325, 8571-8579; `DEOBFUSCATION.md` §31).
+- Player movement now calls `ApplyForce(force, body.GetWorldCenter())`, matching
+  decoded property indexes 163/164 and the native movement paths documented in
+  `DEOBFUSCATION.md` §5 and §35.2.
+- Newly dead discs are removed from the live Box2D world after the step while
+  their final transforms remain available to observations. This mirrors the
+  native next-state rebuild and prevents dead proxies from eventually leaving
+  the fixed broadphase AABB during direct post-death engine ticks.
+- Regression coverage proves a distinct world per episode, disabled warm
+  starting, listener/config/PPM/bounds restoration, map-body/capzone/joint and
+  grapple recreation, tick reset, lethal contact behavior across 75 repeated
+  71-body resets, and zero angular velocity from movement through an offset
+  center of mass. This closes the common reset/broadphase cause tracked by
+  #42, #49, #77, #97, #112, and #119, and the force-point mismatch in #146.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -280,8 +280,7 @@ Bit-flag encoding into a single `Uint8` is extremely cheap (~50 ns per action). 
 | Float32Array observation buffer       | Zero-allocation obs→mem write  | `src/core/worker.ts:27-55` |
 | Ring buffer for action pipelining     | Reduces contention             | `src/ipc/shared-memory.ts:111-127` |
 | Lazy telemetry hook activation        | No overhead when disabled      | `src/core/physics-engine.ts:641-670` |
-| Broadphase crash guards               | Prevents box2d corruption      | `src/core/physics-engine.ts:38-98` |
-| Engine reuse on reset (destroyAllBodies) | Eliminates 160 KB/reset     | `src/core/physics-engine.ts:607` |
+| Fresh-world episode reset             | Avoids stale broadphase state  | `src/core/environment.ts`, `src/core/physics-engine.ts` |
 | Pre-allocated PlayerState objects     | Zero alloc in getPlayerState   | `src/core/physics-engine.ts:205` |
 | Atomics.wait (vs polling)             | ~95% CPU reduction on idle     | `src/core/worker-pool.ts:343-353` |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,7 +82,7 @@ applyInput(playerId: number, input: PlayerInput): void {
   force.x = 0;
   force.y = 0;
   // ... reuse force vector
-  body.ApplyForce(force, pos);
+  body.ApplyForce(force, body.GetWorldCenter());
 }
 ```
 

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -253,11 +253,11 @@ export class BonkEnvironment {
         }
         this.scoreBlue = 0;
         this.scoreRed = 0;
-        // Reuse existing engine — destroy bodies on the same world, don't
-        // create a new PhysicsEngine (eliminates ~160 KB allocation per reset)
-        this.physics.destroyAllBodies();
+        // Discard the old Box2D world instead of destroying bodies in-place;
+        // the bundled port can retain invalid broadphase bounds after teardown.
+        this.physics.reset();
 
-        // Re-add platforms to the existing world
+        // Re-add platforms to the fresh world
         for (const body of this.config.mapData.bodies) {
             this.physics.addBody(body);
         }

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -32,73 +32,6 @@ const {
   b2FilterData,
 } = box2d;
 
-// Monkey-patch b2BroadPhase.Query to guard against undefined bounds entries.
-// The box2d JS port (Box2DFlash v2.0) can leave stale/undefined entries in
-// the bounds array during DestroyProxy, causing "Cannot read properties of
-// undefined (reading 'IsLower')" crashes during Step → Solve → SynchronizeShapes.
-(() => {
-  const b2BroadPhase = box2d.b2BroadPhase;
-
-  // Guard Query (original fix)
-  const _origQuery = b2BroadPhase.prototype.Query;
-  b2BroadPhase.prototype.Query = function (
-    lowerQueryOut: any, upperQueryOut: any,
-    lowerValue: number, upperValue: number,
-    bounds: any[], boundCount: number, axis: number,
-  ) {
-    try {
-      _origQuery.call(this, lowerQueryOut, upperQueryOut, lowerValue, upperValue, bounds, boundCount, axis);
-    } catch (e: any) {
-      if (e instanceof TypeError && (e.message.includes("IsLower") || e.message.includes("value"))) {
-        // Bounds array corrupted — skip this query to prevent cascading failures
-      } else {
-        throw e;
-      }
-    }
-  };
-
-  // Guard TestOverlap
-  const _origTestOverlap = b2BroadPhase.prototype.TestOverlap;
-  b2BroadPhase.prototype.TestOverlap = function (proxyA: number, proxyB: number) {
-    try {
-      return _origTestOverlap.call(this, proxyA, proxyB);
-    } catch (e: any) {
-      if (e instanceof TypeError && (e.message.includes("value") || e.message.includes("IsLower"))) {
-        return false;  // Treat corrupted broadphase as no overlap
-      }
-      throw e;
-    }
-  };
-
-  // Guard MoveProxy
-  const _origMoveProxy = b2BroadPhase.prototype.MoveProxy;
-  b2BroadPhase.prototype.MoveProxy = function (proxyId: number, aabb: any, displacement: any) {
-    try {
-      _origMoveProxy.call(this, proxyId, aabb, displacement);
-    } catch (e: any) {
-      if (e instanceof TypeError && (e.message.includes("value") || e.message.includes("IsLower"))) {
-        // Broadphase corrupted — skip this move to prevent cascading failures
-      } else {
-        throw e;
-      }
-    }
-  };
-
-  // Guard DestroyProxy
-  const _origDestroyProxy = b2BroadPhase.prototype.DestroyProxy;
-  b2BroadPhase.prototype.DestroyProxy = function (proxyId: number) {
-    try {
-      _origDestroyProxy.call(this, proxyId);
-    } catch (e: any) {
-      if (e instanceof TypeError && (e.message.includes("value") || e.message.includes("IsLower"))) {
-        // Broadphase corrupted — skip this destroy to prevent cascading failures
-      } else {
-        throw e;
-      }
-    }
-  };
-})();
-
 // ─── Constants ───────────────────────────────────────────────────────
 /** bonk.io runs at 30 ticks per second */
 export const TPS = 30;
@@ -219,6 +152,8 @@ export class PhysicsEngine {
   private playerBodies: Map<number, any> = new Map();
   private playerHeavyState: Map<number, boolean> = new Map();
   private playerAlive: Map<number, boolean> = new Map();
+  /** Dead discs retained for final observations after removal from the live world. */
+  private detachedPlayerBodies: Set<number> = new Set();
   private playerGrappleJoints: Map<number, any> = new Map();
   private playerTeams: Map<number, string> = new Map();
   private capZoneSensors: any[] = [];
@@ -741,6 +676,7 @@ export class PhysicsEngine {
     body.SetUserData({ playerId: id });
 
     this.playerBodies.set(id, body);
+    this.detachedPlayerBodies.delete(id);
     this.updatePlayerFilter(id);
     this.playerHeavyState.set(id, false);
     this.playerAlive.set(id, true);
@@ -754,7 +690,6 @@ export class PhysicsEngine {
     const body = this.playerBodies.get(playerId);
     if (!body || !this.playerAlive.get(playerId)) return;
 
-    const pos = body.GetPosition();
     const force = this._tempForce;
     force.x = 0;
     force.y = 0;
@@ -765,7 +700,7 @@ export class PhysicsEngine {
     if (input.down) force.y += MOVE_FORCE;
 
     if (input.heavy) force.Multiply(HEAVY_FORCE_MULTIPLIER);
-    body.ApplyForce(force, pos);
+    body.ApplyForce(force, body.GetWorldCenter());
     this.playerHeavyState.set(playerId, input.heavy);
 
     // Handle grapple toggle
@@ -883,6 +818,17 @@ export class PhysicsEngine {
         this.playerDeathType.set(id, 4);
         globalProfiler.increment('death_out_of_bounds');
       }
+    }
+
+    // The native client rebuilds only the next state's live discs. This port
+    // keeps final transforms queryable, but removes dead proxies so they cannot
+    // leave the fixed broadphase AABB during direct post-death engine ticks.
+    for (const [id, body] of this.playerBodies) {
+      if (this.playerAlive.get(id) || this.detachedPlayerBodies.has(id)) continue;
+      this.releaseGrapple(id);
+      this.pendingSwingDestroy.delete(id);
+      this.world.DestroyBody(body);
+      this.detachedPlayerBodies.add(id);
     }
 
     if (isTelemetryEnabled()) {
@@ -1014,39 +960,6 @@ export class PhysicsEngine {
   }
 
   /**
-   * Destroy all bodies on the existing world without replacing it.
-   * Reuses the same b2World and b2BroadPhase — only the bodies and
-   * their associated fixtures/shapes are removed and re-created.
-   */
-  destroyAllBodies(): void {
-    // Destroy player bodies
-    for (const [, body] of this.playerBodies) {
-      try { this.world.DestroyBody(body); } catch { /* broadphase edge case */ }
-    }
-    this.playerBodies.clear();
-    this.playerHeavyState.clear();
-    this.playerAlive.clear();
-    this.playerDeathType.clear();
-    this.playerGrappleJoints.clear();
-    this.pendingSwingDestroy.clear();
-    this.lastHitBy.clear();
-    this.lastHitTicks.clear();
-
-    // Destroy platform/map bodies
-    for (const body of this.platformBodies) {
-      try { this.world.DestroyBody(body); } catch { /* broadphase edge case */ }
-    }
-    this.platformBodies = [];
-    this.platformBodyMap.clear();
-    this.capZoneSensors = [];
-    this.capZoneState.clear();
-    this.capZoneTouches = [];
-    this.lastScoredTeam = null;
-    this.instantGoalResolved = false;
-    this.tickCount = 0;
-  }
-
-  /**
    * Reset the world — discard the old world entirely and create a fresh one.
    * This avoids box2d broadphase corruption that occurs when destroying many
    * bodies (especially polygons and dynamic bodies) individually.
@@ -1066,6 +979,7 @@ export class PhysicsEngine {
     this.playerBodies.clear();
     this.playerHeavyState.clear();
     this.playerAlive.clear();
+    this.detachedPlayerBodies.clear();
     this.playerDeathType.clear();
     this.playerGrappleJoints.clear();
     this.playerTeams.clear();

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -147,13 +147,26 @@ export interface MapDef {
 
 // ─── PhysicsEngine ───────────────────────────────────────────────────
 
+/** Frozen final transforms of a dead disc, snapshotted when its body is detached
+ * from the live world. Observations read these plain objects instead of the
+ * destroyed b2Body, which this port may leave partially readable or recycle. */
+interface DetachedPlayerSnapshot {
+  x: number;
+  y: number;
+  velX: number;
+  velY: number;
+  angle: number;
+  angularVel: number;
+}
+
 export class PhysicsEngine {
   private world: any;
   private playerBodies: Map<number, any> = new Map();
   private playerHeavyState: Map<number, boolean> = new Map();
   private playerAlive: Map<number, boolean> = new Map();
-  /** Dead discs retained for final observations after removal from the live world. */
-  private detachedPlayerBodies: Set<number> = new Set();
+  /** Frozen final transforms of dead discs, snapshotted on detach so observations
+   * never read a destroyed b2Body. Entries live until the next reset(). */
+  private detachedPlayerStates: Map<number, DetachedPlayerSnapshot> = new Map();
   private playerGrappleJoints: Map<number, any> = new Map();
   private playerTeams: Map<number, string> = new Map();
   private capZoneSensors: any[] = [];
@@ -676,7 +689,7 @@ export class PhysicsEngine {
     body.SetUserData({ playerId: id });
 
     this.playerBodies.set(id, body);
-    this.detachedPlayerBodies.delete(id);
+    this.detachedPlayerStates.delete(id);
     this.updatePlayerFilter(id);
     this.playerHeavyState.set(id, false);
     this.playerAlive.set(id, true);
@@ -770,6 +783,29 @@ export class PhysicsEngine {
   }
 
   /**
+   * Freeze a dead disc's final transforms and remove its body from the live
+   * world. Observations read the plain-object snapshot instead of the destroyed
+   * b2Body, and the destroyed proxy can no longer leave the fixed broadphase
+   * AABB during direct post-death engine ticks.
+   */
+  private detachPlayer(id: number, body: any): void {
+    this.releaseGrapple(id);
+    this.pendingSwingDestroy.delete(id);
+    const pos = body.GetPosition();
+    const vel = body.GetLinearVelocity();
+    this.detachedPlayerStates.set(id, {
+      x: pos.x * SCALE,
+      y: pos.y * SCALE,
+      velX: vel.x * SCALE,
+      velY: vel.y * SCALE,
+      angle: body.GetAngle(),
+      angularVel: body.GetAngularVelocity(),
+    });
+    this.world.DestroyBody(body);
+    this.playerBodies.delete(id);
+  }
+
+  /**
    * Advance the physics simulation by exactly one tick (1/30s).
    * This is the core synchronous step — no real-time clock involved.
    */
@@ -807,28 +843,24 @@ export class PhysicsEngine {
       this.pendingSwingDestroy.clear();
     }
 
-    // Check for players out of bounds (dead). Squared comparison avoids a
-    // per-player Math.sqrt on every tick; the threshold is identical.
+    // One pass over the player map: detect OOB deaths, then detach every dead
+    // disc in place. A dead disc's final transforms are snapshotted and its body
+    // removed from the live world (and from playerBodies), so the common
+    // no-death tick stays a single walk instead of two full passes.
     for (const [id, body] of this.playerBodies) {
-      if (!this.playerAlive.get(id)) continue;
-
-      const pos = body.GetPosition();
-      if (pos.x * pos.x + pos.y * pos.y > this.oobRadiusSquared) {
-        this.playerAlive.set(id, false);
-        this.playerDeathType.set(id, 4);
-        globalProfiler.increment('death_out_of_bounds');
+      if (this.playerAlive.get(id)) {
+        // Squared comparison avoids a per-player Math.sqrt; threshold identical.
+        const pos = body.GetPosition();
+        if (pos.x * pos.x + pos.y * pos.y > this.oobRadiusSquared) {
+          this.playerAlive.set(id, false);
+          this.playerDeathType.set(id, 4);
+          globalProfiler.increment('death_out_of_bounds');
+        }
       }
-    }
 
-    // The native client rebuilds only the next state's live discs. This port
-    // keeps final transforms queryable, but removes dead proxies so they cannot
-    // leave the fixed broadphase AABB during direct post-death engine ticks.
-    for (const [id, body] of this.playerBodies) {
-      if (this.playerAlive.get(id) || this.detachedPlayerBodies.has(id)) continue;
-      this.releaseGrapple(id);
-      this.pendingSwingDestroy.delete(id);
-      this.world.DestroyBody(body);
-      this.detachedPlayerBodies.add(id);
+      if (!this.playerAlive.get(id)) {
+        this.detachPlayer(id, body);
+      }
     }
 
     if (isTelemetryEnabled()) {
@@ -916,6 +948,21 @@ export class PhysicsEngine {
    * Get the current state of a player.
    */
   getPlayerState(playerId: number): PlayerState {
+    const detached = this.detachedPlayerStates.get(playerId);
+    if (detached) {
+      return {
+        x: detached.x,
+        y: detached.y,
+        velX: detached.velX,
+        velY: detached.velY,
+        angle: detached.angle,
+        angularVel: detached.angularVel,
+        isHeavy: this.playerHeavyState.get(playerId) || false,
+        alive: false,
+        deathType: this.playerDeathType.get(playerId) || 0,
+      };
+    }
+
     const body = this.playerBodies.get(playerId);
     if (!body) {
       return {
@@ -979,7 +1026,7 @@ export class PhysicsEngine {
     this.playerBodies.clear();
     this.playerHeavyState.clear();
     this.playerAlive.clear();
-    this.detachedPlayerBodies.clear();
+    this.detachedPlayerStates.clear();
     this.playerDeathType.clear();
     this.playerGrappleJoints.clear();
     this.playerTeams.clear();

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -843,11 +843,12 @@ export class PhysicsEngine {
       this.pendingSwingDestroy.clear();
     }
 
-    // One pass over the player map: detect OOB deaths, then detach every dead
-    // disc in place. A dead disc's final transforms are snapshotted and its body
-    // removed from the live world (and from playerBodies), so the common
-    // no-death tick stays a single walk instead of two full passes.
-    for (const [id, body] of this.playerBodies) {
+    // One pass over a snapshot of the player map: detect OOB deaths, then detach
+    // every dead disc. Iterating a copy (instead of the live map, which
+    // detachPlayer deletes from) keeps the pass robust if a future cleanup ever
+    // removes a not-yet-visited id, which a Map iterator would silently skip.
+    // The common no-death tick stays a single walk instead of two full passes.
+    for (const [id, body] of Array.from(this.playerBodies)) {
       if (this.playerAlive.get(id)) {
         // Squared comparison avoids a per-player Math.sqrt; threshold identical.
         const pos = body.GetPosition();

--- a/tests/integration/capzone-scoring.test.ts
+++ b/tests/integration/capzone-scoring.test.ts
@@ -167,29 +167,6 @@ describe('CapZoneScoring', () => {
             expect(second).toBe(null);
         });
 
-        it('destroyAllBodies clears scoring state', () => {
-            engine = new PhysicsEngine();
-
-            engine.addBody({
-                name: 'floor', type: 'rect',
-                x: 0, y: 500, width: 800, height: 30,
-                static: true,
-            });
-
-            engine.addCapZone(
-                { index: 0, owner: 'neutral', type: 2, fixture: 'zone', shapeType: 'bx' },
-                0, 190, 200, 100,
-            );
-
-            addBall(engine, 0, 50, 0, 0);
-
-            for (let i = 0; i < 100; i++) engine.tick();
-
-            engine.destroyAllBodies();
-
-            expect(engine.getTeamScored()).toBe(null);
-        });
-
         it('reset() clears scoring state', () => {
             engine = new PhysicsEngine();
 

--- a/tests/integration/environment-edge-cases.test.ts
+++ b/tests/integration/environment-edge-cases.test.ts
@@ -841,7 +841,11 @@ describe('BonkEnvironment edge cases', () => {
       env.reset();
 
       let deathObs: Observation | null = null;
-      for (let i = 0; i < 80; i++) {
+      // The AI free-falls ~473 px to the lethal platform (~38 physics ticks).
+      // With numOpponents: 0 the vacuous allOpponentsDead check makes the env
+      // tick physics only every other step, so death lands near step 76; the
+      // 200-step budget keeps the test robust to gravity/spawn tweaks.
+      for (let i = 0; i < 200; i++) {
         const result = env.step(EMPTY_INPUT);
         if (result.info.aiAlive === false) {
           deathObs = result.observation;

--- a/tests/integration/environment-edge-cases.test.ts
+++ b/tests/integration/environment-edge-cases.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { BonkEnvironment } from '../../src/core/environment';
+import { BonkEnvironment, Observation } from '../../src/core/environment';
 import { MapDef } from '../../src/core/physics-engine';
 import { safeDestroy, encodeAction, EMPTY_INPUT, GRAPPLE_INPUT, HEAVY_INPUT, RIGHT_INPUT, LEFT_INPUT, UP_INPUT, DOWN_INPUT } from '../utils/test-helpers';
 
@@ -821,6 +821,50 @@ describe('BonkEnvironment edge cases', () => {
         expect(result.info.aiAlive).toBe(false);
 
         previousWorld = world;
+      }
+    });
+  });
+
+  describe('dead-disc observation stability', () => {
+    it('freezes the dead player observation across post-death steps', async () => {
+      const mapData: MapDef = {
+        name: 'lethal-obs',
+        spawnPoints: {
+          team_blue: { x: 0, y: -300 },
+          team_red: { x: 200, y: -100 },
+        },
+        bodies: [
+          { name: 'lethal', type: 'rect', x: 0, y: 200, width: 800, height: 30, static: true, isLethal: true },
+        ],
+      };
+      env = new BonkEnvironment({ mapData, numOpponents: 0, randomOpponent: false, maxTicks: 200 });
+      env.reset();
+
+      let deathObs: Observation | null = null;
+      for (let i = 0; i < 80; i++) {
+        const result = env.step(EMPTY_INPUT);
+        if (result.info.aiAlive === false) {
+          deathObs = result.observation;
+          break;
+        }
+      }
+      expect(deathObs).not.toBeNull();
+      // The snapshot must capture real transforms, not the zero default.
+      expect(deathObs!.playerY).not.toBe(0);
+      expect(deathObs!.playerVelY).not.toBe(0);
+      // The destroyed body must leave playerBodies on detach so observations
+      // never read it.
+      expect((env as any).physics.playerBodies.has(0)).toBe(false);
+
+      for (let i = 0; i < 3; i++) {
+        const result = env.step(EMPTY_INPUT);
+        expect(result.done).toBe(true);
+        expect(result.observation.playerX).toBe(deathObs!.playerX);
+        expect(result.observation.playerY).toBe(deathObs!.playerY);
+        expect(result.observation.playerVelX).toBe(deathObs!.playerVelX);
+        expect(result.observation.playerVelY).toBe(deathObs!.playerVelY);
+        expect(result.observation.playerAngle).toBe(deathObs!.playerAngle);
+        expect(result.observation.playerAngularVel).toBe(deathObs!.playerAngularVel);
       }
     });
   });

--- a/tests/integration/environment-edge-cases.test.ts
+++ b/tests/integration/environment-edge-cases.test.ts
@@ -727,6 +727,102 @@ describe('BonkEnvironment edge cases', () => {
       const result = env.step(0);
       expect(result.observation.tick).toBe(1);
     });
+
+    it('rebuilds map lifecycle state on a fresh world every episode', () => {
+      const mapData: MapDef = makeMap({
+        bodies: [
+          { name: 'grapple-target', type: 'rect', x: 0, y: 100, width: 200, height: 20, static: true },
+          { name: 'joint-anchor', type: 'rect', x: -400, y: 0, width: 20, height: 20, static: true },
+          { name: 'joint-weight', type: 'circle', x: -350, y: 0, radius: 10, static: false },
+        ],
+        joints: [
+          { type: 'distance', bodyA: 'joint-anchor', bodyB: 'joint-weight' },
+        ],
+        capZones: [
+          { index: 0, owner: 'neutral', type: 1, fixture: 'grapple-target', shapeType: 'bx' },
+        ],
+        physics: { ppm: 18, bounds: { width: 60, height: 40 } },
+      });
+      env = new BonkEnvironment({
+        mapData,
+        numOpponents: 0,
+        randomOpponent: false,
+        teamsEnabled: true,
+        noCollide: true,
+        maxTicks: 100,
+      });
+
+      const physics = (env as any).physics;
+      let previousWorld = physics.world;
+
+      for (let episode = 0; episode < 10; episode++) {
+        const observation = env.reset(1000 + episode);
+        const world = physics.world;
+        const playerBody = physics.playerBodies.get(0);
+
+        expect(world).not.toBe(previousWorld);
+        expect(observation.tick).toBe(0);
+        expect(observation.arenaHalfWidth).toBe(30 * 30);
+        expect(observation.arenaHalfHeight).toBe(20 * 30);
+        expect(physics.getBodyMap().size).toBe(mapData.bodies.length);
+        expect(physics.capZoneSensors).toHaveLength(1);
+        expect(physics.ppm).toBe(18);
+        expect(physics.teamsEnabled).toBe(true);
+        expect(physics.noCollide).toBe(true);
+        expect(world.m_contactListener).toBeTruthy();
+        expect(world.constructor.m_warmStarting).toBe(false);
+        expect(world.GetJointCount()).toBe(1);
+        expect(playerBody.GetShapeList().GetRadius()).toBeCloseTo(18 / 30, 12);
+
+        const result = env.step(GRAPPLE_INPUT);
+        expect(result.observation.tick).toBe(1);
+        expect(physics.hasGrappleJoint(0)).toBe(true);
+        expect(world.GetJointCount()).toBe(2);
+
+        previousWorld = world;
+      }
+    });
+
+    it('preserves lethal contacts after repeated many-body resets', () => {
+      const fillerBodies = Array.from({ length: 70 }, (_, index) => ({
+        name: `filler-${index}`,
+        type: 'rect' as const,
+        x: 1000 + index * 40,
+        y: 1000,
+        width: 10,
+        height: 10,
+        static: true,
+      }));
+      const mapData: MapDef = makeMap({
+        spawnPoints: {
+          team_blue: { x: 0, y: 0 },
+          team_red: { x: 200, y: -100 },
+        },
+        bodies: [
+          { name: 'lethal', type: 'rect', x: 0, y: 0, width: 100, height: 100, static: true, isLethal: true },
+          ...fillerBodies,
+        ],
+      });
+      env = new BonkEnvironment({ mapData, numOpponents: 0, randomOpponent: false, maxTicks: 10 });
+
+      const physics = (env as any).physics;
+      let previousWorld = physics.world;
+
+      for (let episode = 0; episode < 75; episode++) {
+        const observation = env.reset(2000 + episode);
+        const world = physics.world;
+
+        expect(world).not.toBe(previousWorld);
+        expect(observation.tick).toBe(0);
+        expect(physics.getBodyMap().size).toBe(mapData.bodies.length);
+
+        const result = env.step(EMPTY_INPUT);
+        expect(result.observation.tick).toBe(1);
+        expect(result.info.aiAlive).toBe(false);
+
+        previousWorld = world;
+      }
+    });
   });
 
   describe('close', () => {

--- a/tests/integration/joints-capzones.test.ts
+++ b/tests/integration/joints-capzones.test.ts
@@ -95,23 +95,6 @@ describe('JointsCapZones', () => {
             expect(bodyMap.size).toBe(2);
         });
 
-        it('destroyAllBodies clears bodyMap', () => {
-            engine = new PhysicsEngine();
-
-            engine.addBody({
-                name: 'block',
-                type: 'rect',
-                x: 0, y: 0,
-                width: 50, height: 10,
-                static: true,
-            });
-
-            engine.destroyAllBodies();
-
-            const bodyMap = (engine as any).getBodyMap();
-            expect(bodyMap.size).toBe(0);
-        });
-
         it('reset() clears bodyMap', () => {
             engine = new PhysicsEngine();
 

--- a/tests/unit/physics-engine-errors.test.ts
+++ b/tests/unit/physics-engine-errors.test.ts
@@ -77,8 +77,7 @@ describe('PhysicsEngine error paths', () => {
     it('does not throw for dead player', () => {
       engine = new PhysicsEngine();
       engine.addPlayer(0, 0, 0);
-      // Manually simulate dead state via destroyAllBodies
-      engine.destroyAllBodies();
+      engine.reset();
       expect(() => {
         engine!.applyInput(0, EMPTY_INPUT);
       }).not.toThrow();

--- a/tests/unit/physics-engine.test.ts
+++ b/tests/unit/physics-engine.test.ts
@@ -16,7 +16,7 @@ import {
   POSITION_ITERATIONS,
   SCALE,
 } from '../../src/core/physics-engine';
-import { safeDestroy } from '../utils/test-helpers';
+import { safeDestroy, UP_INPUT } from '../utils/test-helpers';
 
 describe('PhysicsEngine', () => {
   let engine: PhysicsEngine | null = null;
@@ -95,6 +95,28 @@ describe('PhysicsEngine', () => {
       engine.tick();
       const state = engine.getPlayerState(0);
       expect(state.velX !== 0 || state.velY !== 0).toBe(true);
+    });
+
+    it('applies movement through the center of mass without torque', () => {
+      engine = new PhysicsEngine();
+      engine.addPlayer(0, 0, 0);
+
+      // @ts-ignore -- box2d has no type declarations
+      const { b2CircleDef } = require('box2d');
+      const body = (engine as any).playerBodies.get(0);
+      const offsetFixture = new b2CircleDef();
+      offsetFixture.radius = 0.4;
+      offsetFixture.localPosition.Set(1, 0);
+      offsetFixture.density = 1;
+      body.CreateShape(offsetFixture);
+      body.SetMassFromShapes();
+
+      expect(body.GetWorldCenter().x).not.toBe(body.GetPosition().x);
+
+      engine.applyInput(0, UP_INPUT);
+      engine.tick();
+
+      expect(engine.getPlayerState(0).angularVel).toBeCloseTo(0, 12);
     });
   });
 

--- a/tests/unit/physics-engine.test.ts
+++ b/tests/unit/physics-engine.test.ts
@@ -361,4 +361,51 @@ describe('PhysicsEngine', () => {
       expect(aliveIds.includes(2)).toBe(true);
     });
   });
+
+  describe('dead-disc final state observability', () => {
+    it('snapshots final transforms and velocity so they stay readable and stable across post-death ticks', () => {
+      engine = new PhysicsEngine();
+      // Player starts beyond the circular OOB boundary and dies on the first tick.
+      engine.addPlayer(0, 900, -900);
+      engine.tick();
+
+      const deathState = engine.getPlayerState(0);
+      expect(deathState.alive).toBe(false);
+      expect(deathState.deathType).toBe(4);
+      // The snapshot must capture real transforms, not the zero default.
+      expect(deathState.x).not.toBe(0);
+      expect(deathState.y).not.toBe(0);
+
+      for (let i = 0; i < 5; i++) {
+        engine.tick();
+        const state = engine.getPlayerState(0);
+        expect(state.alive).toBe(false);
+        expect(state.deathType).toBe(4);
+        expect(state.x).toBe(deathState.x);
+        expect(state.y).toBe(deathState.y);
+        expect(state.velX).toBe(deathState.velX);
+        expect(state.velY).toBe(deathState.velY);
+        expect(state.angle).toBe(deathState.angle);
+        expect(state.angularVel).toBe(deathState.angularVel);
+      }
+    });
+
+    it('releases the destroyed body from playerBodies on detach so observations never read it', () => {
+      engine = new PhysicsEngine();
+      engine.addPlayer(0, 0, 0);
+      engine.addPlayer(1, 900, 0);
+      engine.tick();
+
+      expect((engine as any).playerBodies.has(0)).toBe(true);
+      expect((engine as any).playerBodies.has(1)).toBe(false);
+      expect((engine as any).detachedPlayerStates.has(1)).toBe(true);
+
+      // A subsequent tick keeps player 0's live body intact and does not touch
+      // the already-detached dead disc again.
+      engine.tick();
+      expect((engine as any).playerBodies.has(0)).toBe(true);
+      expect((engine as any).playerBodies.has(1)).toBe(false);
+      expect(engine.getPlayerState(0).alive).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
# Fresh-world episode reset & center-of-mass force point

Fixes the Box2D broadphase corruption family and the movement-torque divergence from native Bonk.io physics, grounded in deobfuscation evidence (`docs/DEOBFUSCATION.md` §31, §5, §35.2).

## What changed

- **Fresh world per episode** — `BonkEnvironment` resets now call `PhysicsEngine.reset()` (which discards the old `b2World` and rebuilds it) instead of `destroyAllBodies()`, eliminating the stale-broadphase trigger behind the corruption crashes. Fixes #42, #49, #77, #97, #112, #119.
- **Removed exception-swallowing broadphase monkey patches** — the `b2BroadPhase.Query/TestOverlap/MoveProxy/DestroyProxy` try/catch guards are deleted so corrupted physics fails loudly instead of silently desyncing (root-cause fix for the same family).
- **Removed the unsafe `destroyAllBodies()` API** — callers now use `reset()`; the 160 KB/reset world-reuse optimization was the source of the corruption and is retired.
- **Force applied at center of mass** — player movement uses `body.GetWorldCenter()` instead of `body.GetPosition()`, matching the decoded native `ApplyForce`/`GetWorldCenter` indices (163/164). Eliminates unintended movement-induced torque on off-center discs. Fixes #146.
- **Dead-disc detachment** — newly dead discs are removed from the live world after each step while their final transforms remain observable, mirroring the native next-state rebuild and fixing a latent fixed-AABB broadphase corruption found in the 10,000-tick throughput test.
- **Snapshotted dead-disc final state (PR review follow-up)** — when a dead disc is detached its final transforms are snapshotted into a plain-object map and the destroyed body is removed from `playerBodies`, so observations never read the destroyed `b2Body`. OOB detection and detachment share a single per-tick pass over a snapshot copy of `playerBodies`, so map mutation during detach can never skip a not-yet-visited id.

## Commits

| Commit | Area |
|--------|------|
| `68de683` fix(physics): rebuild world on episode reset and apply force at center of mass | Core physics + regressions |
| `e7feb6c` fix(physics): snapshot dead-disc final state and single-pass death handling | PR #176 review follow-up |
| `0fdbd40` fix(physics): iterate death pass over player map snapshot and widen lethal-fall test budget | PR #176 re-review follow-up |

## Tests

Full suite passes (44 files, 1,115 tests passed, 19 skipped). New regression coverage:

- `tests/unit/physics-engine.test.ts` — movement through an offset center of mass produces zero angular velocity (failed before: `angularVel ≈ 0.603`).
- `tests/unit/physics-engine.test.ts` — dead-disc final transforms and velocity stay readable and stable across 5 post-death ticks, and the destroyed body leaves `playerBodies` on detach (fails under retained-entry behavior).
- `tests/integration/environment-edge-cases.test.ts` — distinct world per episode with listener/warm-start/PPM/bounds/config restoration, body/capzone/joint/grapple recreation, tick reset, and lethal contacts preserved across 75 repeated 71-body resets.
- `tests/integration/environment-edge-cases.test.ts` — dead-player observation stays frozen across 3 post-death steps through the real observation path (200-step death budget; suite re-run 5 times to confirm stability).
- `tests/perf/physics-throughput.test.ts` — 10,000-tick run no longer crashes the broadphase.
- Remaining `destroyAllBodies()` tests converted to `reset()`.

## Notes

- `npm run typecheck` fails repo-wide on `main` due to pre-existing config (tsconfig target `es2016` without the libs/`@types/node` that benchmarks and tests require); no errors are introduced by this branch — changed modules typecheck cleanly under an isolated ES2020/Node check.
- Docs updated: `docs/DEOBFUSCATION_FIX_TRACKER.md` (evidence + closure mapping), `docs/PERFORMANCE.md`, `docs/roadmap.md`, `benchmarks/runner.ts`.