### PR TITLE
fix(worker,ipc): non-blocking shared-memory telemetry snapshots and prompt step replies (#240, #229)

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -995,6 +995,19 @@ export class WorkerPool {
      */
     async getTelemetrySnapshots(): Promise<BigUint64Array[]> {
         this.assertReady('get telemetry');
+
+        // In shared-memory mode every worker is blocked inside the
+        // wait-for-action loop (Atomics.wait) and can never service
+        // GET_TELEMETRY on its event loop, so no reply can ever arrive.
+        // Return an empty snapshot set immediately instead of burning
+        // messageTimeoutMs (30s default) on unreachable workers: the call is
+        // non-blocking, never fails the pool, and leaves the pool untouched
+        // (issue #240). Worker telemetry is otherwise collected through the
+        // shared-memory channel, which carries no telemetry region today.
+        if (this.useSharedMemory) {
+            return [];
+        }
+
         const promises = [];
         for (let i = 0; i < this.workers.length; i++) {
             promises.push(this.sendMessage(this.workers[i], { type: 'GET_TELEMETRY' }));
@@ -1003,14 +1016,10 @@ export class WorkerPool {
         const hungWorker = settled.find(r => r.status === 'rejected' && this.isWorkerTimeout(r.reason));
         if (hungWorker) {
             const failure = this.createFailure('telemetry', (hungWorker as { reason: Error }).reason);
-            // In shared mode workers block in Atomics.wait and never service
-            // GET_TELEMETRY, so that timeout is expected and recoverable. In
-            // message mode a timeout means the worker is hung/unreachable:
+            // In message mode a timeout means the worker is hung/unreachable:
             // fail so callers re-init instead of burning the full timeout on
             // every snapshot.
-            if (!this.useSharedMemory) {
-                await this.failPool(failure);
-            }
+            await this.failPool(failure);
             throw failure;
         }
         const firstRejection = settled.find(r => r.status === 'rejected');

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -146,7 +146,16 @@ export class IpcBridge {
                         // delay this reply or stall the single-threaded ZMQ
                         // loop. The telemetry block runs detached below and
                         // catches its own errors (see #185).
-                        await this._wrappedSend([identity, serialized]);
+                        try {
+                            await this._wrappedSend([identity, serialized]);
+                        } catch (sendError) {
+                            // A send failure must not fabricate a step-error
+                            // reply for a step that already executed — the
+                            // client would retry and double-step it (the #185
+                            // hazard). Log and send nothing, matching the
+                            // trailing send's failure handling.
+                            console.error("[IPC] Error sending response:", sendError);
+                        }
                         serialized = null;
                         replied = true;
                         void this.runPostStepTelemetry();

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -1,6 +1,7 @@
 import * as zmq from "zeromq";
 import { WorkerPool } from "../core/worker-pool";
 import { globalProfiler, wrap, TelemetryIndices, setLatestWorkerTelemetry } from "../telemetry/profiler";
+import { isTelemetryEnabled as isTelemetryControllerEnabled } from '../telemetry/telemetry-controller';
 import { getConfig, type AppConfig, type DeepPartial, mergeEnvironmentConfig } from '../config/config-loader';
 
 // Pre-wrapped JSON.parse for telemetry on bridge deserialization.
@@ -55,6 +56,9 @@ export class IpcBridge {
         // Step responses are serialized eagerly so the borrowed pool graph is
         // consumed before the telemetry branch awaits worker replies.
         let serialized: string | null = null;
+        // True once the step reply was transmitted eagerly ahead of the
+        // post-step telemetry block, so the trailing send below is skipped.
+        let replied = false;
         try {
             const payload = parseJson(rawMsg);
             const command = payload.command;
@@ -135,28 +139,17 @@ export class IpcBridge {
                     globalProfiler.tick();
 
                     if (this.stepCount % 5000 === 0) {
-                        // The step above already completed and its reply is
-                        // serialized. Telemetry is best-effort: a failure here
-                        // must not discard that reply or double-report the step
-                        // as an error (see #185), so it is isolated and logged.
-                        try {
-                            globalProfiler.recordMemory();
-
-                            const telemetryEnabled = require('../telemetry/telemetry-controller').isTelemetryEnabled();
-                            if (telemetryEnabled) {
-                                // Workers blocked in Atomics.wait (shared-memory
-                                // mode) can never service GET_TELEMETRY, so the
-                                // snapshot fetch would always time out there;
-                                // skip it and report without worker snapshots.
-                                if (!this.pool.isUsingSharedMemory()) {
-                                    const snapshots = await this.pool.getTelemetrySnapshots();
-                                    setLatestWorkerTelemetry(snapshots);
-                                }
-                                globalProfiler.report(5000);
-                            }
-                        } catch (telemetryError) {
-                            console.error('[IPC] Telemetry error after step:', telemetryError);
-                        }
+                        // Issue #229: the completed step's reply must be
+                        // transmitted before any best-effort telemetry work and
+                        // must never await it. A slow or failing snapshot fetch
+                        // (up to messageTimeoutMs in message mode) must not
+                        // delay this reply or stall the single-threaded ZMQ
+                        // loop. The telemetry block runs detached below and
+                        // catches its own errors (see #185).
+                        await this._wrappedSend([identity, serialized]);
+                        serialized = null;
+                        replied = true;
+                        void this.runPostStepTelemetry();
                     }
                 }
             } else if (command === "close") {
@@ -182,15 +175,45 @@ export class IpcBridge {
             serialized = null;
         }
 
-        try {
-            await this._wrappedSend([identity, serialized ?? JSON.stringify(response)]);
-        } catch (sendError) {
-            console.error("[IPC] Error sending response:", sendError);
+        if (!replied) {
+            try {
+                await this._wrappedSend([identity, serialized ?? JSON.stringify(response)]);
+            } catch (sendError) {
+                console.error("[IPC] Error sending response:", sendError);
+            }
         }
 
         if (this._shouldClose) {
             this._shouldClose = false;
             await this.close();
+        }
+    }
+
+    /**
+     * Best-effort post-step telemetry: memory gauges, worker snapshot fetch,
+     * and the heatmap report. Detached from the request path — it never
+     * affects the step reply and cannot stall the ZMQ loop (issue #229).
+     * Errors are caught and logged so a telemetry failure is never reported
+     * as a step failure or discards an already-serialized reply (issue
+     * #185); a message-mode snapshot timeout still fails the pool per
+     * worker-pool semantics, surfacing on the next request.
+     */
+    private async runPostStepTelemetry(): Promise<void> {
+        try {
+            globalProfiler.recordMemory();
+
+            if (isTelemetryControllerEnabled()) {
+                // getTelemetrySnapshots is non-blocking in shared-memory mode
+                // (workers blocked in Atomics.wait cannot service
+                // GET_TELEMETRY, so the pool returns an empty set
+                // immediately) and performs a bounded worker round-trip in
+                // message mode.
+                const snapshots = await this.pool.getTelemetrySnapshots();
+                setLatestWorkerTelemetry(snapshots);
+                globalProfiler.report(5000);
+            }
+        } catch (telemetryError) {
+            console.error('[IPC] Telemetry error after step:', telemetryError);
         }
     }
 

--- a/tests/integration/worker-integration.test.ts
+++ b/tests/integration/worker-integration.test.ts
@@ -148,6 +148,26 @@ describe('Worker thread integration', () => {
         }
       }
     });
+
+    it('returns telemetry snapshots immediately in shared memory mode (issue #240)', async () => {
+      if (WorkerPool.isSupported()) {
+        await pool.init(2, {}, true);
+        await pool.reset([1, 2]);
+        await pool.step([0, 0]);
+
+        // Shared-mode workers block in Atomics.wait and can never service
+        // GET_TELEMETRY, so the snapshot must resolve within a small bound
+        // (empty set) instead of burning messageTimeoutMs, and the pool must
+        // remain usable afterwards.
+        const started = Date.now();
+        const snapshots = await pool.getTelemetrySnapshots();
+        expect(Date.now() - started).toBeLessThan(1000);
+        expect(snapshots).toHaveLength(0);
+
+        const results = await pool.step([0, 0]);
+        expect(results).toHaveLength(2);
+      }
+    });
   });
 
   describe('multi-worker coordination', () => {

--- a/tests/unit/ipc-bridge-telemetry-integrity.test.ts
+++ b/tests/unit/ipc-bridge-telemetry-integrity.test.ts
@@ -30,7 +30,6 @@ const mocks = vi.hoisted(() => {
     step: vi.fn().mockResolvedValue([]),
     close: vi.fn(),
     getTelemetrySnapshots: vi.fn().mockResolvedValue([]),
-    isUsingSharedMemory: vi.fn(() => false),
   };
   return {
     sock,
@@ -133,16 +132,15 @@ describe('IpcBridge step reply integrity when telemetry fails (issue #185)', () 
     consoleErrorSpy.mockRestore();
   });
 
-  it('fetches telemetry snapshots in shared-memory mode without blocking (issue #240)', async () => {
-    mocks.pool.isUsingSharedMemory.mockReturnValueOnce(true);
-
+  it('fetches telemetry snapshots on the boundary step, including in shared-memory mode (issue #240)', async () => {
     await initAndStepAtBoundary(12365);
 
     const response = lastSentResponse();
     expect(response.status).toBe('ok');
-    // getTelemetrySnapshots is non-blocking in shared mode (it returns an
-    // empty set immediately instead of waiting on unanswerable worker
-    // messages), so the bridge always fetches instead of skipping.
+    // The bridge always fetches instead of skipping: getTelemetrySnapshots
+    // is non-blocking in shared mode (it returns an empty set immediately
+    // instead of waiting on unanswerable worker messages), so no mode check
+    // is needed at the bridge.
     expect(mocks.pool.getTelemetrySnapshots).toHaveBeenCalled();
   });
 

--- a/tests/unit/ipc-bridge-telemetry-integrity.test.ts
+++ b/tests/unit/ipc-bridge-telemetry-integrity.test.ts
@@ -1,12 +1,20 @@
 /**
- * ipc-bridge-telemetry-integrity.test.ts — Regression coverage for issue #185
+ * ipc-bridge-telemetry-integrity.test.ts — Regression coverage for issues
+ * #185, #229, #240
  *
- * The step reply is serialized before the post-step telemetry block runs. A
- * telemetry failure (e.g. `recordMemory()` throwing, or the worker snapshot
- * fetch rejecting — deterministic in shared-memory mode, where workers blocked
- * in Atomics.wait can never service GET_TELEMETRY) must NOT discard the reply
- * of a step that already completed: the client would otherwise be told the
- * step failed and retry it, double-stepping the environments.
+ * The step reply is serialized before the post-step telemetry block runs.
+ * A telemetry failure (e.g. `recordMemory()` throwing, or the worker snapshot
+ * fetch rejecting) must NOT discard the reply of a step that already
+ * completed: the client would otherwise be told the step failed and retry it,
+ * double-stepping the environments (#185).
+ *
+ * The reply must also be transmitted before/independent of the telemetry
+ * fetch, and the fetch must never await inside the request path: in
+ * message-passing mode a hung worker would otherwise hold the completed
+ * step's reply (and the single-threaded ZMQ loop) for up to messageTimeoutMs
+ * (#229). In shared-memory mode the snapshot fetch is non-blocking — workers
+ * blocked in Atomics.wait can never service GET_TELEMETRY, so the pool
+ * returns an empty set immediately (#240).
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
@@ -73,6 +81,7 @@ describe('IpcBridge step reply integrity when telemetry fails (issue #185)', () 
     mocks.getConfig.mockReturnValue({ server: { port: 5555 }, environment: { seed: 0 } });
     mocks.isTelemetryEnabled.mockReturnValue(true);
     mocks.pool.step.mockResolvedValue([stepResult]);
+    mocks.pool.getTelemetrySnapshots.mockResolvedValue([]);
     sendSpy = vi.spyOn(mocks.sock, 'send').mockResolvedValue(undefined);
   });
 
@@ -124,14 +133,17 @@ describe('IpcBridge step reply integrity when telemetry fails (issue #185)', () 
     consoleErrorSpy.mockRestore();
   });
 
-  it('skips the worker snapshot fetch in shared-memory mode', async () => {
+  it('fetches telemetry snapshots in shared-memory mode without blocking (issue #240)', async () => {
     mocks.pool.isUsingSharedMemory.mockReturnValueOnce(true);
 
     await initAndStepAtBoundary(12365);
 
     const response = lastSentResponse();
     expect(response.status).toBe('ok');
-    expect(mocks.pool.getTelemetrySnapshots).not.toHaveBeenCalled();
+    // getTelemetrySnapshots is non-blocking in shared mode (it returns an
+    // empty set immediately instead of waiting on unanswerable worker
+    // messages), so the bridge always fetches instead of skipping.
+    expect(mocks.pool.getTelemetrySnapshots).toHaveBeenCalled();
   });
 
   it('skips the telemetry block entirely when telemetry is disabled', async () => {
@@ -143,5 +155,33 @@ describe('IpcBridge step reply integrity when telemetry fails (issue #185)', () 
     expect(response.status).toBe('ok');
     expect(mocks.pool.getTelemetrySnapshots).not.toHaveBeenCalled();
     expect(mocks.gpReport).not.toHaveBeenCalled();
+  });
+
+  it('sends the step reply before the telemetry snapshot fetch completes (issue #229)', async () => {
+    const events: string[] = [];
+    let resolveSnapshots!: (value: BigUint64Array[]) => void;
+    mocks.pool.getTelemetrySnapshots.mockImplementation(() => new Promise<BigUint64Array[]>(res => {
+      events.push('snapshot-start');
+      resolveSnapshots = res;
+    }));
+    sendSpy.mockImplementation(async () => {
+      events.push('send');
+    });
+
+    await initAndStepAtBoundary(12367);
+
+    // init replies once, then the boundary step's reply is sent eagerly —
+    // before the telemetry fetch even begins — so a slow or hung worker
+    // snapshot fetch can never delay or stall the completed step's reply.
+    expect(events).toEqual(['send', 'send', 'snapshot-start']);
+
+    const response = lastSentResponse();
+    expect(response.status).toBe('ok');
+    expect(response.data).toHaveLength(1);
+    expect(mocks.pool.step).toHaveBeenCalledTimes(1);
+
+    // Unblock the detached telemetry task so it settles cleanly.
+    resolveSnapshots([]);
+    await new Promise(r => setImmediate(r));
   });
 });

--- a/tests/unit/worker-pool-failures.test.ts
+++ b/tests/unit/worker-pool-failures.test.ts
@@ -493,16 +493,25 @@ describe('WorkerPool failure state', () => {
     expect(results).toHaveLength(1);
   });
 
-  it('propagates telemetry snapshot errors without failing the pool', async () => {
+  it('returns non-blocking telemetry snapshots in shared mode without timing out (issue #240)', async () => {
     fakes.control.messageTimeoutMs = 20;
     pool = new WorkerPool(1);
     await pool.init(1, {}, true);
 
-    await expect(pool.getTelemetrySnapshots()).rejects.toThrow('timed out');
+    // Shared-mode workers block in Atomics.wait inside the wait-for-action
+    // loop and can never answer GET_TELEMETRY, so the snapshot must return
+    // immediately (empty) instead of waiting out messageTimeoutMs, and it
+    // must not fail the pool.
+    const started = Date.now();
+    const snapshots = await pool.getTelemetrySnapshots();
+    expect(Date.now() - started).toBeLessThan(200);
+    expect(snapshots).toHaveLength(0);
 
     expect(fakes.FakeWorker.instances[0].terminated).toBe(false);
+    expect(fakes.FakeSharedMemoryManager.instances[0].disposed).toBe(false);
     const results = await pool.step([0]);
     expect(results).toHaveLength(1);
+    expect((pool as any).state).toBe('ready');
   });
 
   it('propagates shared-memory read errors and disposes the pool', async () => {


### PR DESCRIPTION
## Summary

Two telemetry-related reliability fixes in the worker pool and the ZMQ IPC bridge.

- Fixes #240 — \WorkerPool.getTelemetrySnapshots()\ always timed out after 30 s in the default shared-memory mode: workers blocked in \Atomics.wait\ can never service \GET_TELEMETRY\, so the call burned \messageTimeoutMs\ and rejected every time. It now returns an empty snapshot set immediately (non-blocking, pool untouched) in shared mode.
- Fixes #229 — in message-passing mode the completed step's reply was serialized but only transmitted after the post-step telemetry snapshot fetch (\wait pool.getTelemetrySnapshots()\), so a hung worker held the reply — and the single-threaded ZMQ loop — for up to \messageTimeoutMs\ (30 s). The reply is now sent eagerly before the (detached, self-contained) telemetry work, which can no longer stall the loop.

## Changes

### #240 — non-blocking shared-memory telemetry snapshots
- \src/core/worker-pool.ts\: \getTelemetrySnapshots()\ early-returns \[]\ in shared-memory mode instead of issuing unanswerable \GET_TELEMETRY\ messages; message-mode timeout semantics unchanged (a hung worker still fails the pool).
- Regression tests: \	ests/unit/worker-pool-failures.test.ts\ (bounded resolution, pool stays usable) and \	ests/integration/worker-integration.test.ts\ (real shared-mode pool resolves < 1 s with an empty set).

### #229 — step reply emitted before telemetry
- \src/ipc/ipc-bridge.ts\: the boundary-step reply is transmitted immediately after serialization (before the telemetry block starts), and the telemetry block was extracted into a detached private \unPostStepTelemetry()\ that catches its own errors; shared and message modes now both fetch snapshots without blocking.
- Regression test: \	ests/unit/ipc-bridge-telemetry-integrity.test.ts\ asserts event order \send → send → snapshot-start\ (reply before the fetch) with the fetch kept pending, and the shared-mode fetch is now asserted to be called (non-blocking) instead of skipped.

## Validation
- \
pm run typecheck\ — 0 errors
- \
pm test\ — 58 files, 1262 passed / 19 skipped (baseline 1260 + 2 new)
- \git diff --check\ — clean
