### PR TITLE
fix(tooling): resolve remaining typecheck errors (72 to 0)

### DIFF
--- a/src/config/config-loader.ts
+++ b/src/config/config-loader.ts
@@ -152,6 +152,10 @@ export interface AppConfig {
     python: PythonConfig;
 }
 
+export type DeepPartial<T> = {
+    [K in keyof T]?: T[K] extends readonly unknown[] ? T[K] : T[K] extends object ? DeepPartial<T[K]> : T[K];
+};
+
 // ─── Built-in Defaults ─────────────────────────────────────────────────────
 
 const DEFAULTS: AppConfig = {
@@ -268,7 +272,7 @@ function isPlainObject(val: unknown): val is Record<string, unknown> {
     return typeof val === 'object' && val !== null && !Array.isArray(val);
 }
 
-export function deepMerge<T extends Record<string, any>>(base: T, override: Partial<T>): T {
+export function deepMerge<T extends Record<string, any>>(base: T, override: DeepPartial<T>): T {
     const result: Record<string, any> = { ...base };
     for (const key of Object.keys(override)) {
         if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -728,7 +728,7 @@ export class WorkerPool {
             // TypedArray#slice copies into a fresh buffer, so
             // SharedArrayBuffer-backed views become owned rather than sharing
             // the pool's SAB.
-            return value.slice();
+            return (value as any).slice();
         }
         if (value instanceof ArrayBuffer) {
             return value.slice(0);

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -1,7 +1,7 @@
 import * as zmq from "zeromq";
 import { WorkerPool } from "../core/worker-pool";
 import { globalProfiler, wrap, TelemetryIndices, setLatestWorkerTelemetry } from "../telemetry/profiler";
-import { getConfig, type AppConfig, deepMerge } from '../config/config-loader';
+import { getConfig, type AppConfig, type DeepPartial, deepMerge } from '../config/config-loader';
 
 // Pre-wrapped JSON.parse for telemetry on bridge deserialization.
 const parseJson = wrap(TelemetryIndices.JSON_PARSE, JSON.parse) as (text: string) => any;
@@ -15,8 +15,8 @@ export class IpcBridge {
     private _initialized: boolean = false;
     private _shouldClose: boolean = false;
 
-    constructor(config?: Partial<AppConfig>) {
-        this.port = (config as any)?.server?.port ?? getConfig().server.port;
+    constructor(config?: DeepPartial<AppConfig>) {
+        this.port = config?.server?.port ?? getConfig().server.port;
         this.sock = new zmq.Router();
         this.pool = new WorkerPool();
 

--- a/src/telemetry/telemetry-controller.ts
+++ b/src/telemetry/telemetry-controller.ts
@@ -69,7 +69,7 @@ export class TelemetryController {
    *
    * @param configTelemetry - Optional telemetry config from config.ts
    */
-  initialize(configTelemetry?: TelemetryConfig): void {
+  initialize(configTelemetry?: Partial<TelemetryConfig>): void {
     if (initializationComplete) {
       return;
     }

--- a/tests/integration/environment-edge-cases.test.ts
+++ b/tests/integration/environment-edge-cases.test.ts
@@ -895,7 +895,7 @@ describe('BonkEnvironment edge cases', () => {
       const mapData: MapDef = makeMap({
         physics: {
           ppm: 30,
-          bounds: { halfWidth: 600, halfHeight: 400 },
+          bounds: { width: 1200, height: 800 },
         },
       });
       env = new BonkEnvironment({ mapData, numOpponents: 0, maxTicks: 10 });
@@ -947,7 +947,7 @@ describe('BonkEnvironment edge cases', () => {
           { name: 'bodyB', type: 'rect', x: 100, y: 0, width: 50, height: 50, static: false },
         ],
         joints: [
-          { bodyA: 'bodyA', bodyB: 'bodyB' },
+          { type: 'distance', bodyA: 'bodyA', bodyB: 'bodyB' },
         ],
       };
       env = new BonkEnvironment({ mapData, numOpponents: 0, maxTicks: 10 });

--- a/tests/integration/grapple-mechanics.test.ts
+++ b/tests/integration/grapple-mechanics.test.ts
@@ -51,7 +51,7 @@ describe('GrappleMechanics', () => {
       }));
       engine.addPlayer(0, 0, 0);
 
-      expect(() => engine.applyInput(0, GRAPPLE_INPUT)).not.toThrow();
+      expect(() => engine!.applyInput(0, GRAPPLE_INPUT)).not.toThrow();
       expect(engine.hasGrappleJoint(0)).toBe(true);
       for (let i = 0; i < 15; i++) engine.tick();
 

--- a/tests/integration/ipc-bridge-bypass.test.ts
+++ b/tests/integration/ipc-bridge-bypass.test.ts
@@ -52,7 +52,7 @@ describe('IpcBridge bypass API', () => {
     });
 
     it('initializes with shared memory when supported', async () => {
-      if (IpcBridge.prototype.constructor.isSupported?.()) {
+      if ((IpcBridge.prototype.constructor as any).isSupported?.()) {
         await bridge.initEnv(2, {}, true);
       }
     });

--- a/tests/integration/worker-pool-sharedmem-regression.test.ts
+++ b/tests/integration/worker-pool-sharedmem-regression.test.ts
@@ -325,7 +325,7 @@ describe('WorkerPool shared-memory result ownership', () => {
       // A Map that references itself must not recurse unbounded through the
       // snapshot deep copy; its back-reference resolves to the in-progress
       // copy, so the snapshot graph is a real, owned cycle.
-      const selfRef = new Map([['k', 1]]);
+      const selfRef: Map<string, unknown> = new Map([['k', 1]]);
       selfRef.set('self', selfRef);
 
       const snapshot = (pool as any).snapshotObservation({ selfRef });

--- a/tests/unit/ipc-bridge-constructor.test.ts
+++ b/tests/unit/ipc-bridge-constructor.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
-  const sock = {
+  const sock: { bind: () => Promise<void>; close: () => void; send: () => Promise<void>; [Symbol.asyncIterator]?: any } = {
     bind: async () => {},
     close: () => {},
     send: async () => {},
@@ -125,8 +125,8 @@ describe('IpcBridge constructor', () => {
 
   it('sets up wrapped send for telemetry (line 22)', () => {
     const bridge = new IpcBridge();
-    expect(bridge._wrappedSend).toBeDefined();
-    expect(typeof bridge._wrappedSend).toBe('function');
+    expect((bridge as any)._wrappedSend).toBeDefined();
+    expect(typeof (bridge as any)._wrappedSend).toBe('function');
   });
 });
 
@@ -197,7 +197,7 @@ describe('IpcBridge close() (lines 159-173)', () => {
     await bridge.close();
     expect(bridge.isClosed()).toBe(true);
 
-    const poolCloseSpy = vi.spyOn(bridge.pool, 'close');
+    const poolCloseSpy = vi.spyOn((bridge as any).pool, 'close');
     await bridge.close();
     expect(poolCloseSpy).not.toHaveBeenCalled();
   });
@@ -223,7 +223,7 @@ describe('IpcBridge close() (lines 159-173)', () => {
 
   it('closes the worker pool (line 172)', async () => {
     const bridge = new IpcBridge({ server: { port: 12355 } });
-    const poolCloseSpy = vi.spyOn(bridge.pool, 'close');
+    const poolCloseSpy = vi.spyOn((bridge as any).pool, 'close');
     await bridge.close();
     expect(poolCloseSpy).toHaveBeenCalled();
   });
@@ -245,8 +245,8 @@ describe('IpcBridge telemetry at 5000 steps (lines 90-98)', () => {
     const pool = (bridge as any).pool;
     vi.spyOn(pool, 'step').mockResolvedValue([{ observation: [], reward: 0, done: 0, truncated: 0, tick: 0 }]);
     await simulateSteps(bridge, 100);
-    expect(bridge.stepCount).toBe(100);
-    expect(bridge.stepCount % 5000).not.toBe(0);
+    expect((bridge as any).stepCount).toBe(100);
+    expect((bridge as any).stepCount % 5000).not.toBe(0);
   });
 
   it('records memory at exactly 5000 steps (line 91)', async () => {
@@ -254,8 +254,8 @@ describe('IpcBridge telemetry at 5000 steps (lines 90-98)', () => {
     const pool = (bridge as any).pool;
     vi.spyOn(pool, 'step').mockResolvedValue([{ observation: [], reward: 0, done: 0, truncated: 0, tick: 0 }]);
     await simulateSteps(bridge, 5000);
-    expect(bridge.stepCount).toBe(5000);
-    expect(bridge.stepCount % 5000).toBe(0);
+    expect((bridge as any).stepCount).toBe(5000);
+    expect((bridge as any).stepCount % 5000).toBe(0);
   });
 
   it('checks telemetry enabled at 5000 steps (line 93)', async () => {
@@ -263,7 +263,7 @@ describe('IpcBridge telemetry at 5000 steps (lines 90-98)', () => {
     const pool = (bridge as any).pool;
     vi.spyOn(pool, 'step').mockResolvedValue([{ observation: [], reward: 0, done: 0, truncated: 0, tick: 0 }]);
     await simulateSteps(bridge, 5000);
-    expect(bridge.stepCount).toBe(5000);
+    expect((bridge as any).stepCount).toBe(5000);
   });
 
   it('fetches telemetry snapshots when enabled (lines 94-96)', async () => {
@@ -271,7 +271,7 @@ describe('IpcBridge telemetry at 5000 steps (lines 90-98)', () => {
     const pool = (bridge as any).pool;
     vi.spyOn(pool, 'step').mockResolvedValue([{ observation: [], reward: 0, done: 0, truncated: 0, tick: 0 }]);
     await simulateSteps(bridge, 5000);
-    expect(bridge.stepCount).toBe(5000);
+    expect((bridge as any).stepCount).toBe(5000);
   });
 
   it('reports at 5000 steps when telemetry enabled (line 97)', async () => {
@@ -279,7 +279,7 @@ describe('IpcBridge telemetry at 5000 steps (lines 90-98)', () => {
     const pool = (bridge as any).pool;
     vi.spyOn(pool, 'step').mockResolvedValue([{ observation: [], reward: 0, done: 0, truncated: 0, tick: 0 }]);
     await simulateSteps(bridge, 5000);
-    expect(bridge.stepCount).toBe(5000);
+    expect((bridge as any).stepCount).toBe(5000);
   });
 
   it('does NOT run telemetry branch when disabled', async () => {
@@ -288,7 +288,7 @@ describe('IpcBridge telemetry at 5000 steps (lines 90-98)', () => {
     const pool = (bridge as any).pool;
     vi.spyOn(pool, 'step').mockResolvedValue([{ observation: [], reward: 0, done: 0, truncated: 0, tick: 0 }]);
     await simulateSteps(bridge, 5000);
-    expect(bridge.stepCount).toBe(5000);
+    expect((bridge as any).stepCount).toBe(5000);
   });
 
   it('records memory again at 10000 steps', async () => {
@@ -296,7 +296,7 @@ describe('IpcBridge telemetry at 5000 steps (lines 90-98)', () => {
     const pool = (bridge as any).pool;
     vi.spyOn(pool, 'step').mockResolvedValue([{ observation: [], reward: 0, done: 0, truncated: 0, tick: 0 }]);
     await simulateSteps(bridge, 10000);
-    expect(bridge.stepCount).toBe(10000);
-    expect(bridge.stepCount % 5000).toBe(0);
+    expect((bridge as any).stepCount).toBe(10000);
+    expect((bridge as any).stepCount % 5000).toBe(0);
   });
 });

--- a/tests/unit/profiler-flags-coverage.test.ts
+++ b/tests/unit/profiler-flags-coverage.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { globalProfiler, TelemetryBuffer, TelemetryIndices, Profiler, setLatestWorkerTelemetry, startCollection, stopCollection } from '../../src/telemetry/profiler';
-import { parseFlags, applyEnvOverrides, mergeConfigWithFlags, isAnyTelemetryEnabled } from '../../src/telemetry/flags';
+import { parseFlags, applyEnvOverrides, mergeConfigWithFlags, isAnyTelemetryEnabled, type TelemetryFlags } from '../../src/telemetry/flags';
 
 describe('Profiler uncovered paths', () => {
   beforeEach(() => {
@@ -524,7 +524,7 @@ describe('Flags uncovered paths', () => {
   });
 
   describe('mergeConfigWithFlags', () => {
-    const defaultCliFlags = { enableTelemetry: false, profileLevel: 'standard', debugLevel: 'none', outputFormat: 'console', dashboardPort: 3001, reportInterval: 5000, retentionDays: 7 };
+    const defaultCliFlags: TelemetryFlags = { enableTelemetry: false, profileLevel: 'standard', debugLevel: 'none', outputFormat: 'console', dashboardPort: 3001, reportInterval: 5000, retentionDays: 7 };
 
     it('applies config when CLI has defaults', () => {
       const result = mergeConfigWithFlags({ enabled: true, outputFormat: 'file', retentionDays: 30 }, defaultCliFlags);
@@ -534,7 +534,7 @@ describe('Flags uncovered paths', () => {
     });
 
     it('CLI flags take precedence over config', () => {
-      const cliFlags = { ...defaultCliFlags, enableTelemetry: true, outputFormat: 'file' };
+      const cliFlags: TelemetryFlags = { ...defaultCliFlags, enableTelemetry: true, outputFormat: 'file' };
       const result = mergeConfigWithFlags({ enabled: false, outputFormat: 'console' }, cliFlags);
       expect(result.enableTelemetry).toBe(true);
       expect(result.outputFormat).toBe('file');

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -12,7 +12,7 @@ import {
   getTelemetryController,
 } from '../../src/telemetry/telemetry-controller';
 import { globalProfiler, wrap, TelemetryIndices, TelemetryBuffer } from '../../src/telemetry/profiler';
-import { parseFlags, applyEnvOverrides, mergeConfigWithFlags, isAnyTelemetryEnabled, getExplicitFlagKeys } from '../../src/telemetry/flags';
+import { parseFlags, applyEnvOverrides, mergeConfigWithFlags, isAnyTelemetryEnabled, getExplicitFlagKeys, type TelemetryFlags } from '../../src/telemetry/flags';
 import { resetConfig } from '../../src/config/config-loader';
 
 describe('TelemetryController', () => {
@@ -230,7 +230,7 @@ describe('TelemetryFlags parsing', () => {
 
   describe('mergeConfigWithFlags', () => {
     it('applies config when CLI uses defaults', () => {
-      const cliFlags = { enableTelemetry: false, profileLevel: 'standard', debugLevel: 'none', outputFormat: 'console', dashboardPort: 3001, reportInterval: 5000, retentionDays: 7 };
+      const cliFlags: TelemetryFlags = { enableTelemetry: false, profileLevel: 'standard', debugLevel: 'none', outputFormat: 'console', dashboardPort: 3001, reportInterval: 5000, retentionDays: 7 };
       const config = { enabled: true, outputFormat: 'file' as const };
 
       const merged = mergeConfigWithFlags(config, cliFlags);
@@ -239,7 +239,7 @@ describe('TelemetryFlags parsing', () => {
     });
 
     it('CLI flags take precedence over config', () => {
-      const cliFlags = { enableTelemetry: true, profileLevel: 'detailed', debugLevel: 'none', outputFormat: 'console', dashboardPort: 3001, reportInterval: 5000, retentionDays: 7 };
+      const cliFlags: TelemetryFlags = { enableTelemetry: true, profileLevel: 'detailed', debugLevel: 'none', outputFormat: 'console', dashboardPort: 3001, reportInterval: 5000, retentionDays: 7 };
       const config = { enabled: false };
 
       const merged = mergeConfigWithFlags(config, cliFlags);

--- a/tests/utils/test-helpers.ts
+++ b/tests/utils/test-helpers.ts
@@ -29,7 +29,7 @@ export function makeWall(
     width: 10,
     height: 400,
     static: true,
-    collides,
+    collides: collides as MapBodyDef['collides'],
   };
   engine.addBody(def);
   return def;
@@ -63,8 +63,8 @@ export function addBall(
   y: number,
   _vx = 0,
   _vy = 0,
-): number {
-  return engine.addPlayer(x, y, 0);
+): void {
+  engine.addPlayer(0, x, y);
 }
 
 export function safeDestroy(engine: PhysicsEngine | null): void {


### PR DESCRIPTION
## What

Second half of the typecheck fix: resolves the 72 genuine type errors left after the config PR (which alone took typecheck from 637 → 72).

**Type-only widening where the runtime already accepted the looser shape** (no runtime behavior change):
- `config-loader.ts`: new `DeepPartial<T>` type; `deepMerge` override is a deep partial — matches its recursive runtime merge semantics (the security test "deep partial config merges correctly" was written against this contract but the type said `Partial<T>`)
- `IpcBridge` constructor: `Partial<AppConfig>` → `DeepPartial<AppConfig>` — it only reads `config?.server?.port` and falls back to `getConfig()`; 17 test sites and the security test pass deep partials like `{ server: { port } }`
- `TelemetryController.initialize`: `TelemetryConfig` → `Partial<TelemetryConfig>` — `mergeConfigWithFlags` already treats the arg as partial

**Test fixes (behavior-neutral or intent-restoring):**
- `ipc-bridge-constructor.test.ts`: sock mock typed to allow `[Symbol.asyncIterator]`; private members accessed via `as any` (already the file's pattern)
- `profiler-flags-coverage.test.ts` / `telemetry.test.ts`: TelemetryFlags literals annotated so `profileLevel`/`outputFormat` keep their literal unions
- `worker-pool-sharedmem-regression.test.ts`: self-referencing `Map` needs `Map<string, unknown>` (recursive value type)
- `grapple-mechanics.test.ts`: `engine!` inside a closure (`let`, TS cannot narrow into closures)
- `ipc-bridge-bypass.test.ts`: cast before optional `isSupported?.()` (IpcBridge has no such static — branch stays a no-op, as before)
- `environment-edge-cases.test.ts`: bounds keys `halfWidth/halfHeight` → `width/height` (the engine reads `width/height`; old keys were silently ignored so the test exercised nothing); joint gained required `type: 'distance'` (previously no joint was created — the test only asserted "does not crash")
- `test-helpers.ts`: `makeWall` collides cast; `addBall` return type `void`

**Genuine bugs found and fixed (flagged here per repo policy):**
- `test-helpers.ts addBall`: called `engine.addPlayer(x, y, 0)` but the signature is `addPlayer(id, x, y)` — a ball requested at `(x, y)` was created with id `x` at position `(y, 0)`. Fixed to `addPlayer(0, x, y)`. The helper currently has no callers, so no existing test output changed.
- `src/core/worker-pool.ts` `deepCopy`: `value.slice()` on `ArrayBufferView` — runtime-safe (DataView and Buffer handled above; remaining views are TypedArrays) but not expressible in the type; cast added.

## Before / After typecheck

| | errors |
|---|---|
| main | 637 |
| config PR only | 72 |
| **both PRs** | **0** |

## Tests

`npm test`: 47 files, **1160 passed | 19 skipped** — full suite green. `git diff --check` clean.
