### PR TITLE
fix(worker-pool,ipc): validate environment count and integer numEnvs on init

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -138,6 +138,9 @@ export class WorkerPool {
     }
 
     async init(totalEnvs: number, config: any = {}, useSharedMemory?: boolean) {
+        if (!Number.isInteger(totalEnvs) || totalEnvs < 1) {
+            throw new Error(`Invalid environment count: expected a positive integer, got ${totalEnvs}`);
+        }
         await this.close(); // Clean up existing if re-initialized
         this.state = 'initializing';
         this.failure = null;

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -60,9 +60,15 @@ export class IpcBridge {
             const command = payload.command;
 
             if (command === "init") {
-                const numEnvs = payload.numEnvs;
-                if (typeof numEnvs !== 'number' || numEnvs < 1) {
-                    response = { status: "error", error: "Invalid numEnvs: must be a positive number" };
+                let numEnvs = payload.numEnvs;
+                if (typeof numEnvs === 'string') {
+                    const coerced = Number(numEnvs);
+                    if (Number.isInteger(coerced) && coerced >= 1) {
+                        numEnvs = coerced;
+                    }
+                }
+                if (typeof numEnvs !== 'number' || !Number.isInteger(numEnvs) || numEnvs < 1) {
+                    response = { status: "error", error: "Invalid numEnvs: must be a positive integer" };
                 } else {
                     const useSharedMemory = payload.useSharedMemory;
                     const envDefaults = getConfig().environment;
@@ -199,6 +205,9 @@ export class IpcBridge {
      * Used by BonkEnv for programmatic control.
      */
     async initEnv(numEnvs: number, config: any = {}, useSharedMemory?: boolean): Promise<void> {
+        if (!Number.isInteger(numEnvs) || numEnvs < 1) {
+            throw new Error('Invalid numEnvs: must be a positive integer');
+        }
         await this.pool.init(numEnvs, config, useSharedMemory);
         this._initialized = true;
         this._numEnvs = numEnvs;

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -61,11 +61,8 @@ export class IpcBridge {
 
             if (command === "init") {
                 let numEnvs = payload.numEnvs;
-                if (typeof numEnvs === 'string') {
-                    const coerced = Number(numEnvs);
-                    if (Number.isInteger(coerced) && coerced >= 1) {
-                        numEnvs = coerced;
-                    }
+                if (typeof numEnvs === 'string' && /^\d+$/.test(numEnvs)) {
+                    numEnvs = Number(numEnvs);
                 }
                 if (typeof numEnvs !== 'number' || !Number.isInteger(numEnvs) || numEnvs < 1) {
                     response = { status: "error", error: "Invalid numEnvs: must be a positive integer" };

--- a/tests/integration/env-lifecycle.test.ts
+++ b/tests/integration/env-lifecycle.test.ts
@@ -268,6 +268,39 @@ describe('BonkEnv lifecycle', () => {
     });
   });
 
+  describe('init validation (#227)', () => {
+    it('rejects start with zero numEnvs and stays inactive', async () => {
+      env = new BonkEnv({ numEnvs: 0, portManager: pm });
+      await expect(env.start()).rejects.toThrow(
+        'Invalid environment count: expected a positive integer, got 0',
+      );
+      expect(env.isActive()).toBe(false);
+    });
+
+    it('rejects start with a negative numEnvs and stays inactive', async () => {
+      env = new BonkEnv({ numEnvs: -1, portManager: pm });
+      await expect(env.start()).rejects.toThrow(
+        'Invalid environment count: expected a positive integer, got -1',
+      );
+      expect(env.isActive()).toBe(false);
+      expect(pm.isAllocated(env.port)).toBe(false);
+    });
+
+    it('a rejected start is stop-able and a valid environment still starts', { timeout: 30000 }, async () => {
+      env = new BonkEnv({ numEnvs: 0, portManager: pm });
+      await expect(env.start()).rejects.toThrow('Invalid environment count');
+      await expect(env.stop()).resolves.toBeUndefined();
+
+      const good = new BonkEnv({ numEnvs: 1, portManager: pm });
+      try {
+        await good.start();
+        expect(good.isActive()).toBe(true);
+      } finally {
+        await good.stop();
+      }
+    });
+  });
+
   describe('reset', () => {
     it('reset works after start', { timeout: 30000 }, async () => {
       env = new BonkEnv({ numEnvs: 1, portManager: pm });

--- a/tests/unit/ipc-bridge.test.ts
+++ b/tests/unit/ipc-bridge.test.ts
@@ -96,6 +96,44 @@ describe('IpcBridge handleRequest', () => {
       expect(response.error).toContain('Invalid numEnvs');
     });
 
+    it('rejects init with a fractional numEnvs as error (#195)', async () => {
+      const { sentMessages } = captureSend(bridge);
+      await callHandleRequest(bridge, JSON.stringify({ command: 'init', numEnvs: 1.5 }));
+      expect(sentMessages).toHaveLength(1);
+      const response = JSON.parse(sentMessages[0]);
+      expect(response.status).toBe('error');
+      expect(response.error).toBe('Invalid numEnvs: must be a positive integer');
+    });
+
+    it('rejects init with a sub-one fractional numEnvs as error (#195)', async () => {
+      const { sentMessages } = captureSend(bridge);
+      await callHandleRequest(bridge, JSON.stringify({ command: 'init', numEnvs: 0.5 }));
+      expect(sentMessages).toHaveLength(1);
+      const response = JSON.parse(sentMessages[0]);
+      expect(response.status).toBe('error');
+      expect(response.error).toBe('Invalid numEnvs: must be a positive integer');
+    });
+
+    it('coerces a numeric-string numEnvs to a positive integer (#195)', async () => {
+      const { sentMessages } = captureSend(bridge);
+      await callHandleRequest(bridge, JSON.stringify({ command: 'init', numEnvs: '2' }));
+      expect(JSON.parse(sentMessages[0]).status).toBe('ok');
+      sentMessages.length = 0;
+
+      await callHandleRequest(bridge, JSON.stringify({ command: 'reset', seeds: [1, 2] }));
+      expect(JSON.parse(sentMessages[0]).status).toBe('ok');
+      sentMessages.length = 0;
+
+      await callHandleRequest(bridge, JSON.stringify({ command: 'step', actions: [0, 0] }));
+      expect(JSON.parse(sentMessages[0]).status).toBe('ok');
+      sentMessages.length = 0;
+
+      await callHandleRequest(bridge, JSON.stringify({ command: 'step', actions: [0, 0, 0] }));
+      const response = JSON.parse(sentMessages[0]);
+      expect(response.status).toBe('error');
+      expect(response.error).toContain('expected 2 actions');
+    });
+
     it('handles init with missing numEnvs as error', async () => {
       const { sentMessages } = captureSend(bridge);
       await callHandleRequest(bridge, JSON.stringify({ command: 'init' }));
@@ -330,5 +368,32 @@ describe('IpcBridge close internals (lines 159-173)', () => {
     const spy = vi.spyOn(pool, 'close');
     await bridge.close();
     expect(spy).toHaveBeenCalled();
+  });
+});
+
+describe('IpcBridge initEnv validation (#195, #227)', () => {
+  it('rejects a non-positive or non-integer numEnvs before touching the pool', async () => {
+    const bridge = new IpcBridge({ server: { port: 15571 } } as any);
+    try {
+      const pool = (bridge as any).pool;
+      const initSpy = vi.spyOn(pool, 'init');
+
+      await expect((bridge as any).initEnv(0)).rejects.toThrow('Invalid numEnvs: must be a positive integer');
+      await expect((bridge as any).initEnv(-1)).rejects.toThrow('Invalid numEnvs: must be a positive integer');
+      await expect((bridge as any).initEnv(1.5)).rejects.toThrow('Invalid numEnvs: must be a positive integer');
+      expect(initSpy).not.toHaveBeenCalled();
+    } finally {
+      await bridge.close();
+    }
+  });
+
+  it('applies a valid integer initEnv', async () => {
+    const bridge = new IpcBridge({ server: { port: 15572 } } as any);
+    try {
+      await (bridge as any).initEnv(1, {}, false);
+      expect((bridge as any)._numEnvs).toBe(1);
+    } finally {
+      await bridge.close();
+    }
   });
 });

--- a/tests/unit/ipc-bridge.test.ts
+++ b/tests/unit/ipc-bridge.test.ts
@@ -114,6 +114,15 @@ describe('IpcBridge handleRequest', () => {
       expect(response.error).toBe('Invalid numEnvs: must be a positive integer');
     });
 
+    it('rejects a non-decimal numeric-string numEnvs as error (#195)', async () => {
+      const { sentMessages } = captureSend(bridge);
+      await callHandleRequest(bridge, JSON.stringify({ command: 'init', numEnvs: '0x2' }));
+      expect(sentMessages).toHaveLength(1);
+      const response = JSON.parse(sentMessages[0]);
+      expect(response.status).toBe('error');
+      expect(response.error).toBe('Invalid numEnvs: must be a positive integer');
+    });
+
     it('coerces a numeric-string numEnvs to a positive integer (#195)', async () => {
       const { sentMessages } = captureSend(bridge);
       await callHandleRequest(bridge, JSON.stringify({ command: 'init', numEnvs: '2' }));

--- a/tests/unit/worker-pool-failures.test.ts
+++ b/tests/unit/worker-pool-failures.test.ts
@@ -515,4 +515,64 @@ describe('WorkerPool failure state', () => {
     expect(fakes.FakeWorker.instances[0].terminated).toBe(true);
     expect(fakes.FakeSharedMemoryManager.instances[0].disposed).toBe(true);
   });
+
+  describe('init validation (#195, #227)', () => {
+    it('rejects init(0) in message mode with a clear error and no workers', async () => {
+      pool = new WorkerPool(1);
+
+      await expect(pool.init(0, {}, false)).rejects.toThrow(
+        'Invalid environment count: expected a positive integer, got 0',
+      );
+
+      expect(fakes.FakeWorker.instances).toHaveLength(0);
+      expect((pool as any).state).toBe('idle');
+    });
+
+    it('rejects init(0) in shared-memory mode with the same error and no workers', async () => {
+      pool = new WorkerPool(1);
+
+      await expect(pool.init(0, {}, true)).rejects.toThrow(
+        'Invalid environment count: expected a positive integer, got 0',
+      );
+
+      expect(fakes.FakeWorker.instances).toHaveLength(0);
+      expect(fakes.FakeSharedMemoryManager.instances).toHaveLength(0);
+      expect((pool as any).state).toBe('idle');
+    });
+
+    it('rejects init(-1) with a clear error in both transports (no RangeError)', async () => {
+      for (const useShared of [false, true]) {
+        const p = new WorkerPool(1);
+        await expect(p.init(-1, {}, useShared)).rejects.toThrow(
+          'Invalid environment count: expected a positive integer, got -1',
+        );
+        expect(fakes.FakeWorker.instances).toHaveLength(0);
+        await p.close();
+      }
+    });
+
+    it('rejects a non-integer totalEnvs in both transports', async () => {
+      for (const useShared of [false, true]) {
+        const p = new WorkerPool(1);
+        await expect(p.init(2.5, {}, useShared)).rejects.toThrow(
+          'Invalid environment count: expected a positive integer, got 2.5',
+        );
+        expect(fakes.FakeWorker.instances).toHaveLength(0);
+        await p.close();
+      }
+    });
+
+    it('keeps the pool usable after a rejected init', async () => {
+      pool = new WorkerPool(1);
+
+      await expect(pool.init(0, {}, true)).rejects.toThrow(
+        'Invalid environment count: expected a positive integer, got 0',
+      );
+
+      await pool.init(1, {}, true);
+      expect((pool as any).state).toBe('ready');
+      const results = await pool.step([0]);
+      expect(results).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #227
Fixes #195

Two init-validation fixes in one focused PR (one conventional commit each):

## #227 — WorkerPool.init() accepts non-positive totalEnvs

- `src/core/worker-pool.ts` — `init()` now rejects `totalEnvs` that is not a positive integer (`Invalid environment count: expected a positive integer, got N`) before any pool state is touched. `init(0)` no longer silently creates a ready zero-environment pool and `init(-1)` no longer dies with an opaque SharedArrayBuffer `RangeError` in shared-memory mode; both transports now fail identically with a clear per-request error. Guard at src/core/worker-pool.ts:141.
- `BonkEnv.start()` with `numEnvs: 0`/`-1` now rejects and the environment never reports `isActive() === true`.
- Regression tests: `init(0)`/`-1` in both transports (clean rejection, no worker spawned, pool usable after a corrected init) in tests/unit/worker-pool-failures.test.ts, and `BonkEnv` rejected-start coverage in tests/integration/env-lifecycle.test.ts.

## #195 — IPC init accepts non-integer numEnvs

- `src/ipc/ipc-bridge.ts` — the ZMQ `init` request now rejects any `numEnvs` that is not a positive integer (`Invalid numEnvs: must be a positive integer`), closing the fractional/non-finite hole that previously produced 3 environments for a 2.5-env request or an opaque `byte length of Int32Array should be a multiple of 4` error. Numeric strings that parse to an integer >= 1 (e.g. `"2"`) are coerced before validation and the validated count always lands as an integer >= 1. `handleRequest` init branch at src/ipc/ipc-bridge.ts:63. The programmatic `initEnv()` path gets the same guard (src/ipc/ipc-bridge.ts:201, error before any pool state is touched).
- `WorkerPool.init()` (same guard as #227) also protects the programmatic `BonkEnv`/`EnvManager`/`pool.init` paths from fractional counts.
- Regression tests: `init` with 1.5 / 0.5 reject cleanly, `"2"` is coerced to exactly 2 environments (proven by the 3-action rejection), and `initEnv` rejects 0/-1/1.5 without calling `pool.init` — tests/unit/ipc-bridge.test.ts.

Validation: `npm run typecheck` 0 errors, `npm test` 58 files / 1273 passed / 19 skipped, `git diff --check` clean.