### PR TITLE
fix(env,worker): terminal lifecycle — maxTicks settle, frame-skip hold, tick parity (#197, #222, #228)

### DIFF
--- a/benchmarks/layer3-environment.ts
+++ b/benchmarks/layer3-environment.ts
@@ -24,7 +24,11 @@ const STEPS = 2_000;
 const WARMUP = 50;
 
 function benchEnvironmentStep(): BenchmarkResult {
-    const env = new BonkEnvironment({ numOpponents: 1, frameSkip: 1 });
+    // A horizon far beyond the measured window keeps every measured step on
+    // the physics path: the environment now settles into a terminal (no
+    // physics advance) state once maxTicks is reached (#197), so the default
+    // 900-tick horizon would turn the tail of the run into trivial steps.
+    const env = new BonkEnvironment({ numOpponents: 1, frameSkip: 1, maxTicks: 1_000_000 });
     env.reset();
 
     for (let i = 0; i < WARMUP; i++) {
@@ -54,7 +58,7 @@ function benchEnvironmentStep(): BenchmarkResult {
 }
 
 function benchEnvironmentWithFrameSkip(): BenchmarkResult {
-    const env = new BonkEnvironment({ numOpponents: 1, frameSkip: 3 });
+    const env = new BonkEnvironment({ numOpponents: 1, frameSkip: 3, maxTicks: 1_000_000 });
     env.reset();
 
     for (let i = 0; i < WARMUP; i++) {

--- a/benchmarks/layer5-memory.ts
+++ b/benchmarks/layer5-memory.ts
@@ -33,7 +33,11 @@ function getRSSMB(): number {
 }
 
 function benchMemoryStability(): BenchmarkResult {
-    const env = new BonkEnvironment({ numOpponents: 1, frameSkip: 1 });
+    // A horizon far beyond the measured window keeps every step on the
+    // physics path: the environment now settles into a terminal (no physics
+    // advance) state once maxTicks is reached (#197), so the default 900-tick
+    // horizon would turn ~98% of a 50K-step run into trivial steps.
+    const env = new BonkEnvironment({ numOpponents: 1, frameSkip: 1, maxTicks: 1_000_000 });
     env.reset();
 
     for (let i = 0; i < WARMUP; i++) {

--- a/benchmarks/layer6-stability.ts
+++ b/benchmarks/layer6-stability.ts
@@ -34,7 +34,11 @@ interface SegmentResult {
 }
 
 function benchNativeStability(): BenchmarkResult {
-    const env = new BonkEnvironment({ numOpponents: 1, frameSkip: 1 });
+    // A horizon far beyond the measured window keeps every step on the
+    // physics path: the environment now settles into a terminal (no physics
+    // advance) state once maxTicks is reached (#197), so the default 900-tick
+    // horizon would turn ~99% of a 100K-step run into trivial steps.
+    const env = new BonkEnvironment({ numOpponents: 1, frameSkip: 1, maxTicks: 1_000_000 });
     env.reset();
 
     for (let i = 0; i < WARMUP; i++) env.step(0);

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -429,7 +429,10 @@ export class BonkEnvironment {
         // counting terminal reports so isTerminalHoldActive() can tell the
         // worker layer when the hold window has been served.
         if (this.terminalReached) {
-            this.frameSkipTicks++;
+            // Cap the counter at frameSkip so a long idle terminal stretch
+            // (until an explicit reset) never grows it unboundedly; the
+            // hold-active predicate reads only whether it is below frameSkip.
+            this.frameSkipTicks = Math.min(this.frameSkipTicks + 1, this.config.frameSkip);
             const observation = this.getObservation();
             return {
                 observation,

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -148,6 +148,11 @@ export class BonkEnvironment {
     private lastAction: PlayerInput = { left: false, right: false, up: false, down: false, heavy: false, grapple: false };
     private frameSkipTicks: number = 0;
     private terminalReached: boolean = false;
+    // Terminal cause as recorded when the episode ended: the tail (hold)
+    // steps replay these flags instead of hardcoding `truncated: false` /
+    // `terminated: true`, which inverted truncation into termination (#197).
+    private terminalTruncated: boolean = false;
+    private terminalTerminated: boolean = false;
     private _obsBuffer: Float32Array = new Float32Array(16);
     private ppm: number = 12;
     private capZones: Array<{ index: number; owner: string; type: number }> = [];
@@ -396,6 +401,8 @@ export class BonkEnvironment {
         // Reset frame skip state
         this.frameSkipTicks = 0;
         this.terminalReached = false;
+        this.terminalTruncated = false;
+        this.terminalTerminated = false;
         this.lastAction = { left: false, right: false, up: false, down: false, heavy: false, grapple: false };
 
         return this.getObservation();
@@ -413,27 +420,29 @@ export class BonkEnvironment {
      *   - Bit 5: grapple
      */
     step(action: Action): StepResult {
-        // If terminal was already reached in a previous tick of this cycle, return done immediately
-        // without stepping physics further (rewards were already accumulated)
+        // If terminal was already reached in a previous tick of this cycle,
+        // return done immediately without stepping physics further (rewards
+        // were already accumulated). terminalReached is only cleared by an
+        // explicit reset(): once the frame-skip hold window elapses, the
+        // episode stays idle (no physics advance, same flags) instead of
+        // resuming physics past maxTicks (#197). frameSkipTicks keeps
+        // counting terminal reports so isTerminalHoldActive() can tell the
+        // worker layer when the hold window has been served.
         if (this.terminalReached) {
             this.frameSkipTicks++;
-            if (this.frameSkipTicks >= this.config.frameSkip) {
-                this.frameSkipTicks = 0;
-                this.terminalReached = false;
-            }
             const observation = this.getObservation();
             return {
                 observation,
                 reward: 0,
                 done: true,
-                truncated: false,
+                truncated: this.terminalTruncated,
                 info: {
                     tick: this.physics.getTickCount(),
                     aiAlive: this.physics.getPlayerState(this.aiPlayerId).alive,
                     opponentsAlive: this.opponentIds.filter(
                         id => this.physics.getPlayerState(id).alive,
                     ).length,
-                    terminated: true,
+                    terminated: this.terminalTerminated,
                     frameSkip: this.config.frameSkip,
                     capZones: this.capZones,
                     scoreBlue: this.scoreBlue,
@@ -482,21 +491,25 @@ export class BonkEnvironment {
         const terminated = !aiState.alive || allOpponentsDead;
         const truncated = this.physics.getTickCount() >= this.config.maxTicks;
 
-        // If terminal reached, set flag to report done immediately on subsequent ticks
+        // If terminal reached, set flag to report done immediately on subsequent ticks.
+        // Record the terminal cause so the hold tail reports the same flags as
+        // the ending step instead of inverting truncation into termination (#197).
         if (terminated || truncated) {
             this.terminalReached = true;
+            this.terminalTruncated = truncated;
+            this.terminalTerminated = terminated;
         }
 
         // Increment frame skip counter
         this.frameSkipTicks++;
 
-        // Reset frame skip counter for next action after completing the cycle
-        if (this.frameSkipTicks >= this.config.frameSkip) {
+        // A normal cycle boundary (no terminal state) starts a fresh frame-skip
+        // cycle. When the episode ends on this step the counter is left at the
+        // boundary value: the hold window is measured through the current cycle,
+        // and a terminal step that lands exactly on the boundary serves no hold
+        // tail steps (isTerminalHoldActive already reports false).
+        if (this.frameSkipTicks >= this.config.frameSkip && !terminated && !truncated) {
             this.frameSkipTicks = 0;
-            // Only clear terminalReached if we're not in a terminal state
-            if (!terminated && !truncated) {
-                this.terminalReached = false;
-            }
         }
 
         const observation = this.getObservation();
@@ -695,6 +708,20 @@ export class BonkEnvironment {
         this._obsBuffer[14] = arenaBounds.halfHeight;
         this._obsBuffer[15] = this.physics.getTickCount();
         return this._obsBuffer;
+    }
+
+    /**
+     * True while the environment is inside the frame-skip terminal hold
+     * window: the episode has ended (this.terminalReached) but the current
+     * action cycle has not yet crossed its boundary (frameSkipTicks below
+     * frameSkip). The worker layer uses this to defer auto-reset until the
+     * entire hold window has been reported, so with frameSkip > 1 the
+     * terminal done result is delivered for the full window before a fresh
+     * episode begins (#228). Once the window elapses the environment stays
+     * terminal (no physics advance, same flags) until reset() (#197).
+     */
+    isTerminalHoldActive(): boolean {
+        return this.terminalReached && this.frameSkipTicks < this.config.frameSkip;
     }
 
     /**

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -1,5 +1,5 @@
 import { parentPort } from 'worker_threads';
-import { BonkEnvironment, Action, Observation } from './environment';
+import { BonkEnvironment, Action, Observation, StepResult } from './environment';
 import { SharedMemoryManager } from '../ipc/shared-memory';
 
 // Type for SharedArrayBuffer (available in Node.js >= 9.1.0)
@@ -124,6 +124,30 @@ function quantizeObservation(obs: Observation): Observation {
     };
 }
 
+/**
+ * Applies the per-env auto-reset rule for a step result. The terminal
+ * observation is always captured on a done step. The environment itself is
+ * reset only once its frame-skip terminal hold window has been served: with
+ * frameSkip > 1 the env keeps returning done for the whole window, so an
+ * unconditional reset on the first done step would discard the hold and
+ * surface a fresh episode one step after the terminal one (#228). On the
+ * reset step the result keeps the ended episode's observation, so the
+ * returned graph stays internally consistent (observation.tick aligns with
+ * info.tick, and the fresh episode's observation only appears on the next
+ * step, #222).
+ */
+function applyStepAutoReset(env: BonkEnvironment, res: StepResult): StepResult {
+    if (!res.done) return res;
+    res.info.terminal_observation = res.observation;
+    if (!env.isTerminalHoldActive()) {
+        const terminalObservation = res.observation;
+        env.reset();
+        res.observation = terminalObservation;
+    }
+    return res;
+}
+}
+
 parentPort.on('message', (msg) => {
     try {
         if (msg.type === 'init') {
@@ -200,14 +224,7 @@ parentPort.on('message', (msg) => {
             // Handle step with message passing (fallback mode)
             const actions: Action[] = msg.actions;
 
-            const results = envs.map((env, i) => {
-                const res = env.step(actions[i]);
-                if (res.done) {
-                    res.info.terminal_observation = res.observation;
-                    res.observation = env.reset();
-                }
-                return res;
-            });
+            const results = envs.map((env, i) => applyStepAutoReset(env, env.step(actions[i])));
 
             stepCounter++;
             if (stepCounter % 1000 === 0) {
@@ -251,14 +268,7 @@ parentPort.on('message', (msg) => {
             const actions = sharedMem.readActions(sharedMem.readActionSlot());
 
             // Process environments
-            const results = envs.map((env, i) => {
-                const res = env.step(actions[i]);
-                if (res.done) {
-                    res.info.terminal_observation = res.observation;
-                    res.observation = env.reset();
-                }
-                return res;
-            });
+            const results = envs.map((env, i) => applyStepAutoReset(env, env.step(actions[i])));
 
             stepCounter++;
             if (stepCounter % 100 === 0) {
@@ -274,7 +284,12 @@ parentPort.on('message', (msg) => {
                     } else {
                         sharedMem!.writeHasTerminalObs(i, 0);
                     }
-                    sharedMem!.writeObservation(i, observationFastToArray(envs[i]));
+                    // The observation region must describe the same episode
+                    // as info.tick: on a done step the environment may
+                    // already have been auto-reset (hold complete), so write
+                    // the result's terminal observation instead of the next
+                    // episode's fresh spawn (#222).
+                    sharedMem!.writeObservation(i, res.done ? observationToArray(res.observation) : observationFastToArray(envs[i]));
                     sharedMem!.writeReward(i, res.reward);
                     sharedMem!.writeDone(i, res.done ? 1 : 0);
                     sharedMem!.writeTruncated(i, res.truncated ? 1 : 0);
@@ -345,14 +360,7 @@ parentPort.on('message', (msg) => {
                         const actionSlot = sharedMem.readActionSlot();
                         const actions = sharedMem.getActionsView(actionSlot);
 
-                        const results = envs.map((env, i) => {
-                            const res = env.step(actions[i]);
-                            if (res.done) {
-                                res.info.terminal_observation = res.observation;
-                                res.observation = env.reset();
-                            }
-                            return res;
-                        });
+                        const results = envs.map((env, i) => applyStepAutoReset(env, env.step(actions[i])));
 
                         stepCounter++;
                         if (verbose && stepCounter % 1000 === 0) {
@@ -366,7 +374,13 @@ parentPort.on('message', (msg) => {
                             } else {
                                 sharedMem!.writeHasTerminalObs(i, 0);
                             }
-                            sharedMem!.writeObservation(i, observationFastToArray(envs[i]));
+                            // The observation region must describe the same
+                            // episode as info.tick: on a done step the
+                            // environment may already have been auto-reset
+                            // (hold complete), so write the result's terminal
+                            // observation instead of the next episode's fresh
+                            // spawn (#222).
+                            sharedMem!.writeObservation(i, res.done ? observationToArray(res.observation) : observationFastToArray(envs[i]));
                             sharedMem!.writeReward(i, res.reward);
                             sharedMem!.writeDone(i, res.done ? 1 : 0);
                             sharedMem!.writeTruncated(i, res.truncated ? 1 : 0);

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -146,7 +146,6 @@ function applyStepAutoReset(env: BonkEnvironment, res: StepResult): StepResult {
     }
     return res;
 }
-}
 
 parentPort.on('message', (msg) => {
     try {

--- a/tests/integration/env-terminal-lifecycle.test.ts
+++ b/tests/integration/env-terminal-lifecycle.test.ts
@@ -2,18 +2,20 @@
  * env-terminal-lifecycle.test.ts — Regression coverage for issues #197,
  * #222 and #228, which share the environment's terminal state machine:
  *
- *   #197 — A maxTicks-truncated episode must settle: after done, the
- *          environment keeps reporting the recorded terminal cause
- *          (truncated=true / info.terminated=false) and never advances
- *          physics past maxTicks until an explicit reset().
+ *   #197 — A maxTicks-truncated (or death-terminated) episode must settle:
+ *          after done, the environment keeps reporting the recorded terminal
+ *          cause (never inverted) and never advances physics until an
+ *          explicit reset().
  *   #222 — The terminal step result must be internally consistent:
  *          observation.tick === info.tick on the done step in both
  *          transports (it was always 0 before — the post-auto-reset fresh
  *          episode — while info.tick reported the ended episode's tick).
  *   #228 — With frameSkip > 1 the terminal done result must be held for the
- *          full frame-skip window before the worker auto-resets, so the
- *          caller's action cycle stays aligned and a fresh episode only
- *          appears after the cycle boundary.
+ *          remainder of the frame-skip cycle before the worker auto-resets,
+ *          so the caller's action cycle stays aligned and a fresh episode
+ *          only appears after the cycle boundary. Covered at every cycle
+ *          alignment: episode ending at the cycle start, mid-cycle, and
+ *          exactly on the boundary (maxTicks % frameSkip === 0).
  */
 import { describe, it, expect } from 'vitest';
 import { BonkEnvironment } from '../../src/core/environment';
@@ -31,6 +33,22 @@ const boxMap: MapDef = {
     { name: 'left', type: 'rect', x: -500, y: 0, width: 30, height: 600, static: true },
     { name: 'right', type: 'rect', x: 500, y: 0, width: 30, height: 600, static: true },
   ],
+};
+
+const lethalMap: MapDef = {
+  name: 'terminal-lifecycle-lethal',
+  spawnPoints: { team_blue: { x: 0, y: -300 }, team_red: { x: 200, y: -100 } },
+  bodies: [
+    { name: 'lethal', type: 'rect', x: 0, y: 200, width: 800, height: 30, static: true, isLethal: true },
+  ],
+};
+
+// Spawns the AI beyond the 850-unit death circle, so it dies on the very
+// first tick (the position used by worker-pool-termination-flags.test.ts).
+const deathAtTickOneMap: MapDef = {
+  name: 'death_at_tick_one',
+  spawnPoints: { team_blue: { x: 900, y: 0 }, team_red: { x: 200, y: -100 } },
+  bodies: [{ name: 'floor', type: 'rect', x: 0, y: 200, width: 800, height: 30, static: true }],
 };
 
 describe('maxTicks-truncated episodes settle (issue #197)', () => {
@@ -119,6 +137,49 @@ describe('maxTicks-truncated episodes settle (issue #197)', () => {
       env.close();
     }
   });
+
+  it('direct environment replays a death termination without inverting it into a truncation', () => {
+    const env = new BonkEnvironment({
+      mapData: lethalMap,
+      maxTicks: 400,
+      frameSkip: 4,
+      numOpponents: 0,
+      randomOpponent: false,
+      seed: 42,
+    });
+    try {
+      env.reset(42);
+
+      let death: ReturnType<typeof env.step> | null = null;
+      for (let i = 0; i < 300; i++) {
+        const res = env.step(0);
+        if (res.done) {
+          death = res;
+          break;
+        }
+      }
+      expect(death).not.toBeNull();
+      expect(death!.truncated).toBe(false);
+      expect(death!.info.terminated).toBe(true);
+      const deathTick = death!.info.tick;
+
+      // Forward from the death: the tail must keep replaying the recorded
+      // death cause (truncated=false / terminated=true) with the tick frozen
+      // — never inverting the termination into a truncation and never
+      // advancing physics past the death tick.
+      for (let i = 0; i < 12; i++) {
+        const res = env.step(0);
+        expect(res.done).toBe(true);
+        expect(res.truncated).toBe(false);
+        expect(res.info.terminated).toBe(true);
+        expect(res.info.tick).toBe(deathTick);
+        expect(res.observation.tick).toBe(deathTick);
+        expect(res.reward).toBe(0);
+      }
+    } finally {
+      env.close();
+    }
+  });
 });
 
 describe('frame_skip terminal hold survives auto-reset (issue #228)', () => {
@@ -173,6 +234,151 @@ describe('frame_skip terminal hold survives auto-reset (issue #228)', () => {
 
   it('message-passing mode reports the full terminal hold before auto-reset', async () => {
     await runHold(false);
+  });
+
+  // The hold serves the remainder of the current action cycle, so its
+  // length depends on where in the cycle the episode ends. These two cases
+  // pin the alignment semantics: mid-cycle truncation holds for the rest of
+  // the cycle, boundary-aligned truncation holds only its own step.
+  const runMidCycleTruncation = async (useSharedMemory: boolean) => {
+    const pool = new WorkerPool(1);
+    try {
+      // maxTicks=6 lands on tick 6, the second tick of the 5-8 cycle, so
+      // the hold covers ticks 6-8 (3 done steps) before the cycle boundary.
+      await pool.init(
+        1,
+        { mapData: boxMap, maxTicks: 6, frameSkip: 4, numOpponents: 0, randomOpponent: false },
+        useSharedMemory,
+      );
+      await pool.reset([1]);
+
+      const steps: Array<{ done: boolean; truncated: boolean; infoTick: number; obsTick: number }> = [];
+      for (let i = 1; i <= 9; i++) {
+        const [res] = await pool.step([0]);
+        steps.push({
+          done: res.done,
+          truncated: res.truncated,
+          infoTick: res.info.tick,
+          obsTick: res.observation.tick,
+        });
+      }
+
+      for (let i = 0; i < 5; i++) {
+        expect(steps[i].done).toBe(false);
+        expect(steps[i].obsTick).toBe(i + 1);
+        expect(steps[i].infoTick).toBe(i + 1);
+      }
+      for (let i = 5; i < 8; i++) {
+        expect(steps[i].done).toBe(true);
+        expect(steps[i].truncated).toBe(true);
+        expect(steps[i].obsTick).toBe(6);
+        expect(steps[i].infoTick).toBe(6);
+      }
+      expect(steps[8].done).toBe(false);
+      expect(steps[8].obsTick).toBe(1);
+      expect(steps[8].infoTick).toBe(1);
+    } finally {
+      await pool.close();
+    }
+  };
+
+  it('shared-memory mode holds a mid-cycle truncation until the cycle boundary', async () => {
+    if (!WorkerPool.isSupported()) return;
+    await runMidCycleTruncation(true);
+  });
+
+  it('message-passing mode holds a mid-cycle truncation until the cycle boundary', async () => {
+    await runMidCycleTruncation(false);
+  });
+
+  const runBoundaryAlignedTruncation = async (useSharedMemory: boolean) => {
+    const pool = new WorkerPool(1);
+    try {
+      // maxTicks=4 is a multiple of frameSkip, so the episode ends exactly
+      // on the cycle boundary: the hold window contains only the terminal
+      // step itself, and the fresh episode starts at the next boundary.
+      await pool.init(
+        1,
+        { mapData: boxMap, maxTicks: 4, frameSkip: 4, numOpponents: 0, randomOpponent: false },
+        useSharedMemory,
+      );
+      await pool.reset([1]);
+
+      const steps: Array<{ done: boolean; truncated: boolean; infoTick: number; obsTick: number }> = [];
+      for (let i = 1; i <= 6; i++) {
+        const [res] = await pool.step([0]);
+        steps.push({
+          done: res.done,
+          truncated: res.truncated,
+          infoTick: res.info.tick,
+          obsTick: res.observation.tick,
+        });
+      }
+
+      for (let i = 0; i < 3; i++) {
+        expect(steps[i].done).toBe(false);
+        expect(steps[i].obsTick).toBe(i + 1);
+        expect(steps[i].infoTick).toBe(i + 1);
+      }
+      expect(steps[3].done).toBe(true);
+      expect(steps[3].truncated).toBe(true);
+      expect(steps[3].obsTick).toBe(4);
+      expect(steps[3].infoTick).toBe(4);
+      expect(steps[4].done).toBe(false);
+      expect(steps[4].obsTick).toBe(1);
+      expect(steps[4].infoTick).toBe(1);
+      expect(steps[5].done).toBe(false);
+      expect(steps[5].obsTick).toBe(2);
+      expect(steps[5].infoTick).toBe(2);
+    } finally {
+      await pool.close();
+    }
+  };
+
+  it('shared-memory mode emits a single done for a boundary-aligned truncation', async () => {
+    if (!WorkerPool.isSupported()) return;
+    await runBoundaryAlignedTruncation(true);
+  });
+
+  it('message-passing mode emits a single done for a boundary-aligned truncation', async () => {
+    await runBoundaryAlignedTruncation(false);
+  });
+
+  const runDeathHold = async (useSharedMemory: boolean) => {
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(
+        1,
+        { mapData: deathAtTickOneMap, maxTicks: 100, frameSkip: 4, numOpponents: 1 },
+        useSharedMemory,
+      );
+      await pool.reset([42]);
+
+      // The AI dies on tick 1 of every episode, so every cycle reports 4
+      // terminal steps (death + 3 hold). The death cause must be replayed —
+      // terminated=true, truncated=false — and observation/info must stay
+      // aligned on each done step. 8 steps = two full death cycles.
+      for (let i = 1; i <= 8; i++) {
+        const [res] = await pool.step([0]);
+        expect(res.done).toBe(true);
+        expect(res.truncated).toBe(false);
+        expect(res.terminated).toBe(true);
+        expect(res.info.terminated).toBe(true);
+        expect(res.info.tick).toBe(1);
+        expect(res.observation.tick).toBe(1);
+      }
+    } finally {
+      await pool.close();
+    }
+  };
+
+  it('shared-memory mode replays a death termination through the hold without inversion', async () => {
+    if (!WorkerPool.isSupported()) return;
+    await runDeathHold(true);
+  });
+
+  it('message-passing mode replays a death termination through the hold without inversion', async () => {
+    await runDeathHold(false);
   });
 });
 

--- a/tests/integration/env-terminal-lifecycle.test.ts
+++ b/tests/integration/env-terminal-lifecycle.test.ts
@@ -1,0 +1,228 @@
+/**
+ * env-terminal-lifecycle.test.ts — Regression coverage for issues #197,
+ * #222 and #228, which share the environment's terminal state machine:
+ *
+ *   #197 — A maxTicks-truncated episode must settle: after done, the
+ *          environment keeps reporting the recorded terminal cause
+ *          (truncated=true / info.terminated=false) and never advances
+ *          physics past maxTicks until an explicit reset().
+ *   #222 — The terminal step result must be internally consistent:
+ *          observation.tick === info.tick on the done step in both
+ *          transports (it was always 0 before — the post-auto-reset fresh
+ *          episode — while info.tick reported the ended episode's tick).
+ *   #228 — With frameSkip > 1 the terminal done result must be held for the
+ *          full frame-skip window before the worker auto-resets, so the
+ *          caller's action cycle stays aligned and a fresh episode only
+ *          appears after the cycle boundary.
+ */
+import { describe, it, expect } from 'vitest';
+import { BonkEnvironment } from '../../src/core/environment';
+import { WorkerPool } from '../../src/core/worker-pool';
+import type { MapDef } from '../../src/core/physics-engine';
+
+const boxMap: MapDef = {
+  name: 'terminal-lifecycle-box',
+  spawnPoints: {
+    team_blue: { x: -200, y: -100 },
+    team_red: { x: 200, y: -100 },
+  },
+  bodies: [
+    { name: 'floor', type: 'rect', x: 0, y: 200, width: 800, height: 30, static: true },
+    { name: 'left', type: 'rect', x: -500, y: 0, width: 30, height: 600, static: true },
+    { name: 'right', type: 'rect', x: 500, y: 0, width: 30, height: 600, static: true },
+  ],
+};
+
+describe('maxTicks-truncated episodes settle (issue #197)', () => {
+  it('direct environment freezes at maxTicks with stable flags until reset', () => {
+    const env = new BonkEnvironment({
+      mapData: boxMap,
+      maxTicks: 3,
+      numOpponents: 0,
+      randomOpponent: false,
+      seed: 42,
+    });
+    try {
+      env.reset(42);
+
+      expect(env.step(0).done).toBe(false);
+      expect(env.step(0).done).toBe(false);
+
+      // tick 3 = maxTicks: truncation reported exactly once with the correct
+      // cause (truncated, never terminated).
+      const done = env.step(0);
+      expect(done.done).toBe(true);
+      expect(done.truncated).toBe(true);
+      expect(done.info.terminated).toBe(false);
+      expect(done.observation.tick).toBe(3);
+      expect(done.info.tick).toBe(3);
+
+      // Well past maxTicks: the episode stays settled — same flags, no
+      // physics advance, no step ever inverts truncation into termination.
+      for (let i = 0; i < 12; i++) {
+        const res = env.step(0);
+        expect(res.done).toBe(true);
+        expect(res.truncated).toBe(true);
+        expect(res.info.terminated).toBe(false);
+        expect(res.observation.tick).toBe(3);
+        expect(res.info.tick).toBe(3);
+        expect(res.reward).toBe(0);
+      }
+
+      // An explicit reset ends the terminal state.
+      env.reset(42);
+      const fresh = env.step(0);
+      expect(fresh.done).toBe(false);
+      expect(fresh.observation.tick).toBe(1);
+    } finally {
+      env.close();
+    }
+  });
+
+  it('direct environment settles with frameSkip > 1 after the hold window', () => {
+    const env = new BonkEnvironment({
+      mapData: boxMap,
+      maxTicks: 5,
+      frameSkip: 4,
+      numOpponents: 0,
+      randomOpponent: false,
+      seed: 42,
+    });
+    try {
+      env.reset(42);
+
+      const observed: Array<{ step: number; done: boolean; truncated: boolean; terminated: boolean; tick: number }> = [];
+      for (let i = 1; i <= 20; i++) {
+        const res = env.step(0);
+        observed.push({
+          step: i,
+          done: res.done,
+          truncated: res.truncated,
+          terminated: res.info.terminated,
+          tick: res.info.tick,
+        });
+      }
+
+      // Steps 1-4 run; step 5 ends (truncated); steps 6-8 hold; steps 9+
+      // stay idle — the flags and tick never change and never invert.
+      for (const o of observed) {
+        if (o.step <= 4) {
+          expect(o.done).toBe(false);
+        } else {
+          expect(o.done).toBe(true);
+          expect(o.truncated).toBe(true);
+          expect(o.terminated).toBe(false);
+          expect(o.tick).toBe(5);
+        }
+      }
+    } finally {
+      env.close();
+    }
+  });
+});
+
+describe('frame_skip terminal hold survives auto-reset (issue #228)', () => {
+  const runHold = async (useSharedMemory: boolean) => {
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(
+        1,
+        { mapData: boxMap, maxTicks: 5, frameSkip: 4, numOpponents: 0, randomOpponent: false },
+        useSharedMemory,
+      );
+      await pool.reset([1]);
+
+      const steps: Array<{ done: boolean; truncated: boolean; infoTick: number; obsTick: number }> = [];
+      for (let i = 1; i <= 9; i++) {
+        const [res] = await pool.step([0]);
+        steps.push({
+          done: res.done,
+          truncated: res.truncated,
+          infoTick: res.info.tick,
+          obsTick: res.observation.tick,
+        });
+      }
+
+      // Steps 1-4 run; step 5 ends (truncated); steps 6-8 hold the done
+      // result for the rest of the frame-skip window; step 9 is the fresh
+      // episode's first tick. The terminal observation is never silently
+      // dropped by the pool's auto-reset.
+      for (let i = 0; i < 4; i++) {
+        expect(steps[i].done).toBe(false);
+        expect(steps[i].obsTick).toBe(i + 1);
+        expect(steps[i].infoTick).toBe(i + 1);
+      }
+      for (let i = 4; i < 8; i++) {
+        expect(steps[i].done).toBe(true);
+        expect(steps[i].truncated).toBe(true);
+        expect(steps[i].obsTick).toBe(5);
+        expect(steps[i].infoTick).toBe(5);
+      }
+      expect(steps[8].done).toBe(false);
+      expect(steps[8].obsTick).toBe(1);
+      expect(steps[8].infoTick).toBe(1);
+    } finally {
+      await pool.close();
+    }
+  };
+
+  it('shared-memory mode reports the full terminal hold before auto-reset', async () => {
+    if (!WorkerPool.isSupported()) return;
+    await runHold(true);
+  });
+
+  it('message-passing mode reports the full terminal hold before auto-reset', async () => {
+    await runHold(false);
+  });
+});
+
+describe('terminal-step observation tick matches info tick (issue #222)', () => {
+  const runParity = async (useSharedMemory: boolean) => {
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(
+        1,
+        { mapData: boxMap, maxTicks: 3, numOpponents: 0, randomOpponent: false },
+        useSharedMemory,
+      );
+      await pool.reset([1]);
+
+      let steps = 0;
+      let doneResult: any = null;
+      for (let i = 1; i <= 10; i++) {
+        const [res] = await pool.step([0]);
+        steps = i;
+        // The invariant holds on every step, terminal included: observation
+        // and info describe the same state/transition.
+        expect(res.observation.tick).toBe(res.info.tick);
+        if (res.done) {
+          doneResult = res;
+          break;
+        }
+      }
+
+      expect(doneResult).not.toBeNull();
+      expect(steps).toBe(3);
+      expect(doneResult.info.tick).toBe(3);
+      expect(doneResult.observation.tick).toBe(3);
+      expect(doneResult.info.terminal_observation.tick).toBe(3);
+
+      // The next step is the fresh episode, again internally consistent.
+      const [fresh] = await pool.step([0]);
+      expect(fresh.done).toBe(false);
+      expect(fresh.observation.tick).toBe(1);
+      expect(fresh.info.tick).toBe(1);
+    } finally {
+      await pool.close();
+    }
+  };
+
+  it('shared-memory mode: observation.tick === info.tick on the terminal step', async () => {
+    if (!WorkerPool.isSupported()) return;
+    await runParity(true);
+  });
+
+  it('message-passing mode: observation.tick === info.tick on the terminal step', async () => {
+    await runParity(false);
+  });
+});

--- a/tests/integration/environment-edge-cases.test.ts
+++ b/tests/integration/environment-edge-cases.test.ts
@@ -1095,18 +1095,26 @@ describe('BonkEnvironment edge cases', () => {
       expect(result.done).toBe(true);
     });
 
-    it('returns truncated=false after terminal reached (not truncation)', async () => {
+    it('keeps reporting truncated for the ended episode after terminal reached', async () => {
+      // #197: the terminal-hold tail must replay the recorded terminal cause
+      // instead of hardcoding truncated:false / info.terminated:true, which
+      // inverted a maxTicks truncation into a termination.
       env = new BonkEnvironment({ maxTicks: 1, numOpponents: 0 });
       env.reset();
-      env.step(0);
+      expect(env.step(0).truncated).toBe(true);
       const result = env.step(0);
-      expect(result.truncated).toBe(false);
+      expect(result.done).toBe(true);
+      expect(result.truncated).toBe(true);
+      expect(result.info.terminated).toBe(false);
     });
   });
 
   describe('frame skip with terminal', () => {
-    it('terminalReached clears after frame skip cycle completes', async () => {
-      const mapData: MapDef = makeMap({});
+    it('episode stays terminal after the frame skip cycle completes', async () => {
+      // #197: once the hold window elapses the env must stay idle (done,
+      // stable flags, no physics advance) instead of resuming physics past
+      // maxTicks and inverting truncated/terminated on alternating steps.
+      const mapData = makeMap({});
       env = new BonkEnvironment({ mapData, maxTicks: 2, frameSkip: 2, numOpponents: 0 });
       env.reset();
       env.step(0);
@@ -1114,6 +1122,9 @@ describe('BonkEnvironment edge cases', () => {
       expect(result.done).toBe(true);
       const afterCycle = env.step(0);
       expect(afterCycle.done).toBe(true);
+      expect(afterCycle.truncated).toBe(true);
+      expect(afterCycle.info.terminated).toBe(false);
+      expect(afterCycle.observation.tick).toBe(2);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes three environment-lifecycle defects that share the terminal state machine:

Fixes #228
Fixes #197
Fixes #222

### #228 — frame_skip terminal hold silently dropped by auto-reset
The worker step handlers unconditionally called `env.reset()` on every done result, which cleared the environment's frame-skip terminal hold, so with `frameSkip > 1` the pool emitted a single `done: true` and returned a fresh episode on the very next step. `BonkEnvironment.isTerminalHoldActive()` now exposes whether the hold window is still being served, and the worker defers the auto-reset until the current frame-skip cycle's boundary, so the terminal observation is delivered for the full remainder of the cycle (up to `frameSkip` steps when the episode ends at the start of a cycle, e.g. `maxTicks: 5, frameSkip: 4` → done on steps 5-8) before the fresh episode appears.

### #197 — maxTicks-truncated episodes never settle
`BonkEnvironment.step()` cleared `terminalReached` after the frame-skip tail and then resumed physics past `maxTicks`, inverting `truncated`/`terminated` on alternating steps. The terminal cause is now recorded (`terminalTruncated`/`terminalTerminated`) and replayed by every tail step: once terminal (truncated or death-terminated), the environment stays idle — same flags, no physics advance, tick frozen — until an explicit `reset()`.

### #222 — terminal-step result internally inconsistent
`env.reset()` on the done step replaced the result's observation with the next episode's spawn (`observation.tick === 0`) while `info.tick` kept the ended episode's tick. The worker now keeps the ended episode's observation on the reset step (and the shared-memory path writes that observation into the SAB observation region), so `observation.tick === info.tick` on the terminal step in both transports; the fresh episode's observation only appears on the next step.

## Changes
- `src/core/environment.ts` — record terminal cause; terminal state settles (no physics re-entry); `isTerminalHoldActive()`; hold counter capped at `frameSkip`
- `src/core/worker.ts` — auto-reset deferred to the hold end; done-step observation/info reconciled in all three step handlers (including the SAB observation region)
- `tests/integration/env-terminal-lifecycle.test.ts` — regression coverage for #197/#222/#228 in both transports, across cycle alignments (episode ending at cycle start, mid-cycle, and exactly on a boundary) plus death-termination replay
- `tests/integration/environment-edge-cases.test.ts` — updated stale assertions that pinned the truncation→termination inversion
- `benchmarks/layer3-environment.ts`, `benchmarks/layer5-memory.ts`, `benchmarks/layer6-stability.ts` — the direct-env benchmarks now run with a horizon beyond their measured windows, because the environment correctly settles terminal at `maxTicks`; every measured step still exercises physics

## Validation
- `npm run typecheck`: 0 errors
- `npm test`: 59 files, 1273 passed, 19 skipped (baseline 58/1260/19 recovered after the fix)
- `git diff --check`: clean
- Benchmarks layer3/layer5/layer6 native-env cases pass