### PR TITLE
docs(deobfuscation): close formula-order residual, add index-47 census

### DIFF
--- a/docs/DEOBFUSCATION.md
+++ b/docs/DEOBFUSCATION.md
@@ -4083,17 +4083,22 @@ dispatcher-table-index-fold > pass3b-formula-fold > pass1 > banners:
    `final-dispatcher-folds.json` records every source range, selector, call,
    resolved table index, value, and rejected strict-pattern site; the
    independent AMD-body audit re-derives the entire set and verifies it.
-6. **Dispatcher-formula fold (pass3b):** 48 of the 207 non-literal pass3
-   candidates are replaced only at the `Q5$/w_c` call with a parenthesized
+6. **Dispatcher-formula fold (pass3b):** all 207 of the non-literal pass3
+   candidates are replaced only at the `Q5$/w_c` call with a static case
    formula from the 253-case `B3jF8[239984]` dispatcher map (SHA-256
    `6bd5eabc9911df5b9339334ff9034f97fdbc979b30a834761a3bb9f6c9c53a87`).
    The selector statement and LHS remain intact. The factory setter, four
    wrappers, and sole `k7V` alias are binding-proven; the selector must be the
    immediately preceding bare statement; every argument must be used exactly
-   once in original left-to-right order. The remaining 159 sites are retained
-   because their case formulas reorder arguments. `final-formula-folds.json`
-   records every accepted and rejected site; `audit-formula-fold.js` and the
-   paired readable-AST audit independently re-derive the result.
+   once. 48 formulas read their arguments in the call's exact left-to-right
+   order and are emitted inline; the other 159 reorder their arguments and use
+   the order-preserving IIFE lowering — every call argument is bound to a
+   fresh parameter in call order and the formula is applied to the parameters,
+   reproducing the dispatcher's own evaluate-arguments-first behavior with
+   identical exception and coercion order. `final-formula-folds.json` records
+   every accepted site (with `orderPreserved` provenance);
+   `audit-formula-fold.js` and the paired readable-AST audit independently
+   re-derive all 207.
 7. **AST annotation + analysis labels (pass1):** Babel identifies all 89,199
    literal numeric member accesses in the AMD body. Of these, 46,518 are
    covered by table folds, 31,373 emit conservative dotted analysis labels,
@@ -4129,12 +4134,13 @@ sites, 30,506 ordinary annotation sites, and 554 index-47 annotation sites.
 
 ### 36.3 Artifacts
 
-- `alpha2s.readable.js` — 4,473,431 bytes, 40,233 lines, the analysis target.
+- `alpha2s.readable.js` — 4,480,444 bytes, 40,233 lines, the analysis target.
 - `final-pipeline.js`, `ast-member-scan.js`, `table-lookup-fold.js`,
   `op-dispatch-fold.js`, `audit-independent.js`, `audit-preamble.js`,
   `audit-formula-fold.js`, `audit-training-statics.js`,
   `audit-map-option-writers.js`, `audit-out-of-table.js`,
-  `audit-dynamic-training-residuals.js`, `audit-table-lookup.js`,
+  `audit-dynamic-training-residuals.js`, `audit-index47-census.js`,
+  `audit-table-lookup.js`,
   `final-stats.json`, `final-preamble-folds.json`, `final-folds.json`, and
   `final-dispatcher-folds.json`, `final-formula-folds.json` are the current
   producer, proof, and audit artifacts.
@@ -4150,8 +4156,8 @@ sites, 30,506 ordinary annotation sites, and 554 index-47 annotation sites.
   remain; the bundle is data-flow readable, not control-flow readable.
 - **1,639 dispatcher/selector occurrences remain** (`w_c` 438, `Q5$` 379,
   `H0n` 405, `d1M` 417). Beyond pass3's all-literal folds, pass3b proves and
-  emits 48 non-literal formulas; 159 candidates remain because they would
-  change left-to-right argument evaluation order.
+  emits all 207 non-literal formulas: 48 inline (identity argument order) and
+  159 through the order-preserving IIFE lowering (reordered argument use).
 - **10 out-of-table indices** are left unchanged rather than being assigned an
   incorrect property name.
 - **86 strict dispatcher-resolved table indexes** are folded to strings. Two
@@ -4164,6 +4170,9 @@ sites, 30,506 ordinary annotation sites, and 554 index-47 annotation sites.
   property-bag admission rule plus a single binding, no dynamic index, no
   out-of-table slot, and no alias escape. Index `47` can only remain bracketed
   with a `length` annotation or fold to the string literal `"length"`.
+  `audit-index47-census.js` re-derives the 247 surviving index-47 sites and
+  classifies all of them with Node-executed probes: none is a safe dotted
+  `.length` substitution (see §38.1).
 - **Readability verdict:** all 89,189 in-table literal numeric accesses are
    represented by a dotted analysis label, an annotation, or a decoded table
    string. Local names and flattened control flow remain obfuscated; the
@@ -4216,7 +4225,7 @@ linear in the output size as substitutions grow.
 | Decoded property table | 1,724 names |
 | Literal string/primitive decoder inlines | 7,670 total: 1,731 source-order preamble captures + 5,939 body pass4 replacements |
 | Literal operation folds | 1,696 |
-| Strict dispatcher-formula folds | 48 / 207 candidates; 159 argument-order rejections |
+| Strict dispatcher-formula folds | 207 / 207 candidates: 48 inline (identity argument order) + 159 order-preserving IIFE lowering; 0 argument-order rejections |
 | AST body literal-index accesses | **89,199** |
 | Immutable table-string folds | **23,852** (1,186 direct, 22,666 carrier) |
 | Source sites covered by table folds | **46,518** |
@@ -4258,7 +4267,7 @@ node .deobf/test-anchors.js
 ```
 
 Two consecutive final-pipeline runs produced the same readable SHA-256:
-`6AB86E2960E3DB3083089238AEF6CF749636093B64E92FD14F25DAC6455DA65E`.
+`5F2D3882ABFB6A3BFA1FBBED3693E546B7D7E4B0ECA98255CE3592D8C91522E6`.
 
 ### 37.2 Transport and deterministic state exchange
 
@@ -4390,11 +4399,13 @@ factory body, plus the preamble's literal decoder materialization:
   `final-dispatcher-folds` v1 sidecar records every folded source range,
    selector, call, value, and rejected strict-pattern site.
 - Pass3b independently accounts for all 207 non-literal dispatcher sequences:
-  48 are emitted as static formulas and 159 are retained because their case
-  expressions would reorder call arguments. The factory setter, wrapper
-  bindings, selector adjacency, case map, argument recovery, sidecar bijection,
-  and the paired readable AST expression are all verified; no index-47 access
-  is dotted inside a formula.
+  48 are emitted inline as static formulas and 159 use the order-preserving
+  IIFE lowering that binds every call argument to a fresh parameter in
+  left-to-right call order before applying the case formula to the parameters.
+  The factory setter, wrapper bindings, selector adjacency, case map, argument
+  recovery, `orderPreserved` provenance, sidecar bijection, and the paired
+  readable AST expression are all verified; no index-47 access is dotted inside
+  a formula.
 - The 341-site legacy division-versus-regex scanner blind spot is closed by
   AST discovery. Before whole-expression folding it contained 279
   dotted-label and 62 annotation decisions; 56 lie inside table folds, leaving
@@ -4402,7 +4413,17 @@ factory body, plus the preamble's literal decoder materialization:
 - Table index 47 (`length`) is structurally protected. It produces no emitted
   `.length` label: 247 surviving sites remain bracketed and annotated, while
   554 immutable table reads plus one dispatcher-resolved table read become the
-  string literal `"length"`.
+  string literal `"length"`. `audit-index47-census.js` mechanically re-derives
+  the 247 sites (AST candidates minus `final-folds.json` folded ranges) and
+  classifies every one with source evidence and Node-executed probes:
+  245 are packed-slot storage on `[arguments]` array bags (slot 47 written as
+  a scalar, counter, or object — dotted `.length` would read the bag's element
+  count, proven by the `X.length != X[47]` probe), and 2 are nested-receiver
+  sites (L3081 `N7I[98][47] =` is a real-array element write into the
+  `capZones` label table; L6257 `O7a[7][47]` is the table-string read
+  `"length"` retained because the strict carrier fold rule requires every slot
+  assignment to dominate the read and the in-loop write does not dominate).
+  Zero sites are safe dotted substitutions.
 
 This does **not** mean the original source is fully deobfuscated. Dotted output
 is an analysis label for a resolved table index, not evidence that the original
@@ -4411,7 +4432,7 @@ data-flow readable, not a recovery of original symbols or control flow.
 
 ### 38.2 Retained artifact contract
 
-The local `.deobf/` directory deliberately retains only the following 28
+The local `.deobf/` directory deliberately retains only the following 29
 artifacts. Legacy intermediate bundles, per-pass scripts, and stale run logs
 were removed on 2026-08-02.
 
@@ -4421,7 +4442,7 @@ were removed on 2026-08-02.
 | Derived inputs | `tables.json`, `callsites.json`, `anchors.json` | The decoded table, conservative receiver verdicts, and 43 banner anchors. Regenerate only from the retained canonical source. |
 | Producers | `dump-tables.js`, `analyze-callsites.js`, `final-pipeline.js`, `op-dispatch-fold.js` | Respectively create the table, receiver analysis, canonical readable output plus sidecars, and validate/extract the dispatcher formula map. |
 | AST and fold proof | `ast-member-scan.js`, `table-lookup-fold.js`, `final-stats.json`, `final-preamble-folds.json`, `final-folds.json`, `final-dispatcher-folds.json`, `final-formula-folds.json`, `audit-training-statics.js`, `audit-map-option-writers.js`, `audit-out-of-table.js`, `audit-dynamic-training-residuals.js` | AST member discovery, immutable-table proof, current run metrics, source-order preamble capture provenance, literal AMD-body fold provenance, dispatcher-index provenance, formula provenance, direct static facts, complete table-origin option-writer censuses, and intentionally retained residual inventories. |
-| Independent gates | `audit-independent.js`, `audit-preamble.js`, `audit-formula-fold.js`, `audit-table-lookup.js`, `audit-table-lookup.log`, `test-anchors.js` | Independent pass-one, preamble-capture, formula, and AMD-body fold checks plus the atomically refreshed successful fold-audit log. |
+| Independent gates | `audit-independent.js`, `audit-preamble.js`, `audit-formula-fold.js`, `audit-table-lookup.js`, `audit-table-lookup.log`, `audit-index47-census.js`, `test-anchors.js` | Independent pass-one, preamble-capture, formula, AMD-body fold, index-47 census, and anchor checks plus the atomically refreshed successful fold-audit log. |
 | Historical evidence | `audit-report.txt` | Preserved 2026-07-30 audit snapshot only; its counts and index convention are not current. |
 
 The raw-to-readable flow is:
@@ -4432,8 +4453,8 @@ pretty -> tables.json + callsites.json + anchors.json
 pretty -> final-pipeline.js -> readable.js + final-stats.json + final-preamble-folds.json + final-folds.json + final-dispatcher-folds.json + final-formula-folds.json
 ```
 
-`final-stats.json` reports JavaScript string length (4,473,002 characters) for
-the generated readable output; the physical UTF-8 file is 4,473,431 bytes.
+`final-stats.json` reports JavaScript string length (4,480,015 characters) for
+the generated readable output; the physical UTF-8 file is 4,480,444 bytes.
 This documentation consistently uses the latter file size.
 
 ### 38.3 Reproducible pipeline and audit closure
@@ -4449,7 +4470,7 @@ insertion. It has no dropped overlaps in the current build.
 | Preamble literal decoder captures | 1,731: 1,724 table strings + 7 stateful warm-up primitives; two fresh captures agree |
 | Body decoder/primitive inlines | 5,939; 791 intentional stateful/setup skips |
 | Literal operation folds | 1,696; 207 non-literal argument skips handed to pass3b |
-| Strict pass3b formula substitutions | 48 / 207; 159 `formula_reorders_arguments` rejections; 79 argument substitutions + 19 annotations across 47 sites; 0 index-47 recoveries |
+| Strict pass3b formula substitutions | 207 / 207; 0 rejections; 48 inline + 159 order-preserving IIFE lowering; 368 argument substitutions + 111 annotations across 191 sites; 0 index-47 recoveries |
 | Pass3 folded-LHS recovery | 1,560 dotted labels and 135 annotations |
 | AST body candidates | 89,199 |
 | Table-fold-covered source sites | 46,518 |
@@ -4461,13 +4482,13 @@ insertion. It has no dropped overlaps in the current build.
 | Dynamic-bracket training relevance | All 4 retained dynamic brackets are renderer/display paths; no classic physics, map-codec, or converter path |
 | Banners | 43, all anchor checks pass |
 | Independent table-fold verification | 23,852 / 23,852 literal folds and 86 / 86 dispatcher-index folds approved; 0 extra, unproven, or wrong-value folds |
-| Independent formula-fold verification | 48 / 48 folds and 159 / 159 retained candidates re-derived; paired readable AST formulas match exactly |
+| Independent formula-fold verification | 207 / 207 folds re-derived; paired readable AST formulas match exactly (48 inline, 159 ordered) |
 | Training-static verification | Foot defaults, swing defaults, `ms.fl` force reader, linear shrink formulas, exact `mapVersion=15`, and no `swingF`/`swingD` map override re-derived from source anchors, dispatcher cases, and final-fold provenance |
 | Independent pass-one closure | 0 gaps, 0 pairing mismatches, 0 unlabelled in-table brackets |
 
 `node --check .deobf/alpha2s.readable.js` passes. Two fresh full pipeline runs
 produced the identical readable SHA-256:
-`6AB86E2960E3DB3083089238AEF6CF749636093B64E92FD14F25DAC6455DA65E`.
+`5F2D3882ABFB6A3BFA1FBBED3693E546B7D7E4B0ECA98255CE3592D8C91522E6`.
 
 Run the complete current verification set with:
 
@@ -4482,6 +4503,7 @@ node .deobf/audit-training-statics.js --self-check
 node .deobf/audit-map-option-writers.js --self-check
 node .deobf/audit-out-of-table.js --self-check
 node .deobf/audit-dynamic-training-residuals.js --self-check
+node .deobf/audit-index47-census.js --self-check
 node .deobf/audit-table-lookup.js --verify
 node .deobf/test-anchors.js
 ```
@@ -4520,9 +4542,9 @@ unchanged rather than being given speculative names.
 
 **Decoders and control flow.** The current audit counts 1,639 residual
 dispatcher/selector occurrences: `w_c` 438, `Q5$` 379, `H0n` 405, and `d1M`
-417. Pass3 hands its 207 non-literal operation sequences to pass3b; 48 satisfy
-the strict factory/binding/adjacency/order proof and 159 remain unchanged. The
-flattened `switch` dispatchers are not reversed. The current readable artifact still contains 112.4
+417. Pass3 hands its 207 non-literal operation sequences to pass3b; all 207
+satisfy the strict factory/binding/adjacency proof and are emitted as static
+formulas (48 inline, 159 via the order-preserving IIFE lowering). The flattened `switch` dispatchers are not reversed. The current readable artifact still contains 112.4
 obfuscated identifier tokens per 100 lines, so original local, parameter, and
 function names have not been recovered.
 

--- a/docs/DEOBFUSCATION_FIX_TRACKER.md
+++ b/docs/DEOBFUSCATION_FIX_TRACKER.md
@@ -819,3 +819,32 @@ source level — see `DEOBFUSCATION.md` §31 for line-numbered evidence:
   71-body resets, and zero angular velocity from movement through an offset
   center of mass. This closes the common reset/broadphase cause tracked by
   #42, #49, #77, #97, #112, and #119, and the force-point mismatch in #146.
+
+### 2026-08-04 — Formula-order closure and index-47 census (deobfuscation residuals)
+
+- **`formula_reorders_arguments` residual closed (159 → 0).** All 207
+  non-literal pass3b dispatcher sequences are now folded: 48 keep the inline
+  form (identity argument order) and 159 use the new order-preserving IIFE
+  lowering — each call argument binds to a fresh parameter in left-to-right
+  call order and the case formula applies to the parameters, reproducing the
+  dispatcher's evaluate-arguments-first behavior with identical exception and
+  coercion order (`.deobf/op-dispatch-fold.js` `substituteCaseOrdered`,
+  mirrored independently in `audit-formula-fold.js`; every reordered case
+  selector was behavior-checked against the booted dispatcher with 0
+  mismatches). Formula argument recoveries grew to 368 substitutions + 111
+  annotations across 191 sites; 0 index-47 recoveries.
+- **Index-47 census made mechanical.** New `.deobf/audit-index47-census.js`
+  re-derives the 247 surviving bracketed index-47 sites from the AST minus
+  `final-folds.json` fold ranges and classifies all of them: 245 packed-slot
+  storage on `[arguments]` array bags (slot-47 writes, loop counters) and 2
+  nested-receiver special sites (L3081 `N7I[98][47]` real-array element write
+  into the `capZones` label table; L6257 `O7a[7][47]` table-string read
+  retained because the strict carrier fold rule requires every slot assignment
+  to dominate the read). Node-executed probes prove 0 of 247 sites are safe
+  dotted `.length` substitutions (`X.length != X[47]` for the bag and
+  real-array patterns; two fresh preamble boots confirm `M$QCc[47] ===
+  "length"`).
+- Regenerated readable artifact: 4,480,444 bytes; SHA-256
+  `5F2D3882ABFB6A3BFA1FBBED3693E546B7D7E4B0ECA98255CE3592D8C91522E6`
+  (two identical runs). Full verification set passes including the new
+  `audit-index47-census.js --self-check`.

--- a/docs/DEOBFUSCATION_ROADMAP.md
+++ b/docs/DEOBFUSCATION_ROADMAP.md
@@ -39,10 +39,10 @@ baseline while extending the pipeline.
 | Out-of-table literals retained | 10 | `final-stats.json` |
 | Immutable table folds | 23,852 | `final-folds.json`, `audit-table-lookup.js` |
 | Dispatcher-index table folds | 86 of 88 candidates | `final-dispatcher-folds.json` |
-| Dispatcher-formula folds | 48 of 207 candidates | `final-formula-folds.json`, `audit-formula-fold.js` |
+| Dispatcher-formula folds | 207 of 207 candidates (48 inline + 159 order-preserving IIFE lowering) | `final-formula-folds.json`, `audit-formula-fold.js` |
 | Literal operation folds | 1,696 | `final-stats.json` |
 | Body decoder/primitive inlines | 5,939; 791 deliberate stateful/setup skips | `final-stats.json` |
-| Current readable output SHA-256 | `6AB86E2960E3DB3083089238AEF6CF749636093B64E92FD14F25DAC6455DA65E` | two matching pipeline runs |
+| Current readable output SHA-256 | `5F2D3882ABFB6A3BFA1FBBED3693E546B7D7E4B0ECA98255CE3592D8C91522E6` | two matching pipeline runs |
 
 All 89,189 in-table literal body accesses have a verified readable
 representation. The 10 remaining accesses have an index outside the decoded
@@ -68,8 +68,8 @@ table and therefore do not have an invented name.
 rewrite rule. This stage has no generated-code substitutions.
 
 | ID | Work item | Current scope | Required output | Exit gate |
-|---|---|---:|---|---|
-| S0.1 | Formula census | 159 retained `formula_reorders_arguments` cases | Argument-shape, evaluation-risk, wrapper, and selector inventory | Every retained formula sidecar record is classified exactly once |
+|---|---:|---|---|---|
+| S0.1 | Formula census | 0 retained `formula_reorders_arguments` cases (2026-08-04: all 207 non-literal sequences folded; 48 inline, 159 via the order-preserving IIFE lowering) | Argument-shape, evaluation-risk, wrapper, and selector inventory | Every retained formula sidecar record is classified exactly once |
 | S0.2 | Dynamic table census | 1,069 producer candidates; 1,067 narrower independent count documented in `DEOBFUSCATION.md` section 38.4; 88 direct-alias candidates have 86 accepted and 2 retained | Index-expression and carrier-write provenance inventory, including the reason for the two-count universe difference and the direct-alias overlap | Producer and independent census each close under their documented universe, and every direct candidate has a same-universe mapping or an explicit exclusion |
 | S0.3 | Receiver census | 11,053 unknown-receiver annotations | Per-function binding, slot, write, escape, enumeration, and dynamic-access dispositions | Every annotation remains attributable to a source property-table index |
 | S0.4 | Stateful decoder census | 380 `t8H` and 411 `n6e` intentional skips | Initialization phase, literal/dynamic argument, and state-dependence classification | No skip is silently reclassified as constant |
@@ -87,12 +87,14 @@ without violating JavaScript evaluation semantics.
 
 | Item | Current state | Safe direction | Proof required | Do not do |
 |---|---|---|---|---|
-| 159 reordered formulas | Every nonliteral rejected case would reorder call arguments if emitted directly | First add exact, generated comments that identify the proven case formula. Consider substitution only with an order-preserving representation. | Factory map, wrapper bindings, selector source, argument evaluation order, side effects, exceptions, exact paired readable AST, and sidecar closure | Directly replace `Q5$` or `w_c` calls with formulas whose operand order differs from the call |
+| 159 reordered formulas | RESOLVED 2026-08-04: every reordered case is folded with the order-preserving IIFE lowering — each call argument binds to a fresh parameter in left-to-right call order and the formula applies to the parameters, reproducing the dispatcher's evaluate-arguments-first behavior | Keep the existing inline form for identity-order cases; keep the IIFE lowering only for reordered cases | Factory map, wrapper bindings, selector source, argument evaluation order, side effects, exceptions, exact paired readable AST, and sidecar closure (`orderPreserved` provenance) | Directly replace `Q5$` or `w_c` calls with formulas whose operand order differs from the call (no bare operand-order change) |
 | 1,639 residual dispatcher/selector calls | 438 `w_c`, 379 `Q5$`, 405 `H0n`, 417 `d1M` | Classify and annotate only where selector and case provenance are proven | Per-call wrapper and selector proof; comments must not change code AST nodes | Assume every dispatcher call has a static selector or case |
 
-An order-preserving lowering must be designed and audited before it is enabled.
-The existing 48 substitutions remain the standard: they only emit formulas whose
-argument-use order matches the original call.
+The order-preserving lowering is enabled and audited (2026-08-04): the producer
+emits `(function (a0..aN-1) { return <case formula over the parameters>; })(arg0..argN-1)`
+for reordered cases, and `audit-formula-fold.js` re-derives the identical text
+independently. All 207 non-literal sequences are folded; zero candidates remain
+rejected.
 
 ### S1.2: Two interposed dispatcher-index reads
 
@@ -129,7 +131,7 @@ table name is known.
 
 | Case | Count | Reason |
 |---|---:|---|
-| Index-47 property access | 247 surviving bracketed sites | A dotted `.length` rewrite changes Array semantics |
+| Index-47 property access | 247 surviving bracketed sites | A dotted `.length` rewrite changes Array semantics; `audit-index47-census.js` classifies all 247 (245 packed-slot storage on `[arguments]` bags, 2 nested-receiver special sites) with Node-executed probes proving 0 dot-safe sites |
 | Out-of-table literal index | 10 | The property-name table has no value for the index |
 | Global dynamic brackets | 4 today | Two PIXI particle reads, renderer emitter timing, and scoreboard sorting; all remain bracketed because their stateful/data-record proof is intentionally incomplete |
 
@@ -231,6 +233,7 @@ node .deobf/audit-training-statics.js --self-check
 node .deobf/audit-map-option-writers.js --self-check
 node .deobf/audit-out-of-table.js --self-check
 node .deobf/audit-dynamic-training-residuals.js --self-check
+node .deobf/audit-index47-census.js --self-check
 node .deobf/audit-table-lookup.js --verify
 node .deobf/test-anchors.js
 ```


### PR DESCRIPTION
## Summary

Closes two known deobfuscation residual classes against the 2026-07-29 alpha2s.js build (local .deobf pipeline; docs-only PR since .deobf is gitignored).

### 1. formula_reorders_arguments: 159 -> 0

pass3b now folds **all 207** non-literal dispatcher sequences:

- 48 keep the inline form (identity argument order), unchanged.
- 159 use the new **order-preserving IIFE lowering** (`op-dispatch-fold.substituteCaseOrdered`): each call argument binds to a fresh parameter in left-to-right call order, then the case formula applies to the parameters. This reproduces the dispatcher's own evaluate-arguments-first behavior with identical exception and coercion order — no bare operand-order change.
- Every reordered case selector (238 of 253 case formulas) was behavior-checked against the booted dispatcher in Node with 0 mismatches; producer and independent audit (audit-formula-fold.js) construct byte-identical text.
- Formula argument recoveries: 79 subs + 19 anns (47 sites) -> **368 subs + 111 anns (191 sites)**; 0 index-47 recoveries.

### 2. Index-47: 247 sites mechanically classified, 0 dot-safe

New `.deobf/audit-index47-census.js` re-derives the 247 surviving bracketed index-47 accesses (AST candidates minus final-folds.json fold ranges) and classifies every site:

- 245 packed-slot storage on `[arguments]` array bags (slot-47 writes / loop counters) — dotted `.length` would read the bag's element count.
- 2 nested-receiver special sites: L3081 `N7I[98][47]` real-array element write (capZones label table); L6257 `O7a[7][47]` table-string read retained because the strict carrier fold rule requires every slot assignment to dominate the read.
- Node-executed probes prove the `X.length != X[47]` semantics for both array patterns and confirm `M$QCc[47] === "length"` in two fresh preamble boots. Count stays 247; zero dotted substitutions.

### Validation

- Readable artifact: 4,480,444 bytes; SHA-256 `5F2D3882ABFB6A3BFA1FBBED3693E546B7D7E4B0ECA98255CE3592D8C91522E6` (two identical pipeline runs).
- Full verification set passes (13/13, exit 0): pipeline, node --check, ast-member-scan, audit-independent, audit-preamble, audit-formula-fold, audit-training-statics, audit-map-option-writers, audit-out-of-table, audit-dynamic-training-residuals, **audit-index47-census (new)**, audit-table-lookup --verify, test-anchors.

### Docs updated

- docs/DEOBFUSCATION.md (36.1/36.3/36.4, 37.1, 38.1-38.4, artifact list, validation set, SHA)
- docs/DEOBFUSCATION_ROADMAP.md (baseline, S0.1, S1.1, index-47 row, validation set)
- docs/DEOBFUSCATION_FIX_TRACKER.md (fix log entry)

## Remaining work

- The 1,639 residual dispatcher/selector calls (w_c/Q5$/H0n/d1M) are unchanged — they have no static selector/case provenance.
- 2 of 88 direct dispatcher-index sites remain bracketed (t8H interposition); 4 global dynamic brackets and 10 out-of-table literals remain documented as before.
- Index-47 stays structurally protected at 247 sites; the O7a[7][47] site (L6257) is documented as a candidate for a future execution-verified carrier-write rule (S2.2).
