### PR TITLE
fix(python): start server via node + tsx CLI instead of npx

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -19,16 +19,18 @@ def bonk_server():
     if not os.path.isfile(server_script):
         pytest.skip("src/main.ts not found")
 
-    if shutil.which("npx") is None:
-        pytest.skip("npx not found")
+    if shutil.which("node") is None:
+        pytest.skip("node not found")
 
-    # npx is a .cmd wrapper on Windows; invoke through the shell so
-    # CreateProcess can resolve it (plain Popen([...]) raises WinError 2).
-    npx_cmd = shutil.which("npx")
+    # Invoke tsx's Node CLI directly instead of going through npx, which is a
+    # .cmd shim on Windows and fails when npx is missing or broken.
+    tsx_cli = os.path.join(project_root, "node_modules", "tsx", "dist", "cli.mjs")
+    if not os.path.isfile(tsx_cli):
+        pytest.skip("tsx CLI not found (run npm install)")
+
     proc = subprocess.Popen(
-        f'"{npx_cmd}" tsx src/main.ts',
+        [shutil.which("node"), tsx_cli, "src/main.ts"],
         cwd=project_root,
-        shell=True,
         # DEVNULL, not PIPE: the server logs verbosely per init/reset and an
         # undrained pipe buffer deadlocks the server after a few test cycles.
         stdout=subprocess.DEVNULL,


### PR DESCRIPTION
## What

Hardens the pytest server fixture in `python/tests/conftest.py` against broken/missing `npx`.

The fixture previously spawned the server with `npx tsx src/main.ts` through `shell=True`:
- `npx` is a `.cmd` shim on Windows; when npx is missing or broken, the whole python test suite silently skips
- shell-string quoting is fragile compared to a direct argv list

Now it resolves `node` (a real executable) and invokes `node_modules/tsx/dist/cli.mjs` directly with an argv list (no shell), with clear skip messages when `node` or the tsx CLI is unavailable.

## Verification

- Manually started server with `node node_modules/tsx/dist/cli.mjs src/main.ts` on port 5555 → `python -m pytest python/tests/test_bonk_vec_env.py -q`: **27 passed**
- Stopped manual server, ran pytest again so the fixture itself spawns the server via the new path: **27 passed**
