### PR TITLE
fix(ipc): honor configured server.bindAddress / BIND_ADDRESS / --bind-address (#235)

### DIFF
--- a/src/config/config-loader.ts
+++ b/src/config/config-loader.ts
@@ -479,6 +479,13 @@ function parseCliFlags(config: AppConfig): AppConfig {
                 }
                 break;
 
+            case '--bind-address':
+                if (next) {
+                    config.server.bindAddress = next;
+                    i++;
+                }
+                break;
+
             case '--max-runtime':
                 if (next) {
                     const v = parseInt(next, 10);

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -11,6 +11,7 @@ export class IpcBridge {
     private sock: zmq.Router;
     private pool: WorkerPool;
     private port: number;
+    private bindAddress: string;
     private stepCount: number = 0;
     private _closed: boolean = false;
     private _initialized: boolean = false;
@@ -19,6 +20,7 @@ export class IpcBridge {
 
     constructor(config?: DeepPartial<AppConfig>) {
         this.port = config?.server?.port ?? getConfig().server.port;
+        this.bindAddress = config?.server?.bindAddress ?? getConfig().server.bindAddress;
         this.sock = new zmq.Router();
         this.pool = new WorkerPool();
 
@@ -30,7 +32,7 @@ export class IpcBridge {
     private _wrappedSend: Function;
 
     async start() {
-        const addr = `tcp://127.0.0.1:${this.port}`;
+        const addr = `tcp://${this.bindAddress}:${this.port}`;
         await this.sock.bind(addr);
         console.log(`[IPC] Bound ZMQ Router socket to ${addr}`);
         this._closed = false;
@@ -263,6 +265,13 @@ export class IpcBridge {
      */
     getPort(): number {
         return this.port;
+    }
+
+    /**
+     * Get the configured bind address (network interface to bind the ZMQ socket to).
+     */
+    getBindAddress(): string {
+        return this.bindAddress;
     }
 
     /**

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -20,12 +20,26 @@ export class IpcBridge {
 
     constructor(config?: DeepPartial<AppConfig>) {
         this.port = config?.server?.port ?? getConfig().server.port;
-        this.bindAddress = config?.server?.bindAddress ?? getConfig().server.bindAddress;
+        this.bindAddress = IpcBridge.normalizeBindAddress(config?.server?.bindAddress ?? getConfig().server.bindAddress);
         this.sock = new zmq.Router();
         this.pool = new WorkerPool();
 
         // Create a wrapped send function for telemetry (can't overwrite the built-in send property in newer ZeroMQ)
         this._wrappedSend = wrap(TelemetryIndices.ZMQ_SEND, this.sock.send.bind(this.sock));
+    }
+
+    /**
+     * Normalize a configured bind address into a ZMQ endpoint-ready host.
+     * Empty/whitespace values fall back to the loopback default, and bare
+     * IPv6 literals are wrapped in the brackets the tcp:// endpoint syntax
+     * requires (issue #235).
+     */
+    private static normalizeBindAddress(raw: string | undefined): string {
+        const addr = (raw ?? '').trim();
+        if (addr.length === 0) {
+            return '127.0.0.1';
+        }
+        return addr.includes(':') && !addr.startsWith('[') ? `[${addr}]` : addr;
     }
 
     // Wrapped send function for telemetry

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -31,18 +31,23 @@ export class IpcBridge {
 
     /**
      * Normalize a configured bind address into a ZMQ endpoint-ready host.
-     * Empty/whitespace values fall back to the loopback default, and bare
-     * IPv6 literals are wrapped in the brackets the tcp:// endpoint syntax
-     * requires. Hostnames/interface names pass through; malformed values
-     * (e.g. a host:port mistake, which a naive "contains a colon" IPv6 check
-     * would otherwise bracket into an invalid endpoint) fail loudly at
+     * Empty/whitespace values fall back to the loopback default; `*` (the
+     * libzmq all-interfaces wildcard) passes through; bare IPv6 literals are
+     * wrapped in the brackets the tcp:// endpoint syntax requires. Everything
+     * else must be a valid IPv4 address, a valid IPv6 literal, or an RFC 1123
+     * hostname/interface name — malformed values (e.g. a host:port mistake,
+     * an out-of-range dotted-numeric octet, or a non-name) fail loudly at
      * construction instead of surfacing as an opaque bind() error (issue
      * #235).
      */
     private static normalizeBindAddress(raw: string | undefined): string {
-        let addr = (raw ?? '').trim();
+        const addr = (raw ?? '').trim();
         if (addr.length === 0) {
             return '127.0.0.1';
+        }
+        if (addr === '*') {
+            // libzmq wildcard: bind to all available interfaces.
+            return addr;
         }
         let bare = addr;
         if (addr.startsWith('[') && addr.endsWith(']')) {
@@ -55,13 +60,18 @@ export class IpcBridge {
         if (ipKind === 4) {
             return bare;
         }
-        // RFC 1123-style hostname / interface name (underscore tolerated).
-        // Anything else — semicolons, whitespace, a trailing :port — is
-        // rejected rather than silently producing an invalid bind endpoint.
-        if (!/^[a-zA-Z0-9_]([a-zA-Z0-9_-]*[a-zA-Z0-9_])?(\.[a-zA-Z0-9_]([a-zA-Z0-9_-]*[a-zA-Z0-9_])?)*$/.test(bare)) {
-            throw new Error(`Invalid server.bindAddress "${raw}": expected an IPv4/IPv6 address or hostname (no port).`);
+        // All-dotted-numeric values that net.isIP rejected (1.2.3.4.5,
+        // 999.999.999.999) are malformed IPv4s, not hostnames.
+        if (/^\d+(\.\d+)+$/.test(bare)) {
+            throw new Error(`Invalid server.bindAddress "${raw}": not a valid IPv4 address.`);
         }
-        return bare;
+        // RFC 1123 hostname / interface name. Anything else — semicolons,
+        // whitespace, a trailing :port, a bare `_` label — is rejected rather
+        // than silently producing an invalid bind endpoint.
+        if (/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/.test(bare)) {
+            return bare;
+        }
+        throw new Error(`Invalid server.bindAddress "${raw}": expected an IPv4/IPv6 address, hostname, or '*' (no port).`);
     }
 
     // Wrapped send function for telemetry

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -1,4 +1,5 @@
 import * as zmq from "zeromq";
+import * as net from "net";
 import { WorkerPool } from "../core/worker-pool";
 import { globalProfiler, wrap, TelemetryIndices, setLatestWorkerTelemetry } from "../telemetry/profiler";
 import { isTelemetryEnabled as isTelemetryControllerEnabled } from '../telemetry/telemetry-controller';
@@ -32,14 +33,35 @@ export class IpcBridge {
      * Normalize a configured bind address into a ZMQ endpoint-ready host.
      * Empty/whitespace values fall back to the loopback default, and bare
      * IPv6 literals are wrapped in the brackets the tcp:// endpoint syntax
-     * requires (issue #235).
+     * requires. Hostnames/interface names pass through; malformed values
+     * (e.g. a host:port mistake, which a naive "contains a colon" IPv6 check
+     * would otherwise bracket into an invalid endpoint) fail loudly at
+     * construction instead of surfacing as an opaque bind() error (issue
+     * #235).
      */
     private static normalizeBindAddress(raw: string | undefined): string {
-        const addr = (raw ?? '').trim();
+        let addr = (raw ?? '').trim();
         if (addr.length === 0) {
             return '127.0.0.1';
         }
-        return addr.includes(':') && !addr.startsWith('[') ? `[${addr}]` : addr;
+        let bare = addr;
+        if (addr.startsWith('[') && addr.endsWith(']')) {
+            bare = addr.slice(1, -1);
+        }
+        const ipKind = net.isIP(bare);
+        if (ipKind === 6) {
+            return `[${bare}]`;
+        }
+        if (ipKind === 4) {
+            return bare;
+        }
+        // RFC 1123-style hostname / interface name (underscore tolerated).
+        // Anything else — semicolons, whitespace, a trailing :port — is
+        // rejected rather than silently producing an invalid bind endpoint.
+        if (!/^[a-zA-Z0-9_]([a-zA-Z0-9_-]*[a-zA-Z0-9_])?(\.[a-zA-Z0-9_]([a-zA-Z0-9_-]*[a-zA-Z0-9_])?)*$/.test(bare)) {
+            throw new Error(`Invalid server.bindAddress "${raw}": expected an IPv4/IPv6 address or hostname (no port).`);
+        }
+        return bare;
     }
 
     // Wrapped send function for telemetry

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -34,11 +34,12 @@ export class IpcBridge {
      * Empty/whitespace values fall back to the loopback default; `*` (the
      * libzmq all-interfaces wildcard) passes through; bare IPv6 literals are
      * wrapped in the brackets the tcp:// endpoint syntax requires. Everything
-     * else must be a valid IPv4 address, a valid IPv6 literal, or an RFC 1123
-     * hostname/interface name — malformed values (e.g. a host:port mistake,
-     * an out-of-range dotted-numeric octet, or a non-name) fail loudly at
-     * construction instead of surfacing as an opaque bind() error (issue
-     * #235).
+     * else must be a valid IPv4 address, a valid IPv6 literal, or a DNS /
+     * interface name (underscores tolerated, at least one alphanumeric
+     * character) — malformed values (e.g. a host:port mistake, out-of-range
+     * dotted-numeric octets, purely numeric or underscore-only labels) fail
+     * loudly at construction instead of surfacing as an opaque bind() error
+     * (issue #235).
      */
     private static normalizeBindAddress(raw: string | undefined): string {
         const addr = (raw ?? '').trim();
@@ -65,10 +66,16 @@ export class IpcBridge {
         if (/^\d+(\.\d+)+$/.test(bare)) {
             throw new Error(`Invalid server.bindAddress "${raw}": not a valid IPv4 address.`);
         }
-        // RFC 1123 hostname / interface name. Anything else — semicolons,
-        // whitespace, a trailing :port, a bare `_` label — is rejected rather
-        // than silently producing an invalid bind endpoint.
-        if (/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/.test(bare)) {
+        // A purely numeric label (999, 12345) is neither an IP nor a usable
+        // hostname for binding.
+        if (/^\d+$/.test(bare)) {
+            throw new Error(`Invalid server.bindAddress "${raw}": not a valid IPv4 address.`);
+        }
+        // DNS / interface name: `[a-zA-Z0-9_-]` labels joined by dots, with
+        // at least one alphanumeric character so a bare `_`/`-` is rejected.
+        // Anything else — semicolons, whitespace, a trailing :port — is also
+        // rejected rather than silently producing an invalid bind endpoint.
+        if (/^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/.test(bare) && /[a-zA-Z0-9]/.test(bare)) {
             return bare;
         }
         throw new Error(`Invalid server.bindAddress "${raw}": expected an IPv4/IPv6 address, hostname, or '*' (no port).`);

--- a/tests/integration/ipc-bridge-bind-address.test.ts
+++ b/tests/integration/ipc-bridge-bind-address.test.ts
@@ -17,10 +17,30 @@ import * as zmq from 'zeromq';
 import { IpcBridge } from '../../src/ipc/ipc-bridge';
 import { PortManager } from '../../src/utils/port-manager';
 
+const BIND_ADDRESS = '127.0.0.2';
+const EXPECTED_ENDPOINT = `tcp://${BIND_ADDRESS}`;
+
+/**
+ * Wait until the ROUTER socket reports the configured bind endpoint (or
+ * timeout). This deterministically awaits the async bind() instead of racing
+ * a fixed sleep, and surfaces a bind failure as an assertion instead of a
+ * flaky lastEndpoint read.
+ */
+async function waitForBindEndpoint(sock: any, endpoint: string, timeoutMs: number = 10000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (sock.lastEndpoint === endpoint) {
+      return;
+    }
+    await new Promise(r => setTimeout(r, 25));
+  }
+  expect(sock.lastEndpoint, `socket did not bind to ${endpoint}`).toBe(endpoint);
+}
+
 describe('IpcBridge honors a configured bind address (issue #235)', () => {
-  const BIND_ADDRESS = '127.0.0.2';
   let bridge: IpcBridge;
   let client: zmq.Dealer;
+  let startPromise: Promise<void>;
   let portManager: PortManager;
   let port: number;
 
@@ -28,22 +48,27 @@ describe('IpcBridge honors a configured bind address (issue #235)', () => {
     portManager = new PortManager({ startPort: 15700, endPort: 15799 });
     port = portManager.allocate();
     bridge = new IpcBridge({ server: { port, bindAddress: BIND_ADDRESS } } as any);
-    // start() runs the serve loop until close(), so do not await it.
-    void bridge.start();
+    // start() runs the serve loop until close(), so do not await it here.
+    // Keep the promise referenced so a bind failure is a handled rejection
+    // that the readiness poll below surfaces as a test failure.
+    startPromise = bridge.start();
+    startPromise.catch(() => { /* surfaced by waitForBindEndpoint */ });
+    await waitForBindEndpoint((bridge as any).sock, `${EXPECTED_ENDPOINT}:${port}`);
     client = new zmq.Dealer();
     await client.connect(`tcp://${BIND_ADDRESS}:${port}`);
-    await new Promise(r => setTimeout(r, 300));
+    await new Promise(r => setTimeout(r, 100));
   }, 30000);
 
   afterAll(async () => {
     try { client.close(); } catch { /* ignore */ }
     try { await bridge.close(); } catch { /* ignore */ }
+    try { await startPromise; } catch { /* ignore */ }
     portManager.release(port);
   }, 10000);
 
   it('binds the socket to the configured bind address (last endpoint)', () => {
     const sock: any = (bridge as any).sock;
-    expect(sock.lastEndpoint).toBe(`tcp://${BIND_ADDRESS}:${port}`);
+    expect(sock.lastEndpoint).toBe(`${EXPECTED_ENDPOINT}:${port}`);
   });
 
   it('exposes the configured bind address via getBindAddress()', () => {

--- a/tests/integration/ipc-bridge-bind-address.test.ts
+++ b/tests/integration/ipc-bridge-bind-address.test.ts
@@ -1,0 +1,63 @@
+/**
+ * ipc-bridge-bind-address.test.ts — regression coverage for issue #235
+ *
+ * The IpcBridge must honor a configured `server.bindAddress` (plus the
+ * BIND_ADDRESS env var / --bind-address CLI surface via the config pipeline)
+ * when it binds the ZMQ ROUTER socket. Previously the bind endpoint was
+ * hardcoded to `tcp://127.0.0.1:<port>`, silently discarding any configured
+ * non-loopback interface (ECONNREFUSED for remote clients). This test starts
+ * a bridge on an alternate loopback address (127.0.0.2) on a free port and
+ * proves:
+ *   1. The socket's last bind endpoint is exactly the configured address.
+ *   2. A DEALER client (as the Python client does) can connect to the
+ *      configured address and complete a request/reply round-trip.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as zmq from 'zeromq';
+import { IpcBridge } from '../../src/ipc/ipc-bridge';
+import { PortManager } from '../../src/utils/port-manager';
+
+describe('IpcBridge honors a configured bind address (issue #235)', () => {
+  const BIND_ADDRESS = '127.0.0.2';
+  let bridge: IpcBridge;
+  let client: zmq.Dealer;
+  let portManager: PortManager;
+  let port: number;
+
+  beforeAll(async () => {
+    portManager = new PortManager({ startPort: 15700, endPort: 15799 });
+    port = portManager.allocate();
+    bridge = new IpcBridge({ server: { port, bindAddress: BIND_ADDRESS } } as any);
+    // start() runs the serve loop until close(), so do not await it.
+    void bridge.start();
+    client = new zmq.Dealer();
+    await client.connect(`tcp://${BIND_ADDRESS}:${port}`);
+    await new Promise(r => setTimeout(r, 300));
+  }, 30000);
+
+  afterAll(async () => {
+    try { client.close(); } catch { /* ignore */ }
+    try { await bridge.close(); } catch { /* ignore */ }
+    portManager.release(port);
+  }, 10000);
+
+  it('binds the socket to the configured bind address (last endpoint)', () => {
+    const sock: any = (bridge as any).sock;
+    expect(sock.lastEndpoint).toBe(`tcp://${BIND_ADDRESS}:${port}`);
+  });
+
+  it('exposes the configured bind address via getBindAddress()', () => {
+    expect(bridge.getBindAddress()).toBe(BIND_ADDRESS);
+  });
+
+  it('is reachable on the configured address: DEALER round-trip succeeds (issue #235)', async () => {
+    // A `reset` before init is rejected with a per-request error reply, which
+    // proves the client connected to the configured interface and completed a
+    // full request/reply round-trip without initializing any pool state.
+    await client.send(JSON.stringify({ command: 'reset' }));
+    const [response] = await client.receive();
+    const parsed = JSON.parse(response.toString());
+    expect(parsed.status).toBe('error');
+    expect(parsed.error).toContain('Worker pool not initialized');
+  }, 30000);
+});

--- a/tests/unit/config-loader-env.test.ts
+++ b/tests/unit/config-loader-env.test.ts
@@ -319,6 +319,25 @@ describe('config-loader env vars and CLI', () => {
             expect(cfg.server.port).toBe(3000);
         });
 
+        it('--bind-address sets server bind address', () => {
+            process.argv = ['node', 'script.js', '--bind-address', '0.0.0.0'];
+            const cfg = loadConfig(testDir);
+            expect(cfg.server.bindAddress).toBe('0.0.0.0');
+        });
+
+        it('missing value for --bind-address is ignored', () => {
+            process.argv = ['node', 'script.js', '--bind-address'];
+            const cfg = loadConfig(testDir);
+            expect(cfg.server.bindAddress).toBe('127.0.0.1');
+        });
+
+        it('CLI --bind-address overrides env BIND_ADDRESS', () => {
+            process.env.BIND_ADDRESS = '10.0.0.1';
+            process.argv = ['node', 'script.js', '--bind-address', '0.0.0.0'];
+            const cfg = loadConfig(testDir);
+            expect(cfg.server.bindAddress).toBe('0.0.0.0');
+        });
+
         it('--max-runtime sets max runtime', () => {
             process.argv = ['node', 'script.js', '--max-runtime', '60'];
             const cfg = loadConfig(testDir);

--- a/tests/unit/ipc-bridge-constructor.test.ts
+++ b/tests/unit/ipc-bridge-constructor.test.ts
@@ -63,7 +63,7 @@ let sendSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   mocks.getConfig.mockClear();
-  mocks.getConfig.mockReturnValue({ server: { port: 5555 }, environment: { seed: 0 } });
+  mocks.getConfig.mockReturnValue({ server: { port: 5555, bindAddress: '127.0.0.1' }, environment: { seed: 0 } });
   mocks.isTelemetryEnabled.mockClear();
   mocks.isTelemetryEnabled.mockReturnValue(true);
   mocks.WorkerPool.mockClear();
@@ -106,6 +106,21 @@ describe('IpcBridge constructor', () => {
     expect(bridge.getPort()).toBe(5555);
   });
 
+  it('uses bindAddress from config when provided', () => {
+    const bridge = new IpcBridge({ server: { port: 12345, bindAddress: '0.0.0.0' } });
+    expect(bridge.getBindAddress()).toBe('0.0.0.0');
+  });
+
+  it('falls back to getConfig().server.bindAddress when no config', () => {
+    const bridge = new IpcBridge();
+    expect(bridge.getBindAddress()).toBe('127.0.0.1');
+  });
+
+  it('falls back to getConfig().server.bindAddress when config has no server', () => {
+    const bridge = new IpcBridge({});
+    expect(bridge.getBindAddress()).toBe('127.0.0.1');
+  });
+
   it('creates a ZMQ Router socket (line 18)', () => {
     new IpcBridge();
     expect(bindSpy).not.toHaveBeenCalled();
@@ -136,6 +151,15 @@ describe('IpcBridge start()', () => {
     const startPromise = bridge.start();
     await new Promise(r => setTimeout(r, 10));
     expect(bindSpy).toHaveBeenCalledWith('tcp://127.0.0.1:12345');
+    await bridge.close();
+    await startPromise;
+  });
+
+  it('binds socket to the configured bind address when provided (issue #235)', async () => {
+    const bridge = new IpcBridge({ server: { port: 12348, bindAddress: '0.0.0.0' } });
+    const startPromise = bridge.start();
+    await new Promise(r => setTimeout(r, 10));
+    expect(bindSpy).toHaveBeenCalledWith('tcp://0.0.0.0:12348');
     await bridge.close();
     await startPromise;
   });

--- a/tests/unit/ipc-bridge-constructor.test.ts
+++ b/tests/unit/ipc-bridge-constructor.test.ts
@@ -126,6 +126,11 @@ describe('IpcBridge constructor', () => {
     expect(bridge.getBindAddress()).toBe('localhost');
   });
 
+  it('passes the libzmq all-interfaces wildcard through unmodified', () => {
+    const bridge = new IpcBridge({ server: { port: 12345, bindAddress: '*' } });
+    expect(bridge.getBindAddress()).toBe('*');
+  });
+
   it('rejects a host:port-style bind address with a clear error (issue #235)', () => {
     expect(() => new IpcBridge({ server: { port: 12345, bindAddress: '127.0.0.1:5555' } }))
       .toThrowError(/Invalid server\.bindAddress/);
@@ -133,6 +138,18 @@ describe('IpcBridge constructor', () => {
 
   it('rejects a malformed bind address with a clear error (issue #235)', () => {
     expect(() => new IpcBridge({ server: { port: 12345, bindAddress: 'not a host' } }))
+      .toThrowError(/Invalid server\.bindAddress/);
+  });
+
+  it('rejects a dotted-numeric bind address that is not a valid IPv4 (issue #235)', () => {
+    expect(() => new IpcBridge({ server: { port: 12345, bindAddress: '999.999.999.999' } }))
+      .toThrowError(/Invalid server\.bindAddress/);
+    expect(() => new IpcBridge({ server: { port: 12345, bindAddress: '1.2.3.4.5' } }))
+      .toThrowError(/Invalid server\.bindAddress/);
+  });
+
+  it('rejects a bare underscore bind address (issue #235)', () => {
+    expect(() => new IpcBridge({ server: { port: 12345, bindAddress: '_' } }))
       .toThrowError(/Invalid server\.bindAddress/);
   });
 

--- a/tests/unit/ipc-bridge-constructor.test.ts
+++ b/tests/unit/ipc-bridge-constructor.test.ts
@@ -111,6 +111,21 @@ describe('IpcBridge constructor', () => {
     expect(bridge.getBindAddress()).toBe('0.0.0.0');
   });
 
+  it('wraps a bare IPv6 bind address in brackets for the tcp endpoint', () => {
+    const bridge = new IpcBridge({ server: { port: 12345, bindAddress: '::1' } });
+    expect(bridge.getBindAddress()).toBe('[::1]');
+  });
+
+  it('keeps an already-bracketed IPv6 bind address as-is', () => {
+    const bridge = new IpcBridge({ server: { port: 12345, bindAddress: '[::1]' } });
+    expect(bridge.getBindAddress()).toBe('[::1]');
+  });
+
+  it('falls back to the loopback default for an empty bind address', () => {
+    const bridge = new IpcBridge({ server: { port: 12345, bindAddress: '  ' } });
+    expect(bridge.getBindAddress()).toBe('127.0.0.1');
+  });
+
   it('falls back to getConfig().server.bindAddress when no config', () => {
     const bridge = new IpcBridge();
     expect(bridge.getBindAddress()).toBe('127.0.0.1');
@@ -160,6 +175,15 @@ describe('IpcBridge start()', () => {
     const startPromise = bridge.start();
     await new Promise(r => setTimeout(r, 10));
     expect(bindSpy).toHaveBeenCalledWith('tcp://0.0.0.0:12348');
+    await bridge.close();
+    await startPromise;
+  });
+
+  it('binds an IPv6 bind address with brackets in the endpoint (issue #235)', async () => {
+    const bridge = new IpcBridge({ server: { port: 12348, bindAddress: '::1' } });
+    const startPromise = bridge.start();
+    await new Promise(r => setTimeout(r, 10));
+    expect(bindSpy).toHaveBeenCalledWith('tcp://[::1]:12348');
     await bridge.close();
     await startPromise;
   });

--- a/tests/unit/ipc-bridge-constructor.test.ts
+++ b/tests/unit/ipc-bridge-constructor.test.ts
@@ -126,6 +126,14 @@ describe('IpcBridge constructor', () => {
     expect(bridge.getBindAddress()).toBe('localhost');
   });
 
+  it('passes interface names containing underscores through unmodified', () => {
+    const bridge = new IpcBridge({ server: { port: 12345, bindAddress: 'my_if0' } });
+    expect(bridge.getBindAddress()).toBe('my_if0');
+
+    const bridge2 = new IpcBridge({ server: { port: 12345, bindAddress: 'veth_1' } });
+    expect(bridge2.getBindAddress()).toBe('veth_1');
+  });
+
   it('passes the libzmq all-interfaces wildcard through unmodified', () => {
     const bridge = new IpcBridge({ server: { port: 12345, bindAddress: '*' } });
     expect(bridge.getBindAddress()).toBe('*');
@@ -150,6 +158,13 @@ describe('IpcBridge constructor', () => {
 
   it('rejects a bare underscore bind address (issue #235)', () => {
     expect(() => new IpcBridge({ server: { port: 12345, bindAddress: '_' } }))
+      .toThrowError(/Invalid server\.bindAddress/);
+  });
+
+  it('rejects a purely numeric bind address that is not a valid IPv4 (issue #235)', () => {
+    expect(() => new IpcBridge({ server: { port: 12345, bindAddress: '999' } }))
+      .toThrowError(/Invalid server\.bindAddress/);
+    expect(() => new IpcBridge({ server: { port: 12345, bindAddress: '12345' } }))
       .toThrowError(/Invalid server\.bindAddress/);
   });
 

--- a/tests/unit/ipc-bridge-constructor.test.ts
+++ b/tests/unit/ipc-bridge-constructor.test.ts
@@ -121,6 +121,21 @@ describe('IpcBridge constructor', () => {
     expect(bridge.getBindAddress()).toBe('[::1]');
   });
 
+  it('passes a hostname bind address through unmodified', () => {
+    const bridge = new IpcBridge({ server: { port: 12345, bindAddress: 'localhost' } });
+    expect(bridge.getBindAddress()).toBe('localhost');
+  });
+
+  it('rejects a host:port-style bind address with a clear error (issue #235)', () => {
+    expect(() => new IpcBridge({ server: { port: 12345, bindAddress: '127.0.0.1:5555' } }))
+      .toThrowError(/Invalid server\.bindAddress/);
+  });
+
+  it('rejects a malformed bind address with a clear error (issue #235)', () => {
+    expect(() => new IpcBridge({ server: { port: 12345, bindAddress: 'not a host' } }))
+      .toThrowError(/Invalid server\.bindAddress/);
+  });
+
   it('falls back to the loopback default for an empty bind address', () => {
     const bridge = new IpcBridge({ server: { port: 12345, bindAddress: '  ' } });
     expect(bridge.getBindAddress()).toBe('127.0.0.1');


### PR DESCRIPTION
## Summary

Closes #235. The ZMQ ROUTER socket in \IpcBridge.start()\ hardcoded its bind endpoint as \	cp://127.0.0.1:<port>\, so the documented \server.bindAddress\ config key, \BIND_ADDRESS\ env var, and \--bind-address\ CLI flag were parsed but never consumed — configuring a non-loopback interface (e.g. \