### PR TITLE
fix(physics): native grapple window + a1a recharge (#238, #239)

### DIFF
--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -81,8 +81,9 @@ export const HEAVY_FORCE_MULTIPLIER = 0.7;
  *   `swingF = 2` (Hz) and `swingD = 0` (§32.4). `fh`/`dr` are map `d`-joint
  *   fields and never apply to the grapple.
  * - `a1a` energy meter (§32.3): spawn 1000, fire gate `a1a > 500`, drain
- *   4/step while swinging, recharge 3/step otherwise, forced release and
- *   zeroing below 500. The literal 500 is this energy threshold, NOT a reach.
+ *   4/step while swinging from the tick AFTER attach, recharge 3/step
+ *   otherwise, forced release and zeroing below 500. The literal 500 is this
+ *   energy threshold, NOT a reach.
  */
 /** Native QueryAABB half-extent (native world units). Consumed as `* ppm / SCALE`. */
 export const GRAPPLE_TARGET_WINDOW = 10.0;
@@ -215,6 +216,14 @@ export class PhysicsEngine {
   private playerGrappleJoints: Map<number, any> = new Map();
   /** Native a1a grapple/energy meter (0-1000), per player (DEOBFUSCATION §32.3). */
   private grappleEnergy: Map<number, number> = new Map();
+  /**
+   * Disc IDs whose grapple joint was created this tick. Native §32.3 runs the
+   * a1a update BEFORE the fire gate in the same step, so the attach step never
+   * drains the new rope; this marker makes updateGrappleEnergy() recharge
+   * (instead of draining) on exactly that tick and lets a re-fire at the 501
+   * crossing survive instead of being force-released in the same tick.
+   */
+  private swingJustStarted: Set<number> = new Set();
   private playerTeams: Map<number, string> = new Map();
   private capZoneSensors: any[] = [];
   private lastScoredTeam: string | null = null;
@@ -917,6 +926,13 @@ export class PhysicsEngine {
 
     const joint = this.world.CreateJoint(jointDef);
     this.playerGrappleJoints.set(playerId, joint);
+    // §32.3 native step order: the a1a update runs before the fire gate in the
+    // same physics step, so the attach tick must not drain (or force-release)
+    // the new rope — updateGrappleEnergy() recharges it instead so the first
+    // drain hits on the next tick. Without this a re-fire at exactly 501 is
+    // force-released in the same tick (501 - 4 = 497 < 500) and the recharge
+    // path is dead.
+    this.swingJustStarted.add(playerId);
   }
 
   /**
@@ -995,7 +1011,9 @@ export class PhysicsEngine {
   }
 
   /**
-   * §32.3 a1a energy meter: drain 4/step while swinging with forced release
+   * §32.3 a1a energy meter: drain 4/step while swinging (from the tick AFTER
+   * the rope attaches; the attach tick recharges because the native runs its
+   * a1a update before the fire gate in the same step) with forced release
    * (and zeroing) below 500; recharge 3/step otherwise, capped at 1000.
    */
   private updateGrappleEnergy(): void {
@@ -1003,11 +1021,20 @@ export class PhysicsEngine {
       if (!this.playerAlive.get(playerId)) continue;
       let energy = this.grappleEnergy.get(playerId) ?? A1A_SPAWN;
       if (this.playerGrappleJoints.has(playerId)) {
-        energy -= A1A_SWING_DRAIN;
-        if (energy < 0) energy = 0;
-        if (energy < A1A_FIRE_THRESHOLD) {
-          energy = 0;
-          this.releaseGrapple(playerId); // forced release below 500
+        if (this.swingJustStarted.delete(playerId)) {
+          // Attach tick (§32.3 native order): the step's energy update already
+          // ran before the fire gate, so it applies the not-yet-swinging
+          // recharge branch. A re-fire at 501 recharges to 504 and thus
+          // survives its first drain instead of being released in the same
+          // tick (501 - 4 = 497 < 500).
+          energy = Math.min(energy + A1A_RECHARGE, A1A_MAX);
+        } else {
+          energy -= A1A_SWING_DRAIN;
+          if (energy < 0) energy = 0;
+          if (energy < A1A_FIRE_THRESHOLD) {
+            energy = 0;
+            this.releaseGrapple(playerId); // forced release below 500
+          }
         }
       } else {
         energy = Math.min(energy + A1A_RECHARGE, A1A_MAX);
@@ -1291,6 +1318,7 @@ export class PhysicsEngine {
     this.playerDeathType.clear();
     this.playerGrappleJoints.clear();
     this.grappleEnergy.clear();
+    this.swingJustStarted.clear();
     this.playerTeams.clear();
     this.capZoneSensors = [];
     this.capZoneState.clear();

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -71,7 +71,11 @@ export const HEAVY_FORCE_MULTIPLIER = 0.7;
 /**
  * Verified native grapple constants:
  * - Targeting: QueryAABB ±10 world units around the disc center, candidates
- *   scored by center-to-surface distance `d < 10` (§32.1).
+ *   scored by center-to-surface distance `d < 10` (§32.1). The 10 is in
+ *   NATIVE world units (`map px / ppm`); this port's world is `map px / SCALE`,
+ *   so the window is consumed as `GRAPPLE_TARGET_WINDOW * ppm / SCALE` port
+ *   units — 4.0 at the default ppm = 12 (120 map px = 10 disc radii, not the
+ *   300 map px a bare 10.0 port-unit window would reach).
  * - Joint: `frequencyHz = (sep < swing.l) ? 0.01 : swingF`,
  *   `dampingRatio = swingD`, with the only table-proven writers being
  *   `swingF = 2` (Hz) and `swingD = 0` (§32.4). `fh`/`dr` are map `d`-joint
@@ -80,6 +84,7 @@ export const HEAVY_FORCE_MULTIPLIER = 0.7;
  *   4/step while swinging, recharge 3/step otherwise, forced release and
  *   zeroing below 500. The literal 500 is this energy threshold, NOT a reach.
  */
+/** Native QueryAABB half-extent (native world units). Consumed as `* ppm / SCALE`. */
 export const GRAPPLE_TARGET_WINDOW = 10.0;
 export const GRAPPLE_FREQUENCY_HZ = 2.0;   // native swingF
 export const GRAPPLE_DAMPING_RATIO = 0.0;  // native swingD
@@ -846,17 +851,22 @@ export class PhysicsEngine {
 
     const playerPos = body.GetPosition();
 
-    // §32.1: candidates must lie within a ±10 world-unit window of the disc
-    // center, scored by center-to-surface distance `d < 10`. The native
-    // QueryAABB is a broadphase pre-filter over that same window; iterating
-    // the port's platform bodies (the only grappable "phys" bodies) with the
-    // identical d < 10 scoring yields exactly the same candidate set. The
-    // per-shape AABB overlap test below reproduces the broadphase filter
-    // without a fixed-size result buffer: a shape whose surface is within 10
-    // units of the disc center always overlaps the ±10 box.
+    // §32.1: candidates must lie within the native ±10 world-unit window of
+    // the disc center, scored by center-to-surface distance `d < 10`. The 10
+    // is a NATIVE world unit (= map px / ppm); this port's world is
+    // map px / SCALE, so the window is converted once here to
+    // `10 * ppm / SCALE` port units (4.0 at the default ppm = 12 → 120 map px
+    // = 10 disc radii, not the 300 map px a bare 10.0 value would reach). The
+    // native QueryAABB is a broadphase pre-filter over that same window;
+    // iterating the port's platform bodies (the only grappable "phys" bodies)
+    // with the identical `d < window` scoring yields exactly the same candidate
+    // set. The per-shape AABB overlap test below reproduces the broadphase
+    // filter without a fixed-size result buffer: a shape whose surface is
+    // within `window` units of the disc center always overlaps the ±window box.
+    const windowUnits = (GRAPPLE_TARGET_WINDOW * this.ppm) / SCALE;
     const queryAabb = new b2AABB();
-    queryAabb.lowerBound.Set(playerPos.x - GRAPPLE_TARGET_WINDOW, playerPos.y - GRAPPLE_TARGET_WINDOW);
-    queryAabb.upperBound.Set(playerPos.x + GRAPPLE_TARGET_WINDOW, playerPos.y + GRAPPLE_TARGET_WINDOW);
+    queryAabb.lowerBound.Set(playerPos.x - windowUnits, playerPos.y - windowUnits);
+    queryAabb.upperBound.Set(playerPos.x + windowUnits, playerPos.y + windowUnits);
 
     const candidates: Array<{ d: number; shape: any; body: any; point: { x: number; y: number } }> = [];
     const shapeAabb = new b2AABB();
@@ -871,10 +881,10 @@ export class PhysicsEngine {
         shape.ComputeAABB(shapeAabb, xf);
         if (shapeAabb.lowerBound.x > queryAabb.upperBound.x || shapeAabb.upperBound.x < queryAabb.lowerBound.x ||
             shapeAabb.lowerBound.y > queryAabb.upperBound.y || shapeAabb.upperBound.y < queryAabb.lowerBound.y) {
-          continue; // broadphase window miss — cannot satisfy d < 10
+          continue; // broadphase window miss — cannot satisfy d < window
         }
         const surface = this.closestSurfacePoint(shape, pBody, playerPos);
-        if (surface.d < GRAPPLE_TARGET_WINDOW) {
+        if (surface.d < windowUnits) {
           candidates.push({ d: surface.d, shape, body: pBody, point: surface.point });
         }
       }

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -1044,6 +1044,11 @@ export class PhysicsEngine {
   }
 
   private releaseGrapple(playerId: number): void {
+    // The swingJustStarted marker only ever accompanies a live joint: purge it
+    // on every release (button release, forced drain-out, collision break,
+    // detachPlayer) so it can never outlive the joint and mis-flag a later
+    // re-fire as an attach tick.
+    this.swingJustStarted.delete(playerId);
     const joint = this.playerGrappleJoints.get(playerId);
     if (joint) {
       this.world.DestroyJoint(joint);

--- a/tests/integration/grapple-mechanics.test.ts
+++ b/tests/integration/grapple-mechanics.test.ts
@@ -415,8 +415,9 @@ describe('GrappleMechanics', () => {
 
   describe('a1a grapple energy meter', () => {
     // Verified native (§32.3): spawn 1000; fire gate a1a > 500; drain 4/step
-    // while swinging with forced release and zeroing below 500; recharge
-    // 3/step otherwise, capped at 1000.
+    // while swinging from the tick AFTER attach (the native a1a update runs
+    // before the fire gate in the same step); forced release and zeroing below
+    // 500; recharge 3/step otherwise, capped at 1000.
     it('spawns with full energy and can fire immediately', () => {
       engine = new PhysicsEngine();
       engine.addBody(makePlatformDef({ name: 'p', x: 0, y: 50 }));
@@ -433,10 +434,12 @@ describe('GrappleMechanics', () => {
       engine.addPlayer(0, 0, 0);
 
       engine.applyInput(0, GRAPPLE_INPUT);
-      for (let i = 0; i < 125; i++) {
+      for (let i = 0; i < 126; i++) {
         engine.applyInput(0, GRAPPLE_INPUT);
         engine.tick();
       }
+      // The attach tick does not drain (§32.3 native order: the a1a update
+      // already ran before the fire gate), so 126 ticks = 125 drains:
       // 1000 - 125*4 = 500: exactly at the threshold, still swinging.
       expect(engine.hasGrappleJoint(0)).toBe(true);
       expect(engine.getGrappleEnergy(0)).toBe(500);
@@ -448,17 +451,17 @@ describe('GrappleMechanics', () => {
       expect(engine.getGrappleEnergy(0)).toBe(0);
     });
 
-    it('cannot re-fire while energy is below 500 and recharges 3/step', () => {
+    it('exhausts the meter, recharges 3/step, and a re-fire after recovery attaches and survives a tick', () => {
       engine = new PhysicsEngine();
       engine.addBody(makePlatformDef({ name: 'p', x: 0, y: 50 }));
       engine.addPlayer(0, 0, 0);
 
       engine.applyInput(0, GRAPPLE_INPUT);
-      for (let i = 0; i < 126; i++) {
+      for (let i = 0; i < 127; i++) {
         engine.applyInput(0, GRAPPLE_INPUT);
         engine.tick();
       }
-      // Forced release at 126 ticks; energy zeroed.
+      // Forced release on the 127th swing tick (126 drains): meter zeroed.
       expect(engine.hasGrappleJoint(0)).toBe(false);
       expect(engine.getGrappleEnergy(0)).toBe(0);
 
@@ -466,15 +469,23 @@ describe('GrappleMechanics', () => {
       engine.applyInput(0, GRAPPLE_INPUT);
       expect(engine.hasGrappleJoint(0)).toBe(false);
 
-      // Recharge 3/step: after 167 ticks energy = 501 > 500 -> re-fire.
+      // Recharge 3/step: after 167 ticks energy = 501 > 500 -> the fire gate
+      // re-opens.
       for (let i = 0; i < 167; i++) {
         engine.applyInput(0, GRAPPLE_INPUT);
         engine.tick();
       }
       expect(engine.getGrappleEnergy(0)).toBe(501);
-      // The energy gate re-opens above 500: the next grapple press attaches.
+
+      // Re-fire after recovery: the rope attaches and — because the attach
+      // tick recharges (+3 → 504) instead of draining (§32.3 native step
+      // order) — it survives the burn-in tick instead of being force-released
+      // at 497 in the same tick.
       engine.applyInput(0, GRAPPLE_INPUT);
       expect(engine.hasGrappleJoint(0)).toBe(true);
+      engine.tick();
+      expect(engine.hasGrappleJoint(0)).toBe(true);
+      expect(engine.getGrappleEnergy(0)).toBe(504);
     });
   });
 

--- a/tests/integration/grapple-mechanics.test.ts
+++ b/tests/integration/grapple-mechanics.test.ts
@@ -358,32 +358,31 @@ describe('GrappleMechanics', () => {
   });
 
   describe('grapple target window', () => {
-    // Verified native (§32.1): QueryAABB ±10 world units around the disc
-    // center, scored by center-to-surface distance < 10. There is no
-    // 500/SCALE reach — the 500 literal is the a1a energy threshold.
-    it('attaches when the surface is within the 10-unit window (8.0 world units)', () => {
-      // 200x20 platform at y=250 map units: surface at (250-10)/30 = 8.0
-      // world units below the player at (0,0) — inside the window.
+    // Verified native (§32.1): QueryAABB ±10 NATIVE world units around the
+    // disc center (`map px / ppm`, default ppm = 12), scored by
+    // center-to-surface distance < 10 → a 120 map px window. This port's world
+    // is `map px / SCALE` (SCALE = 30), so the equivalent window is
+    // 10 * 12 / 30 = 4.0 port units = 120 map px (10 disc radii). The 500
+    // literal is the a1a energy threshold, NOT a reach.
+    it('attaches when the surface is within the native window (~110 map px)', () => {
       engine = new PhysicsEngine();
-      engine.addBody(makePlatformDef({ name: 'in-window', x: 0, y: 250 }));
+      engine.addBody(makePlatformDef({ name: 'in-window', x: 0, y: 120 }));
       engine.addPlayer(0, 0, 0);
 
       engine.applyInput(0, GRAPPLE_INPUT);
       expect(engine.hasGrappleJoint(0)).toBe(true);
     });
 
-    it('fails to attach when the surface is beyond the 10-unit window (10.33 world units)', () => {
-      // 200x20 platform at y=320 map units: surface at (320-10)/30 = 10.33
-      // world units away — outside the window.
+    it('fails to attach when the surface is beyond the native window (130 map px)', () => {
       engine = new PhysicsEngine();
-      engine.addBody(makePlatformDef({ name: 'out-window', x: 0, y: 320 }));
+      engine.addBody(makePlatformDef({ name: 'out-window', x: 0, y: 140 }));
       engine.addPlayer(0, 0, 0);
 
       engine.applyInput(0, GRAPPLE_INPUT);
       expect(engine.hasGrappleJoint(0)).toBe(false);
     });
 
-    it('fails to grapple when platform is beyond the window (surface 16.33 world units away)', () => {
+    it('fails to grapple a far platform (surface 16.33 world units away)', () => {
       engine = new PhysicsEngine();
       engine.addBody(makePlatformDef({ name: 'far-platform', x: 0, y: 0 }));
       engine.addPlayer(0, 0, 500);
@@ -402,7 +401,7 @@ describe('GrappleMechanics', () => {
     it('grapples the closer of two in-window surfaces', () => {
       engine = new PhysicsEngine();
       engine.addBody(makePlatformDef({ name: 'near', x: 0, y: 100 }));
-      engine.addBody(makePlatformDef({ name: 'far-but-in-window', x: 0, y: 200 }));
+      engine.addBody(makePlatformDef({ name: 'far-but-in-window', x: 0, y: 120 }));
       engine.addPlayer(0, 0, 0);
 
       engine.applyInput(0, GRAPPLE_INPUT);


### PR DESCRIPTION
## Summary

Two grapple-parity fixes, one conventional commit each.

Fixes #238
Fixes #239

### #238 — Grapple targeting window was 2.5x too large
\GRAPPLE_TARGET_WINDOW = 10\ was consumed as bare port units (\px / SCALE\, SCALE = 30), giving a 300 map px reach. The native window is ±10 **native** world units (\map px / ppm\, default ppm = 12) = 120 map px = 10 disc radii. The window is now converted once in \ireGrapple()\ to \GRAPPLE_TARGET_WINDOW * ppm / SCALE\ (= 4.0 port units at the default ppm), applied consistently to both the QueryAABB pre-filter and the \d < window\ candidate gate. Regression tests: attach at ~110 map px, no attach at 130 map px.

### #239 — a1a grapple recharge was dead
Every re-fire crossing the 500 threshold at exactly 501 was force-released in the same tick (501 − 4 = 497 < 500) before \world.Step\ ran, so the meter could never produce a usable swing again. Native §32.3 runs the a1a update **before** the fire gate in the same step, so the attach tick never drains the new rope. The port now mirrors that: the attach tick applies the recharge branch (via a \swingJustStarted\ marker) and the first drain starts on the next tick — a re-fire at 501 recharges to 504 and survives. The 500 literal stays the a1a energy threshold, not a reach. Regression test: exhaust the meter on a swing, recharge 3/step to 501, re-fire, and the joint survives the following tick (energy 504 ≥ 496).

## Validation
- \
pm run typecheck\: 0 errors
- \
pm test\: 58 files, 1260 passed / 19 skipped (baseline), fully green
- \git diff --check\: clean
- Live repros from both issues verified against the fixed engine