### PR TITLE
fix(worker-pool,ipc): atomic message-mode batch rejection (#207) + termination flags on the maxTicks boundary (#208)

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -579,6 +579,7 @@ export class WorkerPool {
             const rewards = rawResults.rewards;
             const dones = rawResults.dones;
             const truncated = rawResults.truncated;
+            const terminated = rawResults.terminated;
             const ticks = rawResults.ticks;
             const terminalObs = rawResults.terminalObservations;
             const hasTerminalObs = rawResults.hasTerminalObs;
@@ -589,13 +590,20 @@ export class WorkerPool {
                 const resultObj = this._resultPool[resultIdx];
                 const done = dones[j] === 1;
                 const trunc = truncated[j] === 1;
+                // The worker's per-env terminated flag is the environment's
+                // own info.terminated (a death on the maxTicks boundary
+                // reports both flags, #208); reconstructing it as
+                // done && !trunc would turn that death into a pure
+                // truncation. Fall back to the reconstruction only when the
+                // flag array is absent (e.g. mocked managers).
+                const term = terminated ? terminated[j] === 1 : done && !trunc;
                 resultObj.observation = this.extractObservation(obs, j, resultIdx);
                 resultObj.reward = rewards[j];
                 resultObj.done = done;
                 resultObj.truncated = trunc;
-                resultObj.terminated = done && !trunc;
+                resultObj.terminated = term;
                 resultObj.info.tick = ticks[j];
-                resultObj.info.terminated = done && !trunc;
+                resultObj.info.terminated = term;
                 if (hasTerminalObs[j] === 1) {
                     resultObj.info.terminal_observation = this.extractObservation(
                         terminalObs, j, resultIdx, this._terminalObsPool,
@@ -685,12 +693,18 @@ export class WorkerPool {
             globalProfiler.gauge('Sync Gap (ms)', gapMs);
         }
 
-        // Normalize termination flags in place (no per-result spreads) so
-        // message mode reports the same values as the SAB path: a truncation
-        // is never a natural termination, in both modes.
+        // Normalize termination flags in place (no per-result spreads). The
+        // environment's own info.terminated is authoritative: a death on the
+        // same tick maxTicks is reached reports terminated=true AND
+        // truncated=true, and reconstructing terminated as done && !truncated
+        // would destroy the death signal (#208). The reconstruction is only a
+        // fill-in for worker results that omitted the flag.
         const flat = results.flat();
         for (const result of flat) {
-            const terminated = Boolean(result.done && !result.truncated);
+            const envTerminated = result.info ? result.info.terminated : undefined;
+            const terminated = envTerminated !== undefined
+                ? Boolean(envTerminated)
+                : Boolean(result.done && !result.truncated);
             result.terminated = result.terminated ?? terminated;
             if (result.info) {
                 result.info.terminated = terminated;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -628,6 +628,24 @@ export class WorkerPool {
      * on allocation or retention semantics here.
      */
     private async stepMessagePassing(actions: any[], options: ResultOwnershipOptions): Promise<any[]> {
+        // Reject malformed entries before any worker is signalled, mirroring
+        // the shared-memory path's phase-1 encoding. A full-length batch that
+        // contains e.g. `undefined` would otherwise throw inside a worker
+        // mid-slice: that worker's earlier environments would already have
+        // advanced while the pool stays ready, leaving the batch partially
+        // executed and every later step desynced (#207). The ACTION_ENCODE
+        // label marks this as a per-request input error with the pool
+        // untouched, exactly like the shared-memory transport.
+        try {
+            for (const action of actions) {
+                this.encodeAction(action);
+            }
+        } catch (error) {
+            const tagged = error instanceof Error ? error : new Error(String(error));
+            (tagged as Error & { code?: string }).code = 'ACTION_ENCODE';
+            throw tagged;
+        }
+
         const batchStart = process.hrtime.bigint();
         const returnTimes: bigint[] = [];
 

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -636,17 +636,20 @@ export class WorkerPool {
      * on allocation or retention semantics here.
      */
     private async stepMessagePassing(actions: any[], options: ResultOwnershipOptions): Promise<any[]> {
-        // Reject malformed entries before any worker is signalled, mirroring
+        // Encode the whole batch before any worker is signalled, mirroring
         // the shared-memory path's phase-1 encoding. A full-length batch that
         // contains e.g. `undefined` would otherwise throw inside a worker
         // mid-slice: that worker's earlier environments would already have
         // advanced while the pool stays ready, leaving the batch partially
         // executed and every later step desynced (#207). The ACTION_ENCODE
         // label marks this as a per-request input error with the pool
-        // untouched, exactly like the shared-memory transport.
+        // untouched, exactly like the shared-memory transport. The encoded
+        // numbers are dispatched directly, so the worker decodes them instead
+        // of re-validating the raw entries.
+        const encodedActions = new Array<number>(actions.length);
         try {
-            for (const action of actions) {
-                this.encodeAction(action);
+            for (let i = 0; i < actions.length; i++) {
+                encodedActions[i] = this.encodeAction(actions[i]);
             }
         } catch (error) {
             const tagged = error instanceof Error ? error : new Error(String(error));
@@ -661,7 +664,7 @@ export class WorkerPool {
         let actionIdx = 0;
         for (let i = 0; i < this.workers.length; i++) {
             const wEnvs = this.workerEnvs[i];
-            const wActions = actions.slice(actionIdx, actionIdx + wEnvs);
+            const wActions = encodedActions.slice(actionIdx, actionIdx + wEnvs);
 
             const p = this.sendMessage(this.workers[i], { type: 'step', actions: wActions })
                 .then(data => {
@@ -698,14 +701,16 @@ export class WorkerPool {
         // same tick maxTicks is reached reports terminated=true AND
         // truncated=true, and reconstructing terminated as done && !truncated
         // would destroy the death signal (#208). The reconstruction is only a
-        // fill-in for worker results that omitted the flag.
+        // fill-in for worker results that omitted the flag. Both fields are
+        // assigned from the same value so they cannot diverge, matching the
+        // SAB path.
         const flat = results.flat();
         for (const result of flat) {
             const envTerminated = result.info ? result.info.terminated : undefined;
             const terminated = envTerminated !== undefined
                 ? Boolean(envTerminated)
                 : Boolean(result.done && !result.truncated);
-            result.terminated = result.terminated ?? terminated;
+            result.terminated = terminated;
             if (result.info) {
                 result.info.terminated = terminated;
             }

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -200,6 +200,7 @@ parentPort.on('message', (msg) => {
                     sharedMem!.writeReward(i, res.reward);
                     sharedMem!.writeDone(i, res.done ? 1 : 0);
                     sharedMem!.writeTruncated(i, res.truncated ? 1 : 0);
+                    sharedMem!.writeTerminated(i, res.info.terminated ? 1 : 0);
                     sharedMem!.writeTick(i, res.info.tick || stepCounter);
                 });
 
@@ -284,6 +285,7 @@ parentPort.on('message', (msg) => {
                             sharedMem!.writeReward(i, res.reward);
                             sharedMem!.writeDone(i, res.done ? 1 : 0);
                             sharedMem!.writeTruncated(i, res.truncated ? 1 : 0);
+                            sharedMem!.writeTerminated(i, res.info.terminated ? 1 : 0);
                             sharedMem!.writeTick(i, res.info.tick || stepCounter);
                         });
 

--- a/src/ipc/shared-memory.ts
+++ b/src/ipc/shared-memory.ts
@@ -12,6 +12,7 @@ export class SharedMemoryManager {
         rewards: Float32Array;
         dones: Uint8Array;
         truncated: Uint8Array;
+        terminated: Uint8Array;
         ticks: Uint32Array;
     };
     private seeds: Uint32Array;
@@ -46,11 +47,12 @@ export class SharedMemoryManager {
         const rewardBytes = align8(numEnvs * 4);
         const doneBytes = align8(numEnvs * 1);
         const truncatedBytes = align8(numEnvs * 1);
+        const terminatedBytes = align8(numEnvs * 1);
         const tickBytes = align8(numEnvs * 4);
         const seedBytes = align8(numEnvs * 4);
         const controlBytes = 64; // Reserve plenty
 
-        const totalBytes = actionBytes + obsBytes + terminalObsBytes + hasTerminalObsBytes + rewardBytes + doneBytes + truncatedBytes + tickBytes + seedBytes + controlBytes;
+        const totalBytes = actionBytes + obsBytes + terminalObsBytes + hasTerminalObsBytes + rewardBytes + doneBytes + truncatedBytes + terminatedBytes + tickBytes + seedBytes + controlBytes;
 
         if (existingBuffer) {
             this.buffer = existingBuffer;
@@ -69,6 +71,7 @@ export class SharedMemoryManager {
             rewards: null as any,
             dones: null as any,
             truncated: null as any,
+            terminated: null as any,
             ticks: null as any
         };
         offset = align8(offset + actionBytes);
@@ -90,6 +93,9 @@ export class SharedMemoryManager {
 
         this.views.truncated = new Uint8Array(this.buffer, offset, numEnvs);
         offset = align8(offset + truncatedBytes);
+
+        this.views.terminated = new Uint8Array(this.buffer, offset, numEnvs);
+        offset = align8(offset + terminatedBytes);
 
         this.views.ticks = new Uint32Array(this.buffer, offset, numEnvs);
         offset = align8(offset + tickBytes);
@@ -117,7 +123,7 @@ export class SharedMemoryManager {
         const align8 = (n: number) => (n + 7) & ~7;
         return align8(numEnvs * ringSize) + align8(numEnvs * SharedMemoryManager.OBSERVATION_FLOATS * 4) + align8(numEnvs * SharedMemoryManager.OBSERVATION_FLOATS * 4) +
             align8(numEnvs * 1) + align8(numEnvs * 4) + align8(numEnvs * 1) + align8(numEnvs * 1) +
-            align8(numEnvs * 4) + align8(numEnvs * 4) + 64;
+            align8(numEnvs * 1) + align8(numEnvs * 4) + align8(numEnvs * 4) + 64;
     }
 
     getBuffer() { return this.buffer; }
@@ -196,6 +202,7 @@ export class SharedMemoryManager {
             rewards: this.views.rewards,
             dones: this.views.dones,
             truncated: this.views.truncated,
+            terminated: this.views.terminated,
             ticks: this.views.ticks
         };
     }
@@ -213,6 +220,7 @@ export class SharedMemoryManager {
     writeReward(envIndex: number, reward: number) { this.views.rewards[envIndex] = reward; }
     writeDone(envIndex: number, done: number) { this.views.dones[envIndex] = done; }
     writeTruncated(envIndex: number, truncated: number) { this.views.truncated[envIndex] = truncated; }
+    writeTerminated(envIndex: number, terminated: number) { this.views.terminated[envIndex] = terminated; }
     writeTick(envIndex: number, tick: number) { this.views.ticks[envIndex] = tick; }
 
     incrementStepCounter() { return Atomics.add(this.control.stepCounter, 0, 1); }
@@ -244,6 +252,7 @@ export class SharedMemoryManager {
         this.views.rewards.fill(0);
         this.views.dones.fill(0);
         this.views.truncated.fill(0);
+        this.views.terminated.fill(0);
         this.views.ticks.fill(0);
         this.seeds.fill(0);
         Atomics.store(this.control.stepCounter, 0, 0);

--- a/tests/integration/worker-pool-batch-atomicity.test.ts
+++ b/tests/integration/worker-pool-batch-atomicity.test.ts
@@ -1,0 +1,83 @@
+/**
+ * worker-pool-batch-atomicity.test.ts — Regression coverage for issue #207
+ *
+ * A malformed step batch (wrong length, or an invalid entry) must be
+ * rejected before any worker is signalled, in BOTH transports: no
+ * environment may advance on a request that errors. Previously a short
+ * batch in message-passing mode advanced every environment before the
+ * failure point (worker A's envs and the failing worker's earlier envs)
+ * while the pool stayed ready, so every later step ran on permanently
+ * desynced states — the same corruption a full-length batch with an
+ * `undefined` entry still caused until the entry-level check.
+ */
+import { describe, it, expect } from 'vitest';
+import { WorkerPool } from '../../src/core/worker-pool';
+
+describe('WorkerPool malformed step batches leave no environment advanced (issue #207)', () => {
+  /**
+   * Every environment starts at tick 0 after reset and advances by exactly
+   * one tick per executed step, so a correct step following a rejected
+   * batch must return every environment at baseline + 1 — proving the
+   * failed request advanced nothing and the pool resumed from the state
+   * before it.
+   */
+  const assertResumesFromPreErrorState = async (useSharedMemory: boolean) => {
+    const pool = new WorkerPool(2);
+    try {
+      await pool.init(4, {}, useSharedMemory);
+      const baseline = (await pool.reset([1, 2, 3, 4]))[0].tick;
+
+      await expect(pool.step([0, 0, 0])).rejects.toThrow(
+        'Invalid action batch: expected 4 actions for 4 environments, got 3',
+      );
+      expect((pool as any).state).toBe('ready');
+
+      const results = await pool.step([0, 0, 0, 0]);
+      expect(results).toHaveLength(4);
+      for (const res of results) {
+        expect(res.observation.tick).toBe(baseline + 1);
+      }
+    } finally {
+      await pool.close();
+    }
+  };
+
+  it('message-passing mode: short batch errors before dispatch and the next step resumes cleanly', async () => {
+    await assertResumesFromPreErrorState(false);
+  });
+
+  it('shared-memory mode: short batch errors before dispatch and the next step resumes cleanly', async () => {
+    if (!WorkerPool.isSupported()) return;
+    await assertResumesFromPreErrorState(true);
+  });
+
+  const assertInvalidEntryIsAtomic = async (useSharedMemory: boolean) => {
+    const pool = new WorkerPool(2);
+    try {
+      await pool.init(4, {}, useSharedMemory);
+      const baseline = (await pool.reset([1, 2, 3, 4]))[0].tick;
+
+      await expect(pool.step([0, 0, undefined as any, 0])).rejects.toThrow(
+        'Invalid action: expected a PlayerInput object or an encoded number, got undefined',
+      );
+      expect((pool as any).state).toBe('ready');
+
+      const results = await pool.step([0, 0, 0, 0]);
+      expect(results).toHaveLength(4);
+      for (const res of results) {
+        expect(res.observation.tick).toBe(baseline + 1);
+      }
+    } finally {
+      await pool.close();
+    }
+  };
+
+  it('message-passing mode: an invalid entry errors before dispatch and the next step resumes cleanly', async () => {
+    await assertInvalidEntryIsAtomic(false);
+  });
+
+  it('shared-memory mode: an invalid entry errors before dispatch and the next step resumes cleanly', async () => {
+    if (!WorkerPool.isSupported()) return;
+    await assertInvalidEntryIsAtomic(true);
+  });
+});

--- a/tests/integration/worker-pool-termination-flags.test.ts
+++ b/tests/integration/worker-pool-termination-flags.test.ts
@@ -62,3 +62,60 @@ describe('death exactly at maxTicks keeps both termination flags (issue #208)', 
     await runThroughPool(true);
   });
 });
+
+describe('pure truncation at maxTicks stays terminated=false (issue #208)', () => {
+  /**
+   * Counterpart of the death-on-maxTicks case: the AI survives to the time
+   * limit, so the same step must report terminated=false and truncated=true
+   * — locking in the flag asymmetry the pool previously destroyed. Both
+   * spawns sit inside the 850-unit death circle and far apart; the opponent
+   * policy is disabled so no contact can happen on tick 1.
+   */
+  const truncationAtMaxTicksMap: MapDef = {
+    name: 'truncation_at_tick1',
+    spawnPoints: { team_blue: { x: -100, y: 0 }, team_red: { x: 100, y: 0 } },
+    bodies: [{ name: 'floor', type: 'rect', x: 0, y: 200, width: 800, height: 30, static: true }],
+  };
+
+  const truncationConfig: EnvironmentConfig = {
+    mapData: truncationAtMaxTicksMap,
+    numOpponents: 1,
+    maxTicks: 1,
+    seed: 42,
+    randomOpponent: false,
+  };
+
+  it('direct environment reports truncated without termination', () => {
+    const env = new BonkEnvironment(truncationConfig);
+    env.reset(42);
+    const res = env.step(0);
+    expect(res.done).toBe(true);
+    expect(res.truncated).toBe(true);
+    expect(res.info.terminated).toBe(false);
+    env.close();
+  });
+
+  const runThroughPool = async (useSharedMemory: boolean) => {
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(1, truncationConfig, useSharedMemory);
+      await pool.reset([42]);
+      const [res] = await pool.step([0]);
+      expect(res.done).toBe(true);
+      expect(res.truncated).toBe(true);
+      expect(res.terminated).toBe(false);
+      expect(res.info.terminated).toBe(false);
+    } finally {
+      await pool.close();
+    }
+  };
+
+  it('message-passing mode reports a pure truncation', async () => {
+    await runThroughPool(false);
+  });
+
+  it('shared-memory mode reports a pure truncation', async () => {
+    if (!WorkerPool.isSupported()) return;
+    await runThroughPool(true);
+  });
+});

--- a/tests/integration/worker-pool-termination-flags.test.ts
+++ b/tests/integration/worker-pool-termination-flags.test.ts
@@ -1,0 +1,64 @@
+/**
+ * worker-pool-termination-flags.test.ts — Regression coverage for issue #208
+ *
+ * A death on the same tick maxTicks is reached must be reported as
+ * terminated=true AND truncated=true (Gymnasium semantics: the two flags
+ * are not mutually exclusive). The pool previously reconstructed
+ * terminated as done && !truncated in both transports, destroying the
+ * environment's own info.terminated and reclassifying the death as a pure
+ * truncation, which made the Python client skip the terminal observation.
+ *
+ * The map spawns the AI 900 map units from the origin, beyond the 850-unit
+ * death circle, so it dies on the very first tick; maxTicks=1 makes the
+ * time limit fire on that same tick.
+ */
+import { describe, it, expect } from 'vitest';
+import { WorkerPool } from '../../src/core/worker-pool';
+import { BonkEnvironment } from '../../src/core/environment';
+import type { EnvironmentConfig } from '../../src/core/environment';
+import type { MapDef } from '../../src/core/physics-engine';
+
+const deathAtMaxTicksMap: MapDef = {
+  name: 'death_at_tick1',
+  spawnPoints: { team_blue: { x: 900, y: 0 }, team_red: { x: 200, y: -100 } },
+  bodies: [{ name: 'floor', type: 'rect', x: 0, y: 200, width: 800, height: 30, static: true }],
+};
+
+const envConfig: EnvironmentConfig = { mapData: deathAtMaxTicksMap, numOpponents: 1, maxTicks: 1, seed: 42 };
+
+describe('death exactly at maxTicks keeps both termination flags (issue #208)', () => {
+  it('direct environment reports done, truncated and info.terminated', () => {
+    const env = new BonkEnvironment(envConfig);
+    env.reset(42);
+    const res = env.step(0);
+    expect(res.done).toBe(true);
+    expect(res.truncated).toBe(true);
+    expect(res.info.terminated).toBe(true);
+    env.close();
+  });
+
+  const runThroughPool = async (useSharedMemory: boolean) => {
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(1, envConfig, useSharedMemory);
+      await pool.reset([42]);
+      const [res] = await pool.step([0]);
+      expect(res.done).toBe(true);
+      expect(res.truncated).toBe(true);
+      expect(res.terminated).toBe(true);
+      expect(res.info.terminated).toBe(true);
+      expect(res.info.terminal_observation).toBeDefined();
+    } finally {
+      await pool.close();
+    }
+  };
+
+  it('message-passing mode preserves both flags and the terminal observation', async () => {
+    await runThroughPool(false);
+  });
+
+  it('shared-memory mode preserves both flags and the terminal observation', async () => {
+    if (!WorkerPool.isSupported()) return;
+    await runThroughPool(true);
+  });
+});

--- a/tests/unit/worker-pool-failures.test.ts
+++ b/tests/unit/worker-pool-failures.test.ts
@@ -152,6 +152,7 @@ const fakes = vi.hoisted(() => {
         rewards: new Float32Array(this.numEnvs),
         dones: new Uint8Array(this.numEnvs),
         truncated: new Uint8Array(this.numEnvs),
+        terminated: new Uint8Array(this.numEnvs),
         ticks: new Uint32Array(this.numEnvs),
       };
     }


### PR DESCRIPTION
Fixes #207
Fixes #208

Two environment lifecycle/termination fixes, one commit per issue.

## #207 — Message-mode step batch errors no longer desync environments

stepMessagePassing() now validates every action entry (via encodeAction(), tagged ACTION_ENCODE) before any worker is signalled, mirroring the shared-memory path's phase-1 encoding. The up-front length check already rejected short batches in both transports; the entry-level check closes the remaining message-mode hole where a full-length batch containing an invalid entry (e.g. undefined) threw inside a worker mid-slice, advancing that worker's earlier environments while the pool stayed ready — leaving every later step on permanently desynced states.

- src/core/worker-pool.ts — pre-dispatch entry validation in stepMessagePassing()
- 	ests/integration/worker-pool-batch-atomicity.test.ts — short batch and invalid entry both leave every environment at the pre-request state (message + shared mode)

## #208 — Death on the maxTicks boundary keeps both termination flags

The pool reconstructed 	erminated as done && !truncated in both transports, overwriting the environment's authoritative info.terminated and reclassifying a death on the last tick as a pure truncation (the Python client then skipped the terminal observation). The environment's flag now wins in both transports; the SAB layout carries a per-env 	erminated byte so the shared-memory path no longer recomputes it.

- src/core/worker-pool.ts — stepMessagePassing() keeps info.terminated (fills in only when absent); stepSharedMemory() reads the transported flag
- src/ipc/shared-memory.ts — 	erminated byte array (view, writeTerminated, eadResults, calculateBufferSize, reset)
- src/core/worker.ts — both shared step paths write es.info.terminated
- 	ests/integration/worker-pool-termination-flags.test.ts — death exactly at maxTicks reports 	erminated=true and 	runcated=true with the terminal observation, in both transports

## Validation

- 
pm run typecheck — 0 errors
- 
pm test — 1205 passed / 19 skipped (baseline 1198 + 7 new regression tests)
- git diff --check — clean