### PR TITLE
fix(worker,ipc): Float32 transport-precision parity between SAB and message mode (#236)

### DIFF
--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -87,9 +87,14 @@ function observationFastToArray(env: BonkEnvironment): Float32Array {
  * message-passing replies quantize here with Math.fround (identical
  * round-to-nearest-even) to make both transports bit-identical for the same
  * (seed, actions). This is the transport contract we ship to all consumers:
- * the shared-memory transport is the default and the Python client already
- * consumes float32 observations, so message-mode previously returning raw
- * Float64 values was the observable inconsistency.
+ * the shared-memory transport is the default and its Float32 values are what
+ * the pool has always returned; message-mode previously returning raw Float64
+ * values was the observable inconsistency being fixed, not a downgrade of a
+ * consumed precision. Downstream clients already operate at Float32: the
+ * Python client declares a `Box(..., dtype=np.float32)` observation space and
+ * converts every observation into float32 numpy arrays
+ * (python/envs/bonk_env.py), and its reward-dtype tests accept float32.
+ * No first-party consumer does exact-Float64 comparisons on rewards.
  *
  * A fresh observation object is returned and the input is never mutated, so
  * physics-visible state can never be affected even if a future environment

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -86,25 +86,37 @@ function observationFastToArray(env: BonkEnvironment): Float32Array {
  * Float32Array views filled from the Float32 _obsBuffer and storage), so
  * message-passing replies quantize here with Math.fround (identical
  * round-to-nearest-even) to make both transports bit-identical for the same
- * (seed, actions). Boolean/flag fields and integer tick are exact in Float32
- * and are left untouched.
+ * (seed, actions). This is the transport contract we ship to all consumers:
+ * the shared-memory transport is the default and the Python client already
+ * consumes float32 observations, so message-mode previously returning raw
+ * Float64 values was the observable inconsistency.
+ *
+ * A fresh observation object is returned and the input is never mutated, so
+ * physics-visible state can never be affected even if a future environment
+ * caches or reuses observation objects. Boolean/flag fields and the integer
+ * tick are exact in Float32 and are copied through untouched.
  */
 function quantizeObservation(obs: Observation): Observation {
-    obs.playerX = Math.fround(obs.playerX);
-    obs.playerY = Math.fround(obs.playerY);
-    obs.playerVelX = Math.fround(obs.playerVelX);
-    obs.playerVelY = Math.fround(obs.playerVelY);
-    obs.playerAngle = Math.fround(obs.playerAngle);
-    obs.playerAngularVel = Math.fround(obs.playerAngularVel);
-    obs.arenaHalfWidth = Math.fround(obs.arenaHalfWidth);
-    obs.arenaHalfHeight = Math.fround(obs.arenaHalfHeight);
-    for (const opp of obs.opponents) {
-        opp.x = Math.fround(opp.x);
-        opp.y = Math.fround(opp.y);
-        opp.velX = Math.fround(opp.velX);
-        opp.velY = Math.fround(opp.velY);
-    }
-    return obs;
+    return {
+        playerX: Math.fround(obs.playerX),
+        playerY: Math.fround(obs.playerY),
+        playerVelX: Math.fround(obs.playerVelX),
+        playerVelY: Math.fround(obs.playerVelY),
+        playerAngle: Math.fround(obs.playerAngle),
+        playerAngularVel: Math.fround(obs.playerAngularVel),
+        playerIsHeavy: obs.playerIsHeavy,
+        opponents: obs.opponents.map(opp => ({
+            x: Math.fround(opp.x),
+            y: Math.fround(opp.y),
+            velX: Math.fround(opp.velX),
+            velY: Math.fround(opp.velY),
+            isHeavy: opp.isHeavy,
+            alive: opp.alive,
+        })),
+        arenaHalfWidth: Math.fround(obs.arenaHalfWidth),
+        arenaHalfHeight: Math.fround(obs.arenaHalfHeight),
+        tick: obs.tick,
+    };
 }
 
 parentPort.on('message', (msg) => {
@@ -173,7 +185,7 @@ parentPort.on('message', (msg) => {
                 signalSyncCompleted();
             }
             // Always include observation data in the response (shared memory is for step(), not reset())
-            obs.forEach(quantizeObservation);
+            obs.forEach((o, i) => { obs[i] = quantizeObservation(o); });
             parentPort!.postMessage({
                 id: msg.id,
                 status: 'ok',
@@ -204,9 +216,9 @@ parentPort.on('message', (msg) => {
             // terminal observation is a distinct object from the post-reset
             // observation, so both are quantized.
             for (const res of results) {
-                quantizeObservation(res.observation);
+                res.observation = quantizeObservation(res.observation);
                 if (res.info.terminal_observation) {
-                    quantizeObservation(res.info.terminal_observation);
+                    res.info.terminal_observation = quantizeObservation(res.info.terminal_observation);
                 }
                 res.reward = Math.fround(res.reward);
             }

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -79,6 +79,34 @@ function observationFastToArray(env: BonkEnvironment): Float32Array {
     return env.getObservationFast();
 }
 
+/**
+ * Canonical transport precision (issue #236): observations and rewards are
+ * published as IEEE-754 Float32 in every transport. The shared-memory path
+ * quantizes by construction (the SAB observation/reward records are
+ * Float32Array views filled from the Float32 _obsBuffer and storage), so
+ * message-passing replies quantize here with Math.fround (identical
+ * round-to-nearest-even) to make both transports bit-identical for the same
+ * (seed, actions). Boolean/flag fields and integer tick are exact in Float32
+ * and are left untouched.
+ */
+function quantizeObservation(obs: Observation): Observation {
+    obs.playerX = Math.fround(obs.playerX);
+    obs.playerY = Math.fround(obs.playerY);
+    obs.playerVelX = Math.fround(obs.playerVelX);
+    obs.playerVelY = Math.fround(obs.playerVelY);
+    obs.playerAngle = Math.fround(obs.playerAngle);
+    obs.playerAngularVel = Math.fround(obs.playerAngularVel);
+    obs.arenaHalfWidth = Math.fround(obs.arenaHalfWidth);
+    obs.arenaHalfHeight = Math.fround(obs.arenaHalfHeight);
+    for (const opp of obs.opponents) {
+        opp.x = Math.fround(opp.x);
+        opp.y = Math.fround(opp.y);
+        opp.velX = Math.fround(opp.velX);
+        opp.velY = Math.fround(opp.velY);
+    }
+    return obs;
+}
+
 parentPort.on('message', (msg) => {
     try {
         if (msg.type === 'init') {
@@ -145,6 +173,7 @@ parentPort.on('message', (msg) => {
                 signalSyncCompleted();
             }
             // Always include observation data in the response (shared memory is for step(), not reset())
+            obs.forEach(quantizeObservation);
             parentPort!.postMessage({
                 id: msg.id,
                 status: 'ok',
@@ -166,6 +195,20 @@ parentPort.on('message', (msg) => {
             stepCounter++;
             if (stepCounter % 1000 === 0) {
                 globalProfiler.recordMemory();
+            }
+
+            // Canonical transport precision (issue #236): the shared-memory
+            // path stores observations and rewards as Float32, so message
+            // replies quantize to the same precision for bit-identical
+            // (seed, actions) replay across transports. On terminal steps the
+            // terminal observation is a distinct object from the post-reset
+            // observation, so both are quantized.
+            for (const res of results) {
+                quantizeObservation(res.observation);
+                if (res.info.terminal_observation) {
+                    quantizeObservation(res.info.terminal_observation);
+                }
+                res.reward = Math.fround(res.reward);
             }
 
             parentPort!.postMessage({

--- a/tests/integration/worker-pool-transport-parity.test.ts
+++ b/tests/integration/worker-pool-transport-parity.test.ts
@@ -1,0 +1,122 @@
+/**
+ * worker-pool-transport-parity.test.ts — Regression coverage for issue #236
+ *
+ * The shared-memory transport used to publish observations and rewards
+ * through Float32Array SAB records (Float32 quantization), while
+ * message-passing forwarded the environment's Float64 values untouched.
+ * Identical (seed, actions) therefore produced different numbers in the two
+ * transports, silently breaking cross-transport deterministic replay. Both
+ * transports now publish Float32 (message mode quantizes with Math.fround),
+ * so every observation field and reward must be bit-identical (`===`) for
+ * the same seed and action sequence.
+ */
+import { describe, it, expect } from 'vitest';
+import { WorkerPool } from '../../src/core/worker-pool';
+
+const OBS_FLOAT_FIELDS = [
+  'playerX',
+  'playerY',
+  'playerVelX',
+  'playerVelY',
+  'playerAngle',
+  'playerAngularVel',
+  'arenaHalfWidth',
+  'arenaHalfHeight',
+];
+
+const OPP_FLOAT_FIELDS = ['x', 'y', 'velX', 'velY'];
+
+function assertObservationEqual(a: any, b: any): void {
+  for (const field of OBS_FLOAT_FIELDS) {
+    expect(a[field]).toBe(b[field]);
+  }
+  expect(a.playerIsHeavy).toBe(b.playerIsHeavy);
+  expect(a.opponents).toHaveLength(b.opponents.length);
+  for (let i = 0; i < a.opponents.length; i++) {
+    for (const field of OPP_FLOAT_FIELDS) {
+      expect(a.opponents[i][field]).toBe(b.opponents[i][field]);
+    }
+    expect(a.opponents[i].isHeavy).toBe(b.opponents[i].isHeavy);
+    expect(a.opponents[i].alive).toBe(b.opponents[i].alive);
+  }
+  expect(a.tick).toBe(b.tick);
+}
+
+describe('transport precision parity (issue #236)', () => {
+  it('returns bit-identical reset/step observations and rewards in both transports', async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    const run = async (useSharedMemory: boolean) => {
+      const pool = new WorkerPool(1);
+      try {
+        await pool.init(1, { maxTicks: 300, seed: 42, frameSkip: 2 }, useSharedMemory);
+        const resetObs = (await pool.reset([42]))[0];
+        const results = [];
+        // Step [0] is the issue's repro (non-integer playerY, -0.001 time
+        // penalty reward); step [2] exercises a directional input.
+        results.push((await pool.step([0]))[0]);
+        results.push((await pool.step([2]))[0]);
+        return { resetObs, results, pool };
+      } catch (e) {
+        await pool.close();
+        throw e;
+      }
+    };
+
+    const shared = await run(true);
+    const message = await run(false);
+
+    assertObservationEqual(shared.resetObs, message.resetObs);
+    expect(shared.resetObs.playerY).toBe(Math.fround(shared.resetObs.playerY));
+
+    for (let i = 0; i < shared.results.length; i++) {
+      const s = shared.results[i];
+      const m = message.results[i];
+      expect(s.done).toBe(m.done);
+      expect(s.truncated).toBe(m.truncated);
+      assertObservationEqual(s.observation, m.observation);
+      expect(s.reward).toBe(m.reward);
+      // Both transports report the canonical Float32 value, so e.g. the
+      // -0.001 time penalty is the Float32-quantized -0.0010000000474974513.
+      expect(s.reward).toBe(Math.fround(s.reward));
+    }
+
+    await shared.pool.close();
+    await message.pool.close();
+  });
+
+  it('returns bit-identical terminal observations and rewards on terminal steps', async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    const run = async (useSharedMemory: boolean) => {
+      const pool = new WorkerPool(1);
+      try {
+        // maxTicks 1 makes the single step terminal in both transports.
+        await pool.init(1, { maxTicks: 1, seed: 7 }, useSharedMemory);
+        await pool.reset([7]);
+        const result = (await pool.step([0]))[0];
+        return { result, pool };
+      } catch (e) {
+        await pool.close();
+        throw e;
+      }
+    };
+
+    const shared = await run(true);
+    const message = await run(false);
+
+    expect(shared.result.done).toBe(true);
+    expect(message.result.done).toBe(true);
+    assertObservationEqual(shared.result.observation, message.result.observation);
+    expect(shared.result.reward).toBe(message.result.reward);
+    expect(shared.result.info.terminal_observation).toBeDefined();
+    expect(message.result.info.terminal_observation).toBeDefined();
+    assertObservationEqual(
+      shared.result.info.terminal_observation,
+      message.result.info.terminal_observation,
+    );
+
+    await shared.pool.close();
+    await message.pool.close();
+  });
+});

--- a/tests/integration/worker-pool-transport-parity.test.ts
+++ b/tests/integration/worker-pool-transport-parity.test.ts
@@ -56,10 +56,9 @@ describe('transport precision parity (issue #236)', () => {
         // penalty reward); step [2] exercises a directional input.
         results.push((await pool.step([0]))[0]);
         results.push((await pool.step([2]))[0]);
-        return { resetObs, results, pool };
-      } catch (e) {
+        return { resetObs, results };
+      } finally {
         await pool.close();
-        throw e;
       }
     };
 
@@ -80,9 +79,6 @@ describe('transport precision parity (issue #236)', () => {
       // -0.001 time penalty is the Float32-quantized -0.0010000000474974513.
       expect(s.reward).toBe(Math.fround(s.reward));
     }
-
-    await shared.pool.close();
-    await message.pool.close();
   });
 
   it('returns bit-identical terminal observations and rewards on terminal steps', async () => {
@@ -95,10 +91,9 @@ describe('transport precision parity (issue #236)', () => {
         await pool.init(1, { maxTicks: 1, seed: 7 }, useSharedMemory);
         await pool.reset([7]);
         const result = (await pool.step([0]))[0];
-        return { result, pool };
-      } catch (e) {
+        return { result };
+      } finally {
         await pool.close();
-        throw e;
       }
     };
 
@@ -115,8 +110,5 @@ describe('transport precision parity (issue #236)', () => {
       shared.result.info.terminal_observation,
       message.result.info.terminal_observation,
     );
-
-    await shared.pool.close();
-    await message.pool.close();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #236: the shared-memory transport quantizes observations/rewards to Float32 via its Float32Array SAB records while message-passing forwarded the physics engine's Float64 values untouched, so identical (seed, actions) produced different values per transport.

### Contract chosen

**Float32 is the canonical transport precision for both transports.** The shared-memory path already quantizes by construction (observation/reward SAB records are Float32Array views; the worker's obs buffers are Float32Array), so message-passing replies now quantize to the same precision with \Math.fround\ (identical IEEE-754 round-to-nearest-even) before leaving the worker. This makes the two transports bit-identical without changing the SAB layout, and matches the Python client, which already converts observations to \
p.float32\.

### Changes

- \src/core/worker.ts\: new \quantizeObservation\ applies \Math.fround\ to every float observation field (player, opponents, arena) — worker.ts:92-108
- \src/core/worker.ts\ message-mode \step\: quantizes \observation\, \info.terminal_observation\, and \eward\ before posting — worker.ts:200-211
- \src/core/worker.ts\ message-mode \eset\: quantizes the reset observation reply — worker.ts:176
- \	ests/integration/worker-pool-transport-parity.test.ts\: new regression test running identical (seed, actions) through both transports and asserting every observation field and reward is strictly bit-equal (\===\), including a terminal-step case covering \	erminal_observation\.

### Validation

- \
pm run typecheck\: 0 errors
- \
pm test\: 59 files, 1262 passed, 19 skipped (baseline 1260 passed + 2 new parity tests), 0 failures
- \git diff --check\: clean

### Reproducing the issue's example

With seed 42 and action [0], both transports now report bit-equal values:
- \observation.playerY\: \-99.33333587646484\ (Float32-quantized) in both
- \eward\: \-0.0010000000474974513\ (Float32-quantized) in both
