### PR TITLE
fix(worker,ipc,config): worker-pool/IPC reliability fixes (#191, #185, #183, #184)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Telemetry is controlled via CLI flags. All flags are optional; the system defaul
 | Flag | Alias | Description | Default |
 |:-----|:------|:------------|:--------|
 | `--telemetry` | `-t` | Master switch to enable telemetry | `false` |
-| `--profile` | `-p` | Profiling detail level: `minimal`, `standard`, `detailed` | `standard` |
+| `--profile` / `--profile-level` | `-l` | Profiling detail level: `minimal`, `standard`, `detailed` | `standard` |
 | `--debug` | `-d` | Debug output level: `none`, `error`, `verbose` | `none` |
 | `--output` | `-o` | Output format: `console`, `file`, `both` | `console` |
 | `--dashboard-port` | — | HTTP port for telemetry dashboard | `3001` |
@@ -144,11 +144,20 @@ Environment variables provide an alternative way to configure telemetry. They ta
 
 #### Precedence Order
 
-Configuration priority (highest to lowest):
-1. Environment variables
-2. CLI flags
+Configuration priority (highest to lowest) for the server/config-loader settings
+(`--port`, `--workers`, `--seed`, `--map`, telemetry flags, ...):
+
+1. CLI flags
+2. Environment variables
 3. Config file settings
 4. Default values
+
+Note: `-p` is the short form of `--port` (server port) only — it is not a
+telemetry alias. Use `--profile-level` or `-l` for the profiling level.
+
+Telemetry-only settings additionally merge the `MANIFOLD_*` environment
+variables after CLI parsing inside the telemetry controller, so for those
+specific flags the environment takes precedence over the CLI.
 
 ### Usage Examples
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -28,7 +28,7 @@ npx tsx src/main.ts -t --profile detailed --debug verbose
 | Flag | Alias | Description | Default |
 |:-----|:------|:------------|:--------|
 | `--telemetry` | `-t` | Master switch to enable telemetry | `false` |
-| `--profile` | `-p` | Profiling detail level | `standard` |
+| `--profile` / `--profile-level` | `-l` | Profiling detail level | `standard` |
 | `--debug` | `-d` | Debug output level | `none` |
 | `--output` | `-o` | Output format | `console` |
 | `--dashboard-port` | — | HTTP port for telemetry dashboard | `3001` |

--- a/src/config/config-loader.ts
+++ b/src/config/config-loader.ts
@@ -2,7 +2,7 @@
  * config-loader.ts — Layered configuration system
  *
  * Resolution order (highest priority wins):
- *   1. CLI flags          (--port, --telemetry, --profile, --debug, --max-runtime)
+ *   1. CLI flags          (--port/-p, --telemetry, --profile[--level]/-l, --debug, --max-runtime)
  *   2. Environment vars   (PORT, TEST_MODE, MANIFOLD_TELEMETRY, MANIFOLD_*)
  *   3. config.json file   (project root, optional)
  *   4. Built-in defaults  (hardcoded below)
@@ -425,6 +425,8 @@ function parseCliFlags(config: AppConfig): AppConfig {
                 break;
 
             case '--profile':
+            case '--profile-level':
+            case '-l':
                 if (next) {
                     if (next === 'minimal' || next === 'standard' || next === 'detailed') {
                         config.telemetry.profileLevel = next;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -436,7 +436,7 @@ export class WorkerPool {
         if (!Array.isArray(actions) || actions.length !== totalEnvs) {
             const received = Array.isArray(actions) ? actions.length : typeof actions;
             throw new Error(
-                `Invalid action batch: expected ${totalEnvs} actions for ${totalEnvs} environments, got ${received}`,
+                `Invalid action batch: expected ${totalEnvs} action${totalEnvs === 1 ? '' : 's'} for ${totalEnvs} environment${totalEnvs === 1 ? '' : 's'}, got ${received}`,
             );
         }
         try {
@@ -481,7 +481,6 @@ export class WorkerPool {
         // untouched and the caller may retry. It is tagged so step() can treat
         // it as transient rather than failing the pool.
         let actionIdx = 0;
-        const encodedBatches: Uint8Array[] = [];
         try {
             for (let i = 0; i < this.workers.length; i++) {
                 const wEnvs = this.workerEnvs[i];
@@ -491,7 +490,6 @@ export class WorkerPool {
                     encodedActions[j] = this.encodeAction(actions[actionIdx + j]);
                 }
                 actionIdx += wEnvs;
-                encodedBatches.push(encodedActions);
             }
         } catch (error) {
             const tagged = error instanceof Error ? error : new Error(String(error));
@@ -506,7 +504,7 @@ export class WorkerPool {
 
         for (let i = 0; i < this.workers.length; i++) {
             const shm = this.requireSharedMemoryManager(i);
-            shm.writeActionsQuiet(encodedBatches[i]);
+            shm.writeActionsQuiet(this.actionBufferPool[i]);
             shm.sendCommand(0); // STEP command (also notifies worker)
         }
 

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -428,6 +428,17 @@ export class WorkerPool {
      */
     async step(actions: any[], options: ResultOwnershipOptions = {}): Promise<any[]> {
         this.assertReady('step');
+        // Validate the batch before touching any worker state. A short or
+        // over-long action array is a per-request input error in both
+        // transports (mirroring the Python client's exact-count check) and
+        // must never fail or desync the pool.
+        const totalEnvs = this.totalEnvs();
+        if (!Array.isArray(actions) || actions.length !== totalEnvs) {
+            const received = Array.isArray(actions) ? actions.length : typeof actions;
+            throw new Error(
+                `Invalid action batch: expected ${totalEnvs} actions for ${totalEnvs} environments, got ${received}`,
+            );
+        }
         try {
             // Shared memory mode honors `ownership`; message-passing mode always
             // returns caller-owned structured clones.
@@ -440,12 +451,15 @@ export class WorkerPool {
                 throw error;
             }
             const failure = this.createFailure('step', error);
-            // Shared-memory batches can corrupt or desync the pool, so any
-            // failure there is fatal. In message mode an error reply from a
-            // live worker is transient and must not kill the pool, but a
-            // timeout means the worker is hung/unreachable: fail so callers
-            // re-init instead of waiting out the full timeout on every step.
-            if (this.useSharedMemory || this.isWorkerTimeout(error)) {
+            // Failure policy is failure-class-aware. Message-mode error
+            // replies from live workers are transient and must not kill the
+            // pool. In shared mode, only failures that can plausibly corrupt
+            // or desync the pool are fatal (worker timeout/crash/exit,
+            // worker-reported errors, errors after signals were issued); a
+            // pre-signal encoding error leaves the pool untouched and is
+            // treated as a transient per-request error, exactly like message
+            // mode.
+            if (this.isWorkerTimeout(error) || (this.useSharedMemory && !this.isActionEncodeError(error))) {
                 await this.failPool(failure);
             }
             throw failure;
@@ -461,26 +475,41 @@ export class WorkerPool {
         this._returnTimes.fill(BigInt(0));
         const returnTimes = this._returnTimes;
 
-        // 1. Encode actions and signal all workers in parallel
+        // Phase 1 — encode every action into the per-worker buffers before any
+        // worker is signalled. An encoding failure (e.g. a null entry) is a
+        // per-request input error: no command has been sent, so the pool is
+        // untouched and the caller may retry. It is tagged so step() can treat
+        // it as transient rather than failing the pool.
         let actionIdx = 0;
+        const encodedBatches: Uint8Array[] = [];
+        try {
+            for (let i = 0; i < this.workers.length; i++) {
+                const wEnvs = this.workerEnvs[i];
 
+                const encodedActions = this.actionBufferPool[i];
+                for (let j = 0; j < wEnvs; j++) {
+                    encodedActions[j] = this.encodeAction(actions[actionIdx + j]);
+                }
+                actionIdx += wEnvs;
+                encodedBatches.push(encodedActions);
+            }
+        } catch (error) {
+            const tagged = error instanceof Error ? error : new Error(String(error));
+            (tagged as Error & { code?: string }).code = 'ACTION_ENCODE';
+            throw tagged;
+        }
+
+        // Phase 2 — signal all workers and wait for results without blocking
+        // worker event delivery. From here on any failure may have left worker
+        // state inconsistent, so the step() handler treats it as fatal.
         const completedArr = this.prepareSharedBatch();
 
         for (let i = 0; i < this.workers.length; i++) {
-            const wEnvs = this.workerEnvs[i];
-
-            const encodedActions = this.actionBufferPool[i];
-            for (let j = 0; j < wEnvs; j++) {
-                encodedActions[j] = this.encodeAction(actions[actionIdx + j]);
-            }
-            actionIdx += wEnvs;
-
             const shm = this.requireSharedMemoryManager(i);
-            shm.writeActionsQuiet(encodedActions);
+            shm.writeActionsQuiet(encodedBatches[i]);
             shm.sendCommand(0); // STEP command (also notifies worker)
         }
 
-        // 2. Wait for results from all workers without blocking worker event delivery.
         const finished = this._finished;
         finished.fill(0);  // Reset from previous step
 
@@ -657,10 +686,19 @@ export class WorkerPool {
     /**
      * Encodes a PlayerInput action to a number for shared memory storage
      * Uses bit flags: left=1, right=2, up=4, down=8, heavy=16, grapple=32
+     *
+     * Null/undefined or otherwise malformed entries throw a labeled error
+     * instead of failing with an unlabelled TypeError, so callers can tell a
+     * bad request apart from a pool failure.
      */
     private encodeAction(action: PlayerInput | number): number {
         if (typeof action === 'number') {
             return action; // Already encoded
+        }
+        if (action === null || typeof action !== 'object') {
+            throw new Error(
+                `Invalid action: expected a PlayerInput object or an encoded number, got ${action === null ? 'null' : typeof action}`,
+            );
         }
         let encoded = 0;
         if (action.left) encoded |= 1;
@@ -888,6 +926,19 @@ export class WorkerPool {
 
     private isWorkerTimeout(error: unknown): boolean {
         return (error as { code?: string })?.code === 'WORKER_TIMEOUT';
+    }
+
+    /**
+     * True when the error was thrown while encoding actions, before any worker
+     * was signalled. Such errors leave the shared-memory pool untouched and are
+     * transient per-request failures rather than pool-fatal ones.
+     */
+    private isActionEncodeError(error: unknown): boolean {
+        return (error as { code?: string })?.code === 'ACTION_ENCODE';
+    }
+
+    private totalEnvs(): number {
+        return this.workerEnvs.reduce((sum, n) => sum + n, 0);
     }
 
     /**

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -122,13 +122,27 @@ export class IpcBridge {
                     globalProfiler.tick();
 
                     if (this.stepCount % 5000 === 0) {
-                        globalProfiler.recordMemory();
+                        // The step above already completed and its reply is
+                        // serialized. Telemetry is best-effort: a failure here
+                        // must not discard that reply or double-report the step
+                        // as an error (see #185), so it is isolated and logged.
+                        try {
+                            globalProfiler.recordMemory();
 
-                        const telemetryEnabled = require('../telemetry/telemetry-controller').isTelemetryEnabled();
-                        if (telemetryEnabled) {
-                            const snapshots = await this.pool.getTelemetrySnapshots();
-                            setLatestWorkerTelemetry(snapshots);
-                            globalProfiler.report(5000);
+                            const telemetryEnabled = require('../telemetry/telemetry-controller').isTelemetryEnabled();
+                            if (telemetryEnabled) {
+                                // Workers blocked in Atomics.wait (shared-memory
+                                // mode) can never service GET_TELEMETRY, so the
+                                // snapshot fetch would always time out there;
+                                // skip it and report without worker snapshots.
+                                if (!this.pool.isUsingSharedMemory()) {
+                                    const snapshots = await this.pool.getTelemetrySnapshots();
+                                    setLatestWorkerTelemetry(snapshots);
+                                }
+                                globalProfiler.report(5000);
+                            }
+                        } catch (telemetryError) {
+                            console.error('[IPC] Telemetry error after step:', telemetryError);
                         }
                     }
                 }

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -13,6 +13,7 @@ export class IpcBridge {
     private stepCount: number = 0;
     private _closed: boolean = false;
     private _initialized: boolean = false;
+    private _numEnvs: number = 0;
     private _shouldClose: boolean = false;
 
     constructor(config?: DeepPartial<AppConfig>) {
@@ -69,6 +70,7 @@ export class IpcBridge {
                     console.log(`[IPC] Init request: numEnvs=${numEnvs}, config=${JSON.stringify(mergedConfig)}, useSharedMemory=${useSharedMemory}`);
                     await this.pool.init(numEnvs, mergedConfig, useSharedMemory);
                     this._initialized = true;
+                    this._numEnvs = numEnvs;
                     response = { status: "ok" };
                 }
             } else if (command === "reset") {
@@ -95,6 +97,15 @@ export class IpcBridge {
                     response = { status: "error", error: "Invalid actions: array cannot be empty" };
                 } else if (!this._initialized) {
                     response = { status: "error", error: "Worker pool not initialized" };
+                } else if (actions.length !== this._numEnvs) {
+                    // Reject a wrong-sized batch before any pool state is
+                    // touched, mirroring the Python client's exact-count
+                    // check. A short array must not reach the pool as an
+                    // encoding error that could fail it in shared-memory mode.
+                    response = {
+                        status: "error",
+                        error: `Invalid actions: expected ${this._numEnvs} actions for ${this._numEnvs} environments, got ${actions.length}`,
+                    };
                 } else {
                     // Requests are serialized by the server loop, and the
                     // borrowed graph below is only valid until the next pool
@@ -132,6 +143,7 @@ export class IpcBridge {
                     // server keep working.
                     await this.pool.close();
                     this._initialized = false;
+                    this._numEnvs = 0;
                     response = { status: "ok" };
                 }
             } else {

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -102,9 +102,10 @@ export class IpcBridge {
                     // touched, mirroring the Python client's exact-count
                     // check. A short array must not reach the pool as an
                     // encoding error that could fail it in shared-memory mode.
+                    const n = this._numEnvs;
                     response = {
                         status: "error",
-                        error: `Invalid actions: expected ${this._numEnvs} actions for ${this._numEnvs} environments, got ${actions.length}`,
+                        error: `Invalid actions: expected ${n} action${n === 1 ? '' : 's'} for ${n} environment${n === 1 ? '' : 's'}, got ${actions.length}`,
                     };
                 } else {
                     // Requests are serialized by the server loop, and the
@@ -188,6 +189,7 @@ export class IpcBridge {
     async initEnv(numEnvs: number, config: any = {}, useSharedMemory?: boolean): Promise<void> {
         await this.pool.init(numEnvs, config, useSharedMemory);
         this._initialized = true;
+        this._numEnvs = numEnvs;
     }
 
     /**

--- a/src/ipc/shared-memory.ts
+++ b/src/ipc/shared-memory.ts
@@ -142,6 +142,11 @@ export class SharedMemoryManager {
     }
 
     writeSeeds(seeds: number[]) {
+        // Fill every slot first so environments beyond a short seed list get
+        // the no-seed sentinel (0) instead of silently replaying whatever the
+        // previous batch wrote. Without this, a partial reset would re-run the
+        // previous batch's seeds for the tail environments.
+        this.seeds.fill(0);
         this.seeds.set(seeds.slice(0, this.numEnvs));
     }
 

--- a/src/telemetry/README.md
+++ b/src/telemetry/README.md
@@ -6,7 +6,7 @@ Flag-based telemetry activation, high-precision performance profiling, and runti
 
 | File | Purpose |
 |------|---------|
-| `flags.ts` | CLI flag parser — `--telemetry`, `--profile`, `--debug`, `--output`, `--dashboard-port`, `--report-interval`, `--retention` |
+| `flags.ts` | CLI flag parser — `--telemetry`, `--profile`, `--profile-level`, `--debug`, `--output`, `--dashboard-port`, `--report-interval`, `--retention` |
 | `profiler.ts` | High-precision profiler — `BigUint64Array` accumulator, `wrap()` decorator, heatmap reporting |
 | `telemetry-controller.ts` | Singleton controller — coordinates flags, config, and profiler lifecycle |
 
@@ -15,7 +15,7 @@ Flag-based telemetry activation, high-precision performance profiling, and runti
 | Flag | Alias | Type | Default | Description |
 |------|-------|------|---------|-------------|
 | `--telemetry` | `-t` | boolean | `false` | Master switch to enable telemetry |
-| `--profile` | `-p` | value | `standard` | Profile level: `minimal`, `standard`, `detailed` |
+| `--profile` / `--profile-level` | `-l` | value | `standard` | Profile level: `minimal`, `standard`, `detailed` |
 | `--debug` | `-d` | value | `none` | Debug level: `none`, `error`, `verbose` |
 | `--output` | `-o` | value | `console` | Output format: `console`, `file`, `both` |
 | `--dashboard-port` | — | number | `3001` | Telemetry dashboard port |

--- a/src/telemetry/flags.ts
+++ b/src/telemetry/flags.ts
@@ -47,8 +47,12 @@ const FLAG_ALIASES: Record<string, keyof TelemetryFlags> = {
   '-t': 'enableTelemetry',
 
   // Profiling level
+  // NOTE: `-p` is deliberately NOT an alias here — it belongs to `--port` in
+  // config-loader. Use `-l` (or `--profile-level`) instead, so the two parsers
+  // never read the same short flag with different meanings (issue #184).
   '--profile': 'profileLevel',
-  '-p': 'profileLevel',
+  '--profile-level': 'profileLevel',
+  '-l': 'profileLevel',
 
   // Debug level
   '--debug': 'debugLevel',
@@ -75,7 +79,8 @@ const FLAG_ALIASES: Record<string, keyof TelemetryFlags> = {
 function parseValueFlag(flag: string, value: string): { key: keyof TelemetryFlags; valid: boolean; value: unknown } | null {
   switch (flag) {
     case '--profile':
-    case '-p':
+    case '--profile-level':
+    case '-l':
       if (value === 'minimal' || value === 'standard' || value === 'detailed') {
         return { key: 'profileLevel', valid: true, value };
       }
@@ -256,7 +261,7 @@ export function isAnyTelemetryEnabled(): boolean {
     // Keep the fast path exactly aligned with parseFlags(): only the
     // space-separated, valid-value forms imply telemetry.
     const nextArg = argv[i + 1];
-    if ((arg === '--profile' || arg === '-p') &&
+    if ((arg === '--profile' || arg === '--profile-level' || arg === '-l') &&
         (nextArg === 'minimal' || nextArg === 'standard' || nextArg === 'detailed')) {
       return true;
     }

--- a/tests/integration/ipc-bridge-dealer-socket.test.ts
+++ b/tests/integration/ipc-bridge-dealer-socket.test.ts
@@ -1,0 +1,64 @@
+/**
+ * ipc-bridge-dealer-socket.test.ts — DEALER-socket regression coverage for issue #191
+ *
+ * Exercises the exact failure scenario from the issue over a real ZMQ DEALER
+ * socket (as the Python client does): a `step` request with fewer actions than
+ * environments must be rejected as a per-request error, and a subsequent
+ * correctly-sized step/reset must still succeed. Previously, in shared-memory
+ * mode, the short batch permanently failed the pool.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as zmq from 'zeromq';
+import { IpcBridge } from '../../src/ipc/ipc-bridge';
+import { WorkerPool } from '../../src/core/worker-pool';
+
+describe('IpcBridge DEALER-socket action batch validation (issue #191)', () => {
+  let bridge: IpcBridge;
+  let client: zmq.Dealer;
+  const port = 15601;
+
+  beforeAll(async () => {
+    bridge = new IpcBridge({ server: { port } } as any);
+    // start() runs the serve loop until close(), so do not await it.
+    void bridge.start();
+    client = new zmq.Dealer();
+    await client.connect(`tcp://127.0.0.1:${port}`);
+    await new Promise(r => setTimeout(r, 300));
+  }, 30000);
+
+  afterAll(async () => {
+    try { client.close(); } catch { /* ignore */ }
+    try { await bridge.close(); } catch { /* ignore */ }
+  }, 10000);
+
+  async function sendCommand(cmd: object): Promise<any> {
+    await client.send(JSON.stringify(cmd));
+    const [response] = await client.receive();
+    return JSON.parse(response.toString());
+  }
+
+  const expectShortBatchIsTransient = async (useSharedMemory: boolean) => {
+    await sendCommand({ command: 'init', numEnvs: 2, useSharedMemory });
+
+    const bad = await sendCommand({ command: 'step', actions: [0] });
+    expect(bad.status).toBe('error');
+    expect(bad.error).toContain('Invalid actions: expected 2 actions for 2 environments, got 1');
+
+    const good = await sendCommand({ command: 'step', actions: [0, 0] });
+    expect(good.status).toBe('ok');
+    expect(good.data).toHaveLength(2);
+
+    const reset = await sendCommand({ command: 'reset', seeds: [1, 2] });
+    expect(reset.status).toBe('ok');
+    expect(reset.data.observation).toHaveLength(2);
+  };
+
+  it('message-passing mode: short batch is a per-request error and the pool recovers', async () => {
+    await expectShortBatchIsTransient(false);
+  }, 60000);
+
+  it('shared-memory mode: short batch is a per-request error and the pool recovers', async () => {
+    if (!WorkerPool.isSupported()) return;
+    await expectShortBatchIsTransient(true);
+  }, 60000);
+});

--- a/tests/integration/ipc-bridge-dealer-socket.test.ts
+++ b/tests/integration/ipc-bridge-dealer-socket.test.ts
@@ -11,13 +11,17 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import * as zmq from 'zeromq';
 import { IpcBridge } from '../../src/ipc/ipc-bridge';
 import { WorkerPool } from '../../src/core/worker-pool';
+import { PortManager } from '../../src/utils/port-manager';
 
 describe('IpcBridge DEALER-socket action batch validation (issue #191)', () => {
   let bridge: IpcBridge;
   let client: zmq.Dealer;
-  const port = 15601;
+  let portManager: PortManager;
+  let port: number;
 
   beforeAll(async () => {
+    portManager = new PortManager({ startPort: 15600, endPort: 15699 });
+    port = portManager.allocate();
     bridge = new IpcBridge({ server: { port } } as any);
     // start() runs the serve loop until close(), so do not await it.
     void bridge.start();
@@ -29,6 +33,7 @@ describe('IpcBridge DEALER-socket action batch validation (issue #191)', () => {
   afterAll(async () => {
     try { client.close(); } catch { /* ignore */ }
     try { await bridge.close(); } catch { /* ignore */ }
+    portManager.release(port);
   }, 10000);
 
   async function sendCommand(cmd: object): Promise<any> {
@@ -60,5 +65,17 @@ describe('IpcBridge DEALER-socket action batch validation (issue #191)', () => {
   it('shared-memory mode: short batch is a per-request error and the pool recovers', async () => {
     if (!WorkerPool.isSupported()) return;
     await expectShortBatchIsTransient(true);
+  }, 60000);
+
+  it('programmatic initEnv tracks the env count for IPC step validation', async () => {
+    await bridge.initEnv(2, {}, false);
+
+    const good = await sendCommand({ command: 'step', actions: [0, 0] });
+    expect(good.status).toBe('ok');
+    expect(good.data).toHaveLength(2);
+
+    const short = await sendCommand({ command: 'step', actions: [0] });
+    expect(short.status).toBe('error');
+    expect(short.error).toContain('Invalid actions: expected 2 actions for 2 environments, got 1');
   }, 60000);
 });

--- a/tests/integration/ipc-shared-memory.test.ts
+++ b/tests/integration/ipc-shared-memory.test.ts
@@ -263,6 +263,13 @@ describe('SharedMemoryManager', () => {
       const seeds = shm.readSeeds();
       expect(Array.from(seeds)).toEqual([1, 2, 3, 4]);
     });
+
+    it('writeSeeds clears the stale region for short lists (issue #183)', () => {
+      shm.writeSeeds([7, 8, 9, 10]);
+      shm.writeSeeds([1, 2]);
+      const seeds = shm.readSeeds();
+      expect(Array.from(seeds)).toEqual([1, 2, 0, 0]);
+    });
   });
 
   // ---- command read/write ----

--- a/tests/integration/worker-pool-action-count.test.ts
+++ b/tests/integration/worker-pool-action-count.test.ts
@@ -1,0 +1,80 @@
+/**
+ * worker-pool-action-count.test.ts — Regression coverage for issue #191
+ *
+ * A step whose action array length does not match the number of environments
+ * must be rejected as a per-request input error in BOTH transports, without
+ * failing the worker pool. Previously, shared-memory mode encoded `undefined`
+ * for the tail environments and the resulting TypeError permanently failed the
+ * pool, while message mode recovered — a transport divergence.
+ */
+import { describe, it, expect } from 'vitest';
+import { WorkerPool } from '../../src/core/worker-pool';
+
+describe('WorkerPool action batch validation (issue #191)', () => {
+  const runRecoverySequence = async (useSharedMemory: boolean) => {
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(2, {}, useSharedMemory);
+      await pool.reset([11, 22]);
+
+      // Short batch: per-request error, pool untouched.
+      await expect(pool.step([0])).rejects.toThrow(
+        'Invalid action batch: expected 2 actions for 2 environments, got 1',
+      );
+      expect(pool.isUsingSharedMemory()).toBe(useSharedMemory);
+      expect((pool as any).state).toBe('ready');
+
+      // Correctly sized follow-ups succeed in both transports.
+      const results = await pool.step([0, 0]);
+      expect(results).toHaveLength(2);
+      const obs = await pool.reset([33, 44]);
+      expect(obs).toHaveLength(2);
+      await expect(pool.step([0, 0])).resolves.toHaveLength(2);
+    } finally {
+      await pool.close();
+    }
+  };
+
+  it('shared-memory mode: short batch is transient and the pool recovers', async () => {
+    if (!WorkerPool.isSupported()) return;
+    await runRecoverySequence(true);
+  });
+
+  it('message-passing mode: short batch is transient and the pool recovers', async () => {
+    await runRecoverySequence(false);
+  });
+
+  it('shared-memory mode: over-long batch is transient and the pool recovers', async () => {
+    if (!WorkerPool.isSupported()) return;
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(2, {}, true);
+      await pool.reset([1, 2]);
+
+      await expect(pool.step([0, 0, 0])).rejects.toThrow(
+        'Invalid action batch: expected 2 actions for 2 environments, got 3',
+      );
+      expect((pool as any).state).toBe('ready');
+      await expect(pool.step([0, 0])).resolves.toHaveLength(2);
+    } finally {
+      await pool.close();
+    }
+  });
+
+  it('shared-memory mode: a null action is a labeled transient error', async () => {
+    if (!WorkerPool.isSupported()) return;
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(2, {}, true);
+      await pool.reset([1, 2]);
+
+      await expect(pool.step([null as any, 0])).rejects.toThrow(
+        'Invalid action: expected a PlayerInput object or an encoded number, got null',
+      );
+      expect((pool as any).state).toBe('ready');
+      await expect(pool.step([0, 0])).resolves.toHaveLength(2);
+    } finally {
+      await pool.close();
+    }
+  });
+});

--- a/tests/integration/worker-pool-stale-seeds.test.ts
+++ b/tests/integration/worker-pool-stale-seeds.test.ts
@@ -1,0 +1,50 @@
+/**
+ * worker-pool-stale-seeds.test.ts — Regression coverage for issue #183
+ *
+ * A shared-memory reset with fewer seeds than environments must not silently
+ * replay the previous batch's seeds for the tail environments. Previously the
+ * seed table was only partially overwritten, so `reset([333])` after
+ * `reset([111, 222])` re-ran env 1 with the stale seed 222 — producing a
+ * bit-identical trajectory to the reseeded control. Message mode always left
+ * such environments unseeded (continuing their RNG stream), so the two
+ * transports disagreed on the same API call.
+ */
+import { describe, it, expect } from 'vitest';
+import { WorkerPool } from '../../src/core/worker-pool';
+
+describe('Shared-memory reset with a short seed list (issue #183)', () => {
+  it('does not replay stale seeds for environments beyond the seed list', async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    const runSequence = async (useSharedMemory: boolean) => {
+      const pool = new WorkerPool(1);
+      try {
+        // A nonzero config seed keeps environment construction deterministic.
+        await pool.init(2, { seed: 1 }, useSharedMemory);
+        await pool.reset([111, 222]);
+        const seededA = await pool.step([0, 0]); // env 1 seeded 222
+        await pool.reset([333, 222]);
+        const seededB = await pool.step([0, 0]); // control: env 1 re-seeded 222
+        await pool.reset([333]);                 // env 1 has NO seed this call
+        const partial = await pool.step([0, 0]);
+        return { seededA, seededB, partial };
+      } finally {
+        await pool.close();
+      }
+    };
+
+    const shared = await runSequence(true);
+    const message = await runSequence(false);
+
+    // Sanity: reseeding env 1 with 222 is bit-identical across resets.
+    expect(shared.seededB[1].observation).toEqual(shared.seededA[1].observation);
+    expect(message.seededB[1].observation).toEqual(message.seededA[1].observation);
+
+    // Regression: after the partial seed list, env 1 must NOT replay the stale
+    // seed 222 (which would make `partial` bit-identical to the control). It
+    // continues its RNG stream instead, so its trajectory differs. Message mode
+    // always behaved this way; the fix aligns shared mode with it.
+    expect(shared.partial[1].observation).not.toEqual(shared.seededB[1].observation);
+    expect(message.partial[1].observation).not.toEqual(message.seededB[1].observation);
+  });
+});

--- a/tests/unit/config-loader-env.test.ts
+++ b/tests/unit/config-loader-env.test.ts
@@ -306,6 +306,20 @@ describe('config-loader env vars and CLI', () => {
             expect(cfg.telemetry.enabled).toBe(true);
         });
 
+        it('--profile-level sets profile level and enables telemetry', () => {
+            process.argv = ['node', 'script.js', '--profile-level', 'detailed'];
+            const cfg = loadConfig(testDir);
+            expect(cfg.telemetry.profileLevel).toBe('detailed');
+            expect(cfg.telemetry.enabled).toBe(true);
+        });
+
+        it('-l sets profile level (short form)', () => {
+            process.argv = ['node', 'script.js', '-l', 'minimal'];
+            const cfg = loadConfig(testDir);
+            expect(cfg.telemetry.profileLevel).toBe('minimal');
+            expect(cfg.telemetry.enabled).toBe(true);
+        });
+
         it('--profile rejects invalid value', () => {
             process.argv = ['node', 'script.js', '--profile', 'extreme'];
             const cfg = loadConfig(testDir);

--- a/tests/unit/ipc-bridge-telemetry-integrity.test.ts
+++ b/tests/unit/ipc-bridge-telemetry-integrity.test.ts
@@ -1,0 +1,146 @@
+/**
+ * ipc-bridge-telemetry-integrity.test.ts — Regression coverage for issue #185
+ *
+ * The step reply is serialized before the post-step telemetry block runs. A
+ * telemetry failure (e.g. `recordMemory()` throwing, or the worker snapshot
+ * fetch rejecting — deterministic in shared-memory mode, where workers blocked
+ * in Atomics.wait can never service GET_TELEMETRY) must NOT discard the reply
+ * of a step that already completed: the client would otherwise be told the
+ * step failed and retry it, double-stepping the environments.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const sock = {
+    bind: async () => {},
+    close: () => {},
+    send: async () => {},
+  };
+  const pool = {
+    init: vi.fn().mockResolvedValue(undefined),
+    reset: vi.fn().mockResolvedValue([]),
+    step: vi.fn().mockResolvedValue([]),
+    close: vi.fn(),
+    getTelemetrySnapshots: vi.fn().mockResolvedValue([]),
+    isUsingSharedMemory: vi.fn(() => false),
+  };
+  return {
+    sock,
+    pool,
+    Router: function Router() { return sock; },
+    WorkerPool: vi.fn(function WorkerPool() { return pool; }),
+    getConfig: vi.fn(),
+    isTelemetryEnabled: vi.fn(),
+    gpTick: vi.fn(),
+    gpRecordMemory: vi.fn(),
+    gpReport: vi.fn(),
+    setLatestWorkerTelemetry: vi.fn(),
+    wrap: vi.fn((_idx, fn) => fn),
+  };
+});
+
+vi.mock('zeromq', () => ({ Router: mocks.Router }));
+vi.mock('../../src/telemetry/profiler', () => ({
+  globalProfiler: {
+    tick: mocks.gpTick,
+    recordMemory: mocks.gpRecordMemory,
+    report: mocks.gpReport,
+  },
+  wrap: mocks.wrap,
+  TelemetryIndices: { JSON_PARSE: 0, ZMQ_SEND: 1 },
+  setLatestWorkerTelemetry: mocks.setLatestWorkerTelemetry,
+}));
+vi.mock('../../src/telemetry/telemetry-controller', () => ({
+  isTelemetryEnabled: mocks.isTelemetryEnabled,
+}));
+vi.mock('../../src/core/worker-pool', () => ({
+  WorkerPool: mocks.WorkerPool,
+}));
+vi.mock('../../src/config/config-loader', () => ({
+  getConfig: mocks.getConfig,
+  deepMerge: (base: Record<string, any>, override: Record<string, any>) => ({ ...base, ...override }),
+}));
+
+import { IpcBridge } from '../../src/ipc/ipc-bridge';
+
+describe('IpcBridge step reply integrity when telemetry fails (issue #185)', () => {
+  let sendSpy: ReturnType<typeof vi.spyOn>;
+
+  const stepResult = { observation: [], reward: 0.5, done: false, truncated: false, info: { tick: 5 } };
+
+  beforeEach(() => {
+    mocks.getConfig.mockReturnValue({ server: { port: 5555 }, environment: { seed: 0 } });
+    mocks.isTelemetryEnabled.mockReturnValue(true);
+    mocks.pool.step.mockResolvedValue([stepResult]);
+    sendSpy = vi.spyOn(mocks.sock, 'send').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    sendSpy.mockRestore();
+  });
+
+  async function initAndStepAtBoundary(port: number) {
+    const bridge = new IpcBridge({ server: { port } } as any);
+    const handleRequest = (bridge as any).handleRequest.bind(bridge);
+    await handleRequest(Buffer.from('identity'), JSON.stringify({ command: 'init', numEnvs: 1 }));
+    (bridge as any).stepCount = 4999;
+    await handleRequest(Buffer.from('identity'), JSON.stringify({ command: 'step', actions: [0] }));
+    return bridge;
+  }
+
+  function lastSentResponse(): any {
+    const call = sendSpy.mock.calls[sendSpy.mock.calls.length - 1];
+    const frames = call[0] as any[];
+    return JSON.parse(frames[1].toString());
+  }
+
+  it('reports ok for a completed step when recordMemory throws', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mocks.gpRecordMemory.mockImplementationOnce(() => { throw new Error('synthetic memory failure'); });
+
+    await initAndStepAtBoundary(12363);
+
+    const response = lastSentResponse();
+    expect(response.status).toBe('ok');
+    expect(response.data).toHaveLength(1);
+    expect(response.data[0].reward).toBe(0.5);
+    expect(mocks.pool.step).toHaveBeenCalledTimes(1);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('reports ok for a completed step when getTelemetrySnapshots rejects', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    mocks.pool.getTelemetrySnapshots.mockRejectedValueOnce(new Error('snapshot timeout'));
+
+    await initAndStepAtBoundary(12364);
+
+    const response = lastSentResponse();
+    expect(response.status).toBe('ok');
+    expect(response.data).toHaveLength(1);
+    expect(response.data[0].reward).toBe(0.5);
+    expect(mocks.pool.step).toHaveBeenCalledTimes(1);
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('skips the worker snapshot fetch in shared-memory mode', async () => {
+    mocks.pool.isUsingSharedMemory.mockReturnValueOnce(true);
+
+    await initAndStepAtBoundary(12365);
+
+    const response = lastSentResponse();
+    expect(response.status).toBe('ok');
+    expect(mocks.pool.getTelemetrySnapshots).not.toHaveBeenCalled();
+  });
+
+  it('skips the telemetry block entirely when telemetry is disabled', async () => {
+    mocks.isTelemetryEnabled.mockReturnValue(false);
+
+    await initAndStepAtBoundary(12366);
+
+    const response = lastSentResponse();
+    expect(response.status).toBe('ok');
+    expect(mocks.pool.getTelemetrySnapshots).not.toHaveBeenCalled();
+    expect(mocks.gpReport).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/profiler-flags-coverage.test.ts
+++ b/tests/unit/profiler-flags-coverage.test.ts
@@ -294,10 +294,25 @@ describe('Flags uncovered paths', () => {
       expect(flags.profileLevel).toBe('detailed');
     });
 
-    it('parses -p short alias', () => {
-      process.argv = ['node', 'script.js', '-p', 'minimal'];
+    it('parses -l short alias', () => {
+      process.argv = ['node', 'script.js', '-l', 'minimal'];
       const flags = parseFlags();
       expect(flags.profileLevel).toBe('minimal');
+    });
+
+    it('parses --profile-level long alias', () => {
+      process.argv = ['node', 'script.js', '--profile-level', 'detailed'];
+      const flags = parseFlags();
+      expect(flags.profileLevel).toBe('detailed');
+    });
+
+    it('does not treat -p as a profile alias (it belongs to --port, issue #184)', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      process.argv = ['node', 'script.js', '-p', 'minimal'];
+      const flags = parseFlags();
+      expect(flags.profileLevel).toBe('standard');
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
 
     it('warns on invalid profile level and uses default', () => {
@@ -622,6 +637,16 @@ describe('Flags uncovered paths', () => {
     it('returns true for --profile flag', () => {
       process.argv = ['node', 'script.js', '--profile', 'detailed'];
       expect(isAnyTelemetryEnabled()).toBe(true);
+    });
+
+    it('returns true for -l flag', () => {
+      process.argv = ['node', 'script.js', '-l', 'minimal'];
+      expect(isAnyTelemetryEnabled()).toBe(true);
+    });
+
+    it('returns false for -p flag (belongs to --port, issue #184)', () => {
+      process.argv = ['node', 'script.js', '-p', 'minimal'];
+      expect(isAnyTelemetryEnabled()).toBe(false);
     });
 
     it('returns true for --debug flag', () => {

--- a/tests/unit/worker-pool-failures.test.ts
+++ b/tests/unit/worker-pool-failures.test.ts
@@ -464,7 +464,7 @@ describe('WorkerPool failure state', () => {
     await pool.init(1, {}, true);
     await pool.reset([1]);
 
-    await expect(pool.step([0, 0])).rejects.toThrow('Invalid action batch: expected 1 actions for 1 environments, got 2');
+    await expect(pool.step([0, 0])).rejects.toThrow('Invalid action batch: expected 1 action for 1 environment, got 2');
 
     expect(fakes.FakeWorker.instances[0].terminated).toBe(false);
     await expect(pool.step([0])).resolves.toHaveLength(1);

--- a/tests/unit/worker-pool-failures.test.ts
+++ b/tests/unit/worker-pool-failures.test.ts
@@ -431,6 +431,60 @@ describe('WorkerPool failure state', () => {
     expect(results).toHaveLength(1);
   });
 
+  it('treats a short action batch in shared mode as a transient per-request error', async () => {
+    pool = new WorkerPool(1);
+    await pool.init(2, {}, true);
+    await pool.reset([1, 2]);
+
+    await expect(pool.step([0])).rejects.toThrow('Invalid action batch: expected 2 actions for 2 environments, got 1');
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(false);
+    expect(fakes.FakeSharedMemoryManager.instances[0].disposed).toBe(false);
+
+    const results = await pool.step([0, 0]);
+    expect(results).toHaveLength(2);
+    await expect(pool.reset([1, 2])).resolves.toHaveLength(2);
+  });
+
+  it('treats a short action batch in message mode as a transient per-request error', async () => {
+    pool = new WorkerPool(1);
+    await pool.init(2, {}, false);
+    await pool.reset([1, 2]);
+
+    await expect(pool.step([0])).rejects.toThrow('Invalid action batch: expected 2 actions for 2 environments, got 1');
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(false);
+
+    await expect(pool.step([0, 0])).resolves.toBeDefined();
+    expect((pool as any).state).toBe('ready');
+  });
+
+  it('rejects an over-long action batch without touching the pool', async () => {
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, true);
+    await pool.reset([1]);
+
+    await expect(pool.step([0, 0])).rejects.toThrow('Invalid action batch: expected 1 actions for 1 environments, got 2');
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(false);
+    await expect(pool.step([0])).resolves.toHaveLength(1);
+  });
+
+  it('treats an invalid (null) action in shared mode as a transient per-request error', async () => {
+    pool = new WorkerPool(1);
+    await pool.init(1, {}, true);
+    await pool.reset([1]);
+
+    await expect(pool.step([null as any])).rejects.toThrow('Invalid action: expected a PlayerInput object or an encoded number, got null');
+
+    expect(fakes.FakeWorker.instances[0].terminated).toBe(false);
+    expect(fakes.FakeSharedMemoryManager.instances[0].disposed).toBe(false);
+    expect((pool as any).state).toBe('ready');
+
+    const results = await pool.step([0]);
+    expect(results).toHaveLength(1);
+  });
+
   it('propagates telemetry snapshot errors without failing the pool', async () => {
     fakes.control.messageTimeoutMs = 20;
     pool = new WorkerPool(1);


### PR DESCRIPTION
## Summary

Fixes four worker-pool/IPC reliability issues in one focused PR.

### #191 — Short action batch in shared-memory step permanently fails the worker pool
- \WorkerPool.step()\ validates \ctions.length === totalEnvs\ up front in both transports, before any worker state is touched (mirrors the Python client's exact-count check).
- \IpcBridge.handleRequest()\ rejects wrong-sized batches against the initialized env count with a per-request error before calling the pool.
- \stepSharedMemory()\ encodes every action before signalling any worker; encoding errors are tagged \ACTION_ENCODE\ and treated as transient, so \ailPool()\ is reserved for worker crash/timeout/post-signal failures.
- \encodeAction()\ throws a labeled error for null/undefined entries instead of an unlabelled TypeError.
- Regression tests: unit (shared + message recovery), integration with real workers, DEALER-socket level over a real ZMQ socket.

### #185 — Post-step telemetry failure discards the completed step reply
- The telemetry block is isolated in its own try/catch; failures are logged and the already-serialized ok reply is sent unchanged.
- The worker-snapshot fetch is skipped in shared-memory mode (workers blocked in Atomics.wait can never service GET_TELEMETRY), removing the deterministic 30s hang + error reply on every 5000th step.
- Regression tests: recordMemory() throwing, snapshot rejection, shared-mode skip, telemetry disabled.

### #183 — Shared-memory reset with fewer seeds than envs replays stale seeds
- \writeSeeds()\ fills the whole seed view with the no-seed sentinel (0) before applying the given seeds, so tail envs are left unseeded (RNG stream continues) exactly as in message mode.
- Regression tests: SharedMemoryManager unit test + deterministic end-to-end parity test.

### #184 — CLI flag -p collision (port vs profile level)
- Telemetry profile now uses \--profile-level\ / \-l\; \-p\ is no longer a telemetry alias (it remains the \--port\ short form).
- README/docs flag tables and precedence section corrected.
- Tests updated: \-l\ / \--profile-level\ parsing, \-p\ no longer treated as a profile flag.

## Validation
- \
pm run typecheck\: 0 errors
- \
pm test\: 51 files, 1182 passed / 19 skipped (baseline 1160 passed / 19 skipped)
- \git diff --check\: clean

Fixes #191
Fixes #185
Fixes #183
Fixes #184