### PR TITLE
fix(physics): map-relative OOB death circle (#206) and contested cap-zone countdown gate (#214)

### DIFF
--- a/maps/bonk_Ball_Pit_524616.json
+++ b/maps/bonk_Ball_Pit_524616.json
@@ -9,6 +9,12 @@
       "y": 370
     }
   },
+  "physics": {
+    "deathCenter": {
+      "x": 730,
+      "y": 500
+    }
+  },
   "capZones": [],
   "bodies": [
     {

--- a/maps/bonk_Simple_1v1_123.json
+++ b/maps/bonk_Simple_1v1_123.json
@@ -9,6 +9,12 @@
       "y": 450
     }
   },
+  "physics": {
+    "deathCenter": {
+      "x": 730,
+      "y": 500
+    }
+  },
   "capZones": [],
   "bodies": [
     {

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -145,6 +145,8 @@ export class BonkEnvironment {
     private ppm: number = 12;
     private capZones: Array<{ index: number; owner: string; type: number }> = [];
     private mapBounds: { width: number; height: number } | null = null;
+    /** Map-relative OOB death-circle center (physics.deathCenter), if declared. */
+    private mapDeathCenter: { x: number; y: number } | null = null;
 
     constructor(config: Partial<EnvironmentConfig> = {}) {
         // Normalize config: accept both camelCase and snake_case
@@ -239,6 +241,17 @@ export class BonkEnvironment {
         // Cache explicit map bounds — reset() re-adds bodies, which recomputes
         // dynamic bounds, so the override must be re-applied after every reset.
         this.mapBounds = (mapDef as any).physics?.bounds ?? null;
+
+        // Cache the map's OOB death-circle center (physics.deathCenter). The
+        // native death circle is centered on the map's authored origin (850 map
+        // units, DEOBFUSCATION "Death Type 4"); exported maps whose coordinates
+        // are offset from the world origin carry that center here. Maps without
+        // one use the engine default (world origin), preserving origin-centered
+        // behavior for hand-built maps.
+        this.mapDeathCenter = (mapDef as any).physics?.deathCenter ?? null;
+        if (this.mapDeathCenter && typeof (this.physics as any).setDeathCircleCenter === 'function') {
+            this.physics.setDeathCircleCenter(this.mapDeathCenter.x, this.mapDeathCenter.y);
+        }
 
         this.reset();
     }
@@ -339,6 +352,12 @@ export class BonkEnvironment {
         // dynamic bounds and would otherwise clobber the override every reset.
         if (this.mapBounds && typeof (this.physics as any).setMapBounds === 'function') {
             this.physics.setMapBounds(this.mapBounds.width, this.mapBounds.height);
+        }
+
+        // Re-apply the map's OOB death-circle center — like mapBounds it is a
+        // map-level override that must survive the fresh world of every reset.
+        if (this.mapDeathCenter && typeof (this.physics as any).setDeathCircleCenter === 'function') {
+            this.physics.setDeathCircleCenter(this.mapDeathCenter.x, this.mapDeathCenter.y);
         }
 
         // Reset frame skip state

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -677,6 +677,17 @@ export class PhysicsEngine {
    * disc radius never widens or shrinks the boundary).
    */
   setDeathCircleCenter(centerXMapUnits: number, centerYMapUnits: number): void {
+    // A non-finite center would make every OOB distance check NaN, and NaN >
+    // threshold is false, silently disabling OOB elimination map-wide. Guard
+    // so the death circle is always defined: ignore the bad input and keep the
+    // previous (default-origin or last-valid) center.
+    if (!Number.isFinite(centerXMapUnits) || !Number.isFinite(centerYMapUnits)) {
+      console.warn(
+        `setDeathCircleCenter ignoring non-finite center (${centerXMapUnits}, ${centerYMapUnits}); ` +
+          `keeping the previous death-circle center so OOB elimination stays enabled`,
+      );
+      return;
+    }
     this.oobCenterX = centerXMapUnits / SCALE;
     this.oobCenterY = centerYMapUnits / SCALE;
   }
@@ -1282,9 +1293,14 @@ export class PhysicsEngine {
     this.platformBodies = [];
     this.platformBodyMap = new Map();
     this.tickCount = 0;
-    // oobCenterX/oobCenterY are deliberately preserved: like teamsEnabled and
-    // noCollide they are map-level configuration, not per-episode state. The
-    // environment re-applies physics.deathCenter after every reset anyway.
+    // Reset the OOB death-circle center to the origin default. Although it is
+    // map-level configuration, it must not survive across maps: reusing this
+    // engine for a map without a physics.deathCenter would otherwise keep a
+    // stale center from the previous map and shift (never disable) the death
+    // circle. The environment re-applies deathCenter after every reset for maps
+    // that define it; maps without one fall back to the origin default.
+    this.oobCenterX = 0;
+    this.oobCenterY = 0;
   }
 
   /**

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -1101,9 +1101,16 @@ export class PhysicsEngine {
     }
   }
 
+  /**
+   * Timed cap-zone (type 1) completion countdown, gated on the native
+   * `while (p >= l)` rule (DEOBFUSCATION §34.6, lines 3698-3703): the f
+   * countdown only advances while the zone progress is at the limit, so a
+   * contested zone (p < l) pauses the timer and a takeover team must hold
+   * the zone to the limit before the capture fires.
+   */
   private processCapZoneCountdowns(): void {
     for (const [, state] of this.capZoneState) {
-      if (state.f > 0) {
+      if (state.f > 0 && state.p >= state.l) {
         state.f--;
         if (state.f === 0) {
           const ownerTeam = state.ot;

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -175,7 +175,14 @@ export interface MapDef {
   bodies: MapBodyDef[];
   capZones?: Array<{ index: number; owner: string; type: number; fixture: string; shapeType: string; l?: number }>;
   joints?: Array<{ type: string; bodyA: string; bodyB: string; anchorA?: { x: number; y: number }; anchorB?: { x: number; y: number }; localAnchorA?: { x: number; y: number }; localAnchorB?: { x: number; y: number }; length?: number; frequencyHz?: number; dampingRatio?: number; collideConnected?: boolean }>;
-  physics?: { ppm?: number; bounds?: { width: number; height: number } };
+  physics?: {
+    ppm?: number;
+    bounds?: { width: number; height: number };
+    /** Map-relative out-of-bounds death-circle center in map units. When absent
+     * the engine keeps the world origin, which is correct for maps authored
+     * around the origin (see setDeathCircleCenter). */
+    deathCenter?: { x: number; y: number };
+  };
 }
 
 // ─── PhysicsEngine ───────────────────────────────────────────────────
@@ -230,6 +237,10 @@ export class PhysicsEngine {
   private lastHitTicks: Map<number, number> = new Map();
   /** Cached squared OOB radius so tick() avoids per-player Math.sqrt. */
   private oobRadiusSquared: number = Math.pow(OUT_OF_BOUNDS_DISTANCE / SCALE, 2);
+  /** OOB death-circle center in world units. Defaults to the world origin;
+   * setDeathCircleCenter() moves it to the map center for exported maps. */
+  private oobCenterX: number = 0;
+  private oobCenterY: number = 0;
   /** Reused by getArenaBounds so the zero-GC observation path allocates nothing per step. */
   private _arenaBoundsCache: { halfWidth: number; halfHeight: number } = { halfWidth: 0, halfHeight: 0 };
 
@@ -649,6 +660,27 @@ export class PhysicsEngine {
     }
   }
 
+  /**
+   * Sets the out-of-bounds death-circle center in map coordinates.
+   *
+   * Native semantics (DEOBFUSCATION "Death Type 4"): a disc dies with
+   * deathType 4 when its center is more than 850 map units from the map
+   * center. The native engine authors maps around the world origin (editor
+   * canvas 730×500 with the world origin at the canvas center, §33.5), so
+   * its `GetPosition().Length()` check is origin-relative only because the
+   * map center IS the world origin. Exported maps carry their map-center
+   * offset in the fixture data (`physics.deathCenter`); maps already
+   * centered on the world origin keep the default (0, 0).
+   *
+   * The radius is unchanged: OUT_OF_BOUNDS_DISTANCE (850) map units from
+   * this center, measured to the disc center (native GetPosition, so the
+   * disc radius never widens or shrinks the boundary).
+   */
+  setDeathCircleCenter(centerXMapUnits: number, centerYMapUnits: number): void {
+    this.oobCenterX = centerXMapUnits / SCALE;
+    this.oobCenterY = centerYMapUnits / SCALE;
+  }
+
   getBodyMap(): Map<string, any> {
     return this.platformBodyMap;
   }
@@ -1047,8 +1079,12 @@ export class PhysicsEngine {
     for (const [id, body] of Array.from(this.playerBodies)) {
       if (this.playerAlive.get(id)) {
         // Squared comparison avoids a per-player Math.sqrt; threshold identical.
+        // Distance is measured from the OOB death-circle center (defaults to
+        // the world origin; setDeathCircleCenter moves it to the map center).
         const pos = body.GetPosition();
-        if (pos.x * pos.x + pos.y * pos.y > this.oobRadiusSquared) {
+        const dx = pos.x - this.oobCenterX;
+        const dy = pos.y - this.oobCenterY;
+        if (dx * dx + dy * dy > this.oobRadiusSquared) {
           this.playerAlive.set(id, false);
           this.playerDeathType.set(id, 4);
           globalProfiler.increment('death_out_of_bounds');
@@ -1239,6 +1275,9 @@ export class PhysicsEngine {
     this.platformBodies = [];
     this.platformBodyMap = new Map();
     this.tickCount = 0;
+    // oobCenterX/oobCenterY are deliberately preserved: like teamsEnabled and
+    // noCollide they are map-level configuration, not per-episode state. The
+    // environment re-applies physics.deathCenter after every reset anyway.
   }
 
   /**

--- a/tests/integration/capzone-scoring.test.ts
+++ b/tests/integration/capzone-scoring.test.ts
@@ -387,6 +387,114 @@ describe('CapZoneScoring', () => {
             expect(engine.getPlayerState(1).deathType).toBe(3);
             expect(engine.getPlayerState(0).alive).toBe(true);
         });
+
+        // Native completion semantics (DEOBFUSCATION §34.6, lines 3698-3703):
+        // the whole completion block runs `while (p >= l)` — the f countdown
+        // only advances while the zone progress is at the limit, so a contested
+        // zone (p < l) pauses the timer and the capture only fires at f == 0
+        // while the holder keeps p at the limit.
+        it('capture countdown pauses while the zone is contested and only resumes after the holder regains p >= l', () => {
+            engine = new PhysicsEngine();
+
+            engine.addBody({
+                name: 'floor', type: 'rect',
+                x: 0, y: 600, width: 2000, height: 30,
+                static: true,
+            });
+
+            engine.addCapZone(
+                { index: 0, owner: 'neutral', type: 1, fixture: 'zone', shapeType: 'bx', l: 0.1 },
+                0, 540, 400, 300,
+            );
+
+            engine.addPlayer(0, 0, 400);    // red holder, rests inside the zone
+            engine.setPlayerTeam(0, 'red');
+            engine.addPlayer(1, 500, 400); // blue, outside the zone
+            engine.setPlayerTeam(1, 'blue');
+
+            // Red holds the zone alone: real contact events fill p to l and
+            // start the f = 20 countdown.
+            for (let i = 0; i < 8; i++) engine.tick();
+            let s: any = (engine as any).capZoneState.get(0);
+            expect(s.p).toBe(s.l);
+            expect(s.f).toBeGreaterThan(0);
+            expect(engine.getTeamScored()).toBe(null);
+
+            // Blue enters and contests: progress drops below the limit and the
+            // running countdown must pause instead of completing the capture.
+            s.p = 0;
+            s.f = 5;
+            for (let i = 0; i < 6; i++) {
+                (engine as any).capZoneTouches.push({ zoneIndex: 0, playerId: 1, team: 'blue' });
+                engine.tick();
+            }
+            s = (engine as any).capZoneState.get(0);
+            expect(s.p).toBe(0);
+            expect(s.f).toBe(5);
+            expect(engine.getTeamScored()).toBe(null);
+            expect(engine.getPlayerState(0).alive).toBe(true);
+            expect(engine.getPlayerState(1).alive).toBe(true);
+
+            // Blue leaves the zone: red alone re-fills p to the limit and the
+            // paused countdown resumes from 5 — the capture fires only after
+            // the re-hold, not for the contested interval.
+            for (let i = 0; i < 10; i++) engine.tick();
+            expect(engine.getTeamScored()).toBe('red');
+            expect(engine.getPlayerState(1).alive).toBe(false);
+            expect(engine.getPlayerState(1).deathType).toBe(3);
+            expect(engine.getPlayerState(0).alive).toBe(true);
+        });
+
+        it('a takeover team that never completed the hold cannot win; the capture fires only after it holds p >= l', () => {
+            engine = new PhysicsEngine();
+
+            engine.addBody({
+                name: 'floor', type: 'rect',
+                x: 0, y: 600, width: 2000, height: 30,
+                static: true,
+            });
+
+            engine.addCapZone(
+                { index: 0, owner: 'neutral', type: 1, fixture: 'zone', shapeType: 'bx', l: 0.1 },
+                0, 540, 400, 300,
+            );
+
+            engine.addPlayer(0, 0, 400);    // red holder, rests inside the zone
+            engine.setPlayerTeam(0, 'red');
+            engine.addPlayer(1, 500, 400); // blue, outside the zone
+            engine.setPlayerTeam(1, 'blue');
+
+            // Red holds the zone alone: p fills to l and the countdown starts.
+            for (let i = 0; i < 8; i++) engine.tick();
+            let s: any = (engine as any).capZoneState.get(0);
+            expect(s.p).toBe(s.l);
+            expect(s.f).toBeGreaterThan(0);
+
+            // Blue takes over mid-countdown while the holder dies: ownership
+            // transfers with progress reset to 0 and f still running.
+            s.p = 0;
+            s.o = 1;
+            s.ot = 'blue';
+            s.f = 5;
+            (engine as any).detachPlayer(0, (engine as any).playerBodies.get(0));
+
+            // Blue alone must complete the hold: p refills to l before the
+            // paused countdown resumes from 5. While p < l nothing fires.
+            for (let i = 0; i < 5; i++) {
+                (engine as any).capZoneTouches.push({ zoneIndex: 0, playerId: 1, team: 'blue' });
+                engine.tick();
+            }
+            expect(engine.getTeamScored()).toBe(null);
+
+            for (let i = 0; i < 7; i++) {
+                (engine as any).capZoneTouches.push({ zoneIndex: 0, playerId: 1, team: 'blue' });
+                engine.tick();
+            }
+            expect(engine.getTeamScored()).toBe('blue');
+            expect(engine.getPlayerState(0).alive).toBe(false);
+            expect(engine.getPlayerState(0).deathType).toBe(3);
+            expect(engine.getPlayerState(1).alive).toBe(true);
+        });
     });
 
     describe('environment integration', () => {

--- a/tests/integration/map-integration.test.ts
+++ b/tests/integration/map-integration.test.ts
@@ -8,6 +8,7 @@ import {
     TPS,
     DT
 } from '../../src/core/physics-engine';
+import { BonkEnvironment } from '../../src/core/environment';
 import { safeDestroy } from '../utils/test-helpers';
 import { loadMap, addAllBodies, getSpawnXY, getMapFiles } from '../utils/map-loader';
 
@@ -599,5 +600,78 @@ describe('MapIntegration', () => {
                 }
             );
         });
+    });
+
+    describe('out-of-bounds death circle follows the map center', () => {
+        // Native death type 4 (DEOBFUSCATION "Death Type 4"): a disc dies when
+        // its center is more than 850 map units from the MAP center. The
+        // bundled exports are captured in a coordinate space offset from the
+        // native world origin, so each fixture's physics.deathCenter carries
+        // the map center (730, 500) in export units. Spawn points must survive;
+        // a disc placed > 850 units from that center must die with deathType 4.
+        it.each(['simple1v1', 'ballPit'] as const)(
+            '%s spawn survives while a disc beyond 850 map units from the map center dies',
+            (key) => {
+                const map = loadMap(MAP_FILES[key]);
+                const dc = (map as any).physics?.deathCenter;
+                expect(dc).toBeDefined();
+
+                const sp = getSpawnXY(map);
+                expect(Math.hypot(sp.x - dc.x, sp.y - dc.y)).toBeLessThan(850);
+
+                const e = new PhysicsEngine();
+                try {
+                    addAllBodies(e, map);
+                    e.setDeathCircleCenter(dc.x, dc.y);
+
+                    // Idle player at the map spawn survives 5 full ticks.
+                    e.addPlayer(0, sp.x, sp.y);
+                    for (let i = 0; i < 5; i++) {
+                        e.applyInput(0, EMPTY_INPUT);
+                        e.tick();
+                    }
+                    const atSpawn = e.getPlayerState(0);
+                    expect(atSpawn.alive).toBe(true);
+                    expect(e.getTickCount()).toBe(5);
+
+                    // Disc 900 map units from the map center: inside the reported
+                    // arena bounds but far outside the 850-unit death circle.
+                    e.addPlayer(1, dc.x + 900, dc.y);
+                    e.tick();
+                    const farDisc = e.getPlayerState(1);
+                    expect(farDisc.alive).toBe(false);
+                    expect(farDisc.deathType).toBe(4);
+                } finally {
+                    safeDestroy(e);
+                }
+            },
+        );
+
+        it.each(['simple1v1', 'ballPit'] as const)(
+            '%s environment episode survives 5+ ticks with players alive at spawn',
+            (key) => {
+                const map = loadMap(MAP_FILES[key]);
+                const env = new BonkEnvironment({
+                    mapData: map as any,
+                    numOpponents: 1,
+                    randomOpponent: false,
+                    seed: 42,
+                    maxTicks: 100,
+                });
+                try {
+                    let done = false;
+                    for (let i = 0; i < 5; i++) {
+                        const r = env.step(0);
+                        expect(r.info.aiAlive).toBe(true);
+                        expect(r.info.opponentsAlive).toBe(1);
+                        expect(r.observation.tick).toBe(i + 1);
+                        done = r.done;
+                    }
+                    expect(done).toBe(false);
+                } finally {
+                    env.close();
+                }
+            },
+        );
     });
 });

--- a/tests/unit/physics-engine.test.ts
+++ b/tests/unit/physics-engine.test.ts
@@ -341,6 +341,38 @@ describe('PhysicsEngine', () => {
       engine.tick();
       expect(engine.getPlayerState(0).alive).toBe(false);
     });
+
+    it('death circle follows the configured map center, not the world origin', () => {
+      engine = new PhysicsEngine();
+      // Map centered at (800, 800) map units (an arena offset from the world
+      // origin, like the bundled exports): the disc at spawn is ~50 units
+      // from the map center and must survive the first tick.
+      engine.setDeathCircleCenter(800, 800);
+      engine.addPlayer(0, 800, 850);
+      engine.tick();
+      expect(engine.getPlayerState(0).alive).toBe(true);
+
+      // A disc more than 850 map units from the map center still dies with
+      // deathType 4 (native rule, measured from the map center).
+      engine.addPlayer(1, 800, 1700); // 900 map units from (800, 800)
+      engine.tick();
+      const outside = engine.getPlayerState(1);
+      expect(outside.alive).toBe(false);
+      expect(outside.deathType).toBe(4);
+    });
+
+    it('setDeathCircleCenter survives reset() (map-level configuration)', () => {
+      engine = new PhysicsEngine();
+      engine.setDeathCircleCenter(800, 800);
+      engine.addPlayer(0, 800, 850);
+      engine.tick();
+      expect(engine.getPlayerState(0).alive).toBe(true);
+
+      engine.reset();
+      engine.addPlayer(0, 800, 850);
+      engine.tick();
+      expect(engine.getPlayerState(0).alive).toBe(true);
+    });
   });
 
   describe('getAlivePlayerIds', () => {

--- a/tests/unit/physics-engine.test.ts
+++ b/tests/unit/physics-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   PhysicsEngine,
   PlayerInput,
@@ -361,17 +361,44 @@ describe('PhysicsEngine', () => {
       expect(outside.deathType).toBe(4);
     });
 
-    it('setDeathCircleCenter survives reset() (map-level configuration)', () => {
+    it('reset() clears a stale death-circle center back to the origin default', () => {
       engine = new PhysicsEngine();
+      // Map centered at (800, 800): the disc ~50 units from that center survives.
       engine.setDeathCircleCenter(800, 800);
       engine.addPlayer(0, 800, 850);
       engine.tick();
       expect(engine.getPlayerState(0).alive).toBe(true);
 
+      // Reused for a map WITHOUT a deathCenter: the stale (800, 800) center must
+      // not persist, so the same disc (~1145 from the origin) is now OOB.
       engine.reset();
       engine.addPlayer(0, 800, 850);
       engine.tick();
-      expect(engine.getPlayerState(0).alive).toBe(true);
+      expect(engine.getPlayerState(0).alive).toBe(false);
+      expect(engine.getPlayerState(0).deathType).toBe(4);
+    });
+
+    it('non-finite death-circle center is ignored and never disables OOB', () => {
+      engine = new PhysicsEngine();
+      engine.setDeathCircleCenter(NaN, NaN);
+
+      // A disc just beyond the origin-based OOB radius must still die: the
+      // rejected NaN center must not have disabled the OOB check map-wide.
+      engine.addPlayer(0, 900, 0);
+      engine.tick();
+      const killed = engine.getPlayerState(0);
+      expect(killed.alive).toBe(false);
+      expect(killed.deathType).toBe(4);
+
+      // And a non-finite center must not clobber a previously valid one.
+      engine.reset();
+      const warned = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      engine.setDeathCircleCenter(800, 800);
+      engine.setDeathCircleCenter(Infinity, 0);
+      warned.mockRestore();
+      engine.addPlayer(1, 800, 850); // safe if center stayed (800, 800)
+      engine.tick();
+      expect(engine.getPlayerState(1).alive).toBe(true);
     });
   });
 

--- a/tests/unit/physics-engine.test.ts
+++ b/tests/unit/physics-engine.test.ts
@@ -370,7 +370,7 @@ describe('PhysicsEngine', () => {
       expect(engine.getPlayerState(0).alive).toBe(true);
 
       // Reused for a map WITHOUT a deathCenter: the stale (800, 800) center must
-      // not persist, so the same disc (~1145 from the origin) is now OOB.
+      // not persist, so the same disc (~1167 from the origin) is now OOB.
       engine.reset();
       engine.addPlayer(0, 800, 850);
       engine.tick();


### PR DESCRIPTION
## Summary

Fixes two physics-engine correctness defects against the verified native semantics in `docs/DEOBFUSCATION.md`:

### #206 — OOB death circle hardcoded to the world origin

The native death check (`sqrt(x² + y²) > 850` map units, "Death Type 4") is centered on the **map center** because the native engine authors maps around the world origin (editor canvas 730×500, world origin = canvas center, §33.5). The port measured distance from the world origin while consuming map coordinates verbatim, so every bundled map (platform at (730, 500), spawns 1000+ units from origin) eliminated all players on the first tick.

- `PhysicsEngine.setDeathCircleCenter()` — map-relative death-circle center in map units; defaults to the world origin so existing origin-centered maps are unchanged.
- `tick()` OOB check now measures `(pos - center)` distance; radius stays the verified 850 map units (`850 / SCALE` world units).
- `MapDef.physics.deathCenter` optional field; `BonkEnvironment` reads it and re-applies it on every reset (mirroring `physics.bounds`).
- Both bundled fixtures carry `physics.deathCenter: { x: 730, y: 500 }` — the export-format map center (Simple 1v1's platform sits exactly there; Ball Pit's spawn is 577 units from it). A plain AABB center was rejected because Ball Pit's distant decorative balls dominate the AABB.
- Regression tests: engine + environment survival at spawn on both bundled maps, death with `deathType 4` beyond 850 units from the map center, plus unit tests for the center API and reset persistence.

### #214 — Timed cap-zone countdown ignores contesting

Native completion runs `while (p >= l)` (§34.6, lines 3698-3703): the `f` countdown and the `f == 0` elimination only execute while the zone progress is at the limit. The port decremented `f` unconditionally, so a takeover team that never completed the hold won the capture.

- `processCapZoneCountdowns()` now decrements and fires only when `state.f > 0 && state.p >= state.l`; a contested zone (`p < l`) pauses the timer and the capture resumes only after the holder regains the limit.
- Regression tests: contest pauses the countdown with no capture while `p < l` and red captures only after the re-hold; a takeover team (holder detached mid-countdown) wins only after completing the hold.

## Validation

- `npm run typecheck` — 0 errors
- `npm test` — 51 files, 1206 passed / 19 skipped (1198 pre-existing + 8 new)
- All 8 new tests fail without the fixes (verified by stashing) and pass with them
- `git diff --check` clean

Fixes #206
Fixes #214
