### PR TITLE
fix(env): EnvManager batch APIs — flat stepAll results and numEnvs>1 batching (#198, #230)

### DIFF
--- a/examples/parallel-envs.ts
+++ b/examples/parallel-envs.ts
@@ -60,13 +60,7 @@ async function main() {
             console.log(`  Step ${step + 1}:`);
             for (let i = 0; i < results.length; i++) {
                 const result = results[i];
-                if (Array.isArray(result) && result[0]) {
-                    const r = result[0];
-                    console.log(`    Env ${i}: reward=${r.reward?.toFixed(3)}, done=${r.done}, tick=${r.info?.tick}`);
-                } else if (result && result[0]) {
-                    const r = result[0];
-                    console.log(`    Env ${i}: reward=${r.reward?.toFixed(3)}, done=${r.done}, tick=${r.info?.tick}`);
-                }
+                console.log(`    Env ${i}: reward=${result.reward?.toFixed(3)}, done=${result.done}, tick=${result.info?.tick}`);
             }
         }
 

--- a/src/env/README.md
+++ b/src/env/README.md
@@ -47,6 +47,19 @@ class EnvManager {
 - Port allocation range: 6000–7000 (configurable)
 - Environments run in separate processes for true parallelism
 
+## Batch semantics
+
+`EnvManager`'s batch methods cover every *internal* environment of the
+manager's pools: a `BonkEnv` configured with `numEnvs: N` contributes `N`
+entries to each batch. `resetAll(seeds)` and `stepAll(actions)` therefore
+expect exactly one seed / exactly one action per internal environment
+(`sum(numEnvs)` across all created `BonkEnv`s) and return a single flat array
+with one entry per internal environment — the same shape from both APIs. A
+count mismatch is rejected with an `Invalid seed batch` / `Invalid action
+batch` error before any pool is touched, so an under-sized batch can never
+silently leave internal environments unseeded or fail a multi-env worker
+pool.
+
 ## Result Ownership
 
 `reset` and `step` return caller-owned object graphs by default. Retaining an

--- a/src/env/README.md
+++ b/src/env/README.md
@@ -19,7 +19,7 @@ class BonkEnv {
   async start(): Promise<void>;
   async stop(): Promise<void>;
   async reset(seeds?: number[], options?: ResultOwnershipOptions): Promise<any>;
-  async step(actions: any[], options?: ResultOwnershipOptions): Promise<StepResult | StepResult[]>;
+  async step(actions: any[], options?: ResultOwnershipOptions): Promise<StepResult[]>;
   isActive(): boolean;
 }
 ```

--- a/src/env/bonk-env.ts
+++ b/src/env/bonk-env.ts
@@ -145,11 +145,11 @@ export class BonkEnv {
 
     /**
      * Take a step in the environment with the given action(s).
-     * @param actions Action(s) to apply
+     * @param actions Action(s) to apply, one per internal environment
      * @param options Result ownership mode; caller-owned by default
-     * @returns Step result(s) containing observation, reward, done, truncated, info
+     * @returns Step results, one per internal environment, containing observation, reward, done, truncated, info
      */
-    async step(actions: any[], options?: ResultOwnershipOptions): Promise<StepResult | StepResult[]> {
+    async step(actions: any[], options?: ResultOwnershipOptions): Promise<StepResult[]> {
         if (!this.isRunning || !this.pool) {
             throw new Error(`Environment ${this.id} is not running`);
         }

--- a/src/env/bonk-env.ts
+++ b/src/env/bonk-env.ts
@@ -131,13 +131,36 @@ export class BonkEnv {
 
     /**
      * Reset the environment to initial state.
-     * @param seeds Optional seeds for environment reset
+     * @param seeds Optional seeds, one per internal environment of this env's
+     *   pool. A seed list must cover every internal environment: a short list
+     *   would otherwise silently leave the tail environments on an arbitrary
+     *   RNG stream (issue #230).
      * @param options Result ownership mode; caller-owned by default
-     * @returns Initial observation(s)
+     * @returns Initial observation(s), one per internal environment
      */
     async reset(seeds?: number[], options?: ResultOwnershipOptions): Promise<any> {
         if (!this.isRunning || !this.pool) {
             throw new Error(`Environment ${this.id} is not running`);
+        }
+
+        // The low-level pool intentionally tolerates a short seed list (#183,
+        // tail environments reset unseeded) — a documented escape hatch for
+        // direct pool/getPool() users, pinned by worker-pool-stale-seeds. The
+        // BonkEnv wrapper enforces its own exact-count contract instead (#230)
+        // so callers of the public wrapper API can never silently lose seeds;
+        // the IPC/Python client is unaffected because it always sends exactly
+        // num_envs seeds.
+        const numEnvs = this.getNumEnvs();
+        if (seeds !== undefined) {
+            if (!Array.isArray(seeds)) {
+                throw new Error(`Invalid seed batch: expected an array of seeds, got ${typeof seeds}`);
+            }
+            if (seeds.length !== numEnvs) {
+                const received = seeds.length;
+                throw new Error(
+                    `Invalid seed batch: expected ${numEnvs} seed${numEnvs === 1 ? '' : 's'} for ${numEnvs} environment${numEnvs === 1 ? '' : 's'} in ${this.id}, got ${received}`,
+                );
+            }
         }
         
         return this.pool.reset(seeds, options);
@@ -171,6 +194,17 @@ export class BonkEnv {
      */
     getPool(): WorkerPool | null {
         return this.pool;
+    }
+
+    /**
+     * Get the number of internal environments managed by this env's worker
+     * pool. Matches the configured numEnvs (default: 1), which is exactly the
+     * count the pool is initialized with, so callers can size batch
+     * action/seed lists for this BonkEnv.
+     * @returns Number of internal environments in the worker pool
+     */
+    getNumEnvs(): number {
+        return this.config.numEnvs ?? 1;
     }
 
     /**

--- a/src/env/env-manager.ts
+++ b/src/env/env-manager.ts
@@ -186,25 +186,44 @@ export class EnvManager {
 
     /**
      * Reset all environments.
-     * @param seeds Optional seeds for each environment
+     * @param seeds Optional seeds, one per internal environment across the
+     *   manager's pools. When provided the batch must contain exactly one
+     *   seed per internal environment (numEnvs per BonkEnv) so no internal
+     *   environment is silently left unseeded.
      * @param options Result ownership mode; caller-owned by default
-     * @returns Array of initial observations
+     * @returns Flat array of initial observations, one per internal environment
      */
     async resetAll(seeds?: number[], options?: ResultOwnershipOptions): Promise<any[]> {
         const envs = this.getAllEnvs();
         const results: any[] = [];
         
-        // Reset all environments in parallel, each with its own seed
-        const resetPromises = envs.map((env, idx) => {
-            const envSeed = seeds?.[idx];
-            return env.reset(envSeed !== undefined ? [envSeed] : undefined, options);
+        if (seeds !== undefined) {
+            if (!Array.isArray(seeds)) {
+                throw new Error(`Invalid seed batch: expected an array of seeds, got ${typeof seeds}`);
+            }
+            this.assertBatchLength('seed', seeds.length, envs);
+        }
+
+        // Reset all environments in parallel, slicing the batch per pool so
+        // every internal environment of a multi-env BonkEnv receives its own
+        // seed instead of only the first one (issue #230).
+        let seedIdx = 0;
+        const resetPromises = envs.map((env) => {
+            const count = env.getNumEnvs();
+            const envSeeds = seeds !== undefined ? seeds.slice(seedIdx, seedIdx + count) : undefined;
+            seedIdx += count;
+            return env.reset(envSeeds, options);
         });
         
         const resetResults = await Promise.all(resetPromises);
         
         for (const result of resetResults) {
             if (Array.isArray(result)) {
-                results.push(...result);
+                // Flatten per-env results with an explicit loop: spreading a
+                // very large batch would exceed the engine's argument limit.
+                for (const item of result) {
+                    results.push(item);
+                }
             } else {
                 results.push(result);
             }
@@ -215,36 +234,73 @@ export class EnvManager {
 
     /**
      * Step all environments with the given actions.
-     * @param actions Actions for each environment
+     * @param actions Actions for each internal environment across the
+     *   manager's pools: exactly one action per internal environment
+     *   (numEnvs per BonkEnv)
      * @param options Result ownership mode; caller-owned by default
-     * @returns Flat array of step results, one per environment, matching the
-     *   shape returned by {@link resetAll}
+     * @returns Flat array of step results, one per internal environment,
+     *   matching the shape returned by {@link resetAll}
      */
     async stepAll(actions: any[], options?: ResultOwnershipOptions): Promise<any[]> {
         const envs = this.getAllEnvs();
         
-        // Step all environments in parallel, each with exactly one action
-        const stepPromises = envs.map((env, idx) => {
-            const action = actions[idx];
-            return env.step(action !== undefined ? [action] : [], options);
+        if (!Array.isArray(actions)) {
+            throw new Error(`Invalid action batch: expected an array of actions, got ${typeof actions}`);
+        }
+        this.assertBatchLength('action', actions.length, envs);
+
+        // Step all environments in parallel, slicing the batch so each pool
+        // receives the actions for all of its internal environments instead
+        // of a single-element batch that a multi-env pool would reject
+        // (issue #230).
+        let actionIdx = 0;
+        const stepPromises = envs.map((env) => {
+            const count = env.getNumEnvs();
+            const envActions = actions.slice(actionIdx, actionIdx + count);
+            actionIdx += count;
+            return env.step(envActions, options);
         });
         
         const stepResults = await Promise.all(stepPromises);
-        
-        // Each BonkEnv.step resolves to an array (its worker pool always
-        // resolves one result per environment), so flatten the batch into the
-        // same flat shape resetAll returns instead of a nested StepResult[][]
-        // (issue #198). The pooled array path is fully symmetric with the
-        // resetAll flattening below.
+
+        // Every BonkEnv.step resolves to an array (one StepResult per internal
+        // environment), so collect the results into the same flat shape
+        // resetAll returns (issue #198).
         const results: any[] = [];
         for (const result of stepResults) {
             if (Array.isArray(result)) {
-                results.push(...result);
+                // Flatten per-env results with an explicit loop: spreading a
+                // very large batch would exceed the engine's argument limit.
+                for (const item of result) {
+                    results.push(item);
+                }
             } else {
                 results.push(result);
             }
         }
         return results;
+    }
+
+    /**
+     * Validate that a batch covers exactly the internal environments of the
+     * given BonkEnvs. A count mismatch rejects before any pool is touched, so
+     * a malformed batch can never fail or desync a worker pool by forwarding
+     * an empty or short action list.
+     * @param kind 'seed' or 'action' (used in the error message)
+     * @param received Number of entries in the caller's batch
+     * @param envs The BonkEnv instances the batch is meant to cover
+     */
+    private assertBatchLength(kind: 'seed' | 'action', received: number, envs: BonkEnv[]): void {
+        let expected = 0;
+        for (const env of envs) {
+            expected += env.getNumEnvs();
+        }
+        if (received !== expected) {
+            const plural = expected === 1 ? '' : 's';
+            throw new Error(
+                `Invalid ${kind} batch: expected ${expected} ${kind}${plural} for ${expected} internal environment${plural} across ${envs.length} environment pool${envs.length === 1 ? '' : 's'}, got ${received}`,
+            );
+        }
     }
 
     /**

--- a/src/env/env-manager.ts
+++ b/src/env/env-manager.ts
@@ -217,7 +217,8 @@ export class EnvManager {
      * Step all environments with the given actions.
      * @param actions Actions for each environment
      * @param options Result ownership mode; caller-owned by default
-     * @returns Array of step results
+     * @returns Flat array of step results, one per environment, matching the
+     *   shape returned by {@link resetAll}
      */
     async stepAll(actions: any[], options?: ResultOwnershipOptions): Promise<any[]> {
         const envs = this.getAllEnvs();
@@ -228,7 +229,22 @@ export class EnvManager {
             return env.step(action !== undefined ? [action] : [], options);
         });
         
-        return Promise.all(stepPromises);
+        const stepResults = await Promise.all(stepPromises);
+        
+        // Each BonkEnv.step resolves to an array (its worker pool always
+        // resolves one result per environment), so flatten the batch into the
+        // same flat shape resetAll returns instead of a nested StepResult[][]
+        // (issue #198). The pooled array path is fully symmetric with the
+        // resetAll flattening below.
+        const results: any[] = [];
+        for (const result of stepResults) {
+            if (Array.isArray(result)) {
+                results.push(...result);
+            } else {
+                results.push(result);
+            }
+        }
+        return results;
     }
 
     /**

--- a/tests/integration/env-lifecycle.test.ts
+++ b/tests/integration/env-lifecycle.test.ts
@@ -181,6 +181,10 @@ describe('EnvManager lifecycle', () => {
       const results = await manager.stepAll([0, 0]);
       expect(results).toBeDefined();
       expect(results).toHaveLength(2);
+      // stepAll returns flat StepResult objects, not per-env arrays (#198).
+      expect(Array.isArray(results[0])).toBe(false);
+      expect(typeof results[0].reward).toBe('number');
+      expect(results[0].observation).toBeDefined();
     });
   });
 

--- a/tests/integration/env-manager-batch-shape.test.ts
+++ b/tests/integration/env-manager-batch-shape.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { EnvManager } from '../../src/env/env-manager';
+import { WorkerPool } from '../../src/core/worker-pool';
+
+/**
+ * Regression coverage for issue #198: stepAll() must return the same flat
+ * per-environment result shape as resetAll() instead of a nested
+ * StepResult[][] (an element of a stepAll result is a StepResult object, so
+ * `result.reward` / `result.done` / `result.observation` work as documented).
+ */
+describe('EnvManager batch result shape (issue #198)', () => {
+  let manager: EnvManager;
+
+  beforeEach(() => {
+    manager = new EnvManager({
+      portManager: { startPort: 8100, endPort: 8200 },
+      defaultEnvConfig: { numEnvs: 1, useSharedMemory: false },
+    });
+  });
+
+  afterEach(async () => {
+    try { await manager.shutdownAll(); } catch { /* ignore */ }
+  });
+
+  it('stepAll and resetAll both return a flat array with matching element shape', { timeout: 30000 }, async () => {
+    await manager.createPool(2);
+
+    const resetResults = await manager.resetAll([1, 2]);
+    const stepResults = await manager.stepAll([0, 0]);
+
+    expect(resetResults).toHaveLength(2);
+    expect(stepResults).toHaveLength(2);
+
+    // Contract: both APIs return one flat element per environment, never a
+    // per-env array wrapper.
+    expect(Array.isArray(resetResults[0])).toBe(false);
+    expect(Array.isArray(stepResults[0])).toBe(false);
+    expect(typeof stepResults[0].reward).toBe('number');
+    expect(stepResults[0].observation).toBeDefined();
+    expect(typeof stepResults[0].done).toBe('boolean');
+
+    for (let i = 0; i < stepResults.length; i++) {
+      expect(Array.isArray(stepResults[i])).toBe(Array.isArray(resetResults[i]));
+    }
+  });
+
+  it('stepAll results expose reward/done/observation directly on each element', { timeout: 30000 }, async () => {
+    await manager.createPool(1);
+    await manager.resetAll([1]);
+
+    const results = await manager.stepAll([0]);
+
+    // The documented Promise<any[]> contract: results[i] is a StepResult.
+    expect(Array.isArray(results[0])).toBe(false);
+    expect(results[0].reward).toBeDefined();
+    expect(results[0].done).toBeDefined();
+    expect(results[0].observation).toBeDefined();
+  });
+
+  it('shared-memory transport returns the same flat shape', { timeout: 30000 }, async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    manager.shutdownAll();
+    manager = new EnvManager({
+      portManager: { startPort: 8200, endPort: 8300 },
+      defaultEnvConfig: { numEnvs: 1, useSharedMemory: true },
+    });
+    await manager.createPool(2);
+
+    const resetResults = await manager.resetAll([1, 2]);
+    const stepResults = await manager.stepAll([0, 0]);
+
+    expect(resetResults).toHaveLength(2);
+    expect(stepResults).toHaveLength(2);
+    expect(Array.isArray(resetResults[0])).toBe(false);
+    expect(Array.isArray(stepResults[0])).toBe(false);
+    expect(typeof stepResults[0].reward).toBe('number');
+    expect(stepResults[0].observation).toBeDefined();
+  });
+});

--- a/tests/integration/env-manager-batch-shape.test.ts
+++ b/tests/integration/env-manager-batch-shape.test.ts
@@ -78,3 +78,121 @@ describe('EnvManager batch result shape (issue #198)', () => {
     expect(stepResults[0].observation).toBeDefined();
   });
 });
+
+/**
+ * Regression coverage for issue #230: the EnvManager batch APIs must work for
+ * BonkEnv with numEnvs > 1. stepAll must hand the multi-env pool a full
+ * action list (not a single-element batch that the exact-count validation
+ * rejects), and resetAll must seed every internal environment (not silently
+ * seed only the first one).
+ */
+describe('EnvManager batch APIs with numEnvs > 1 (issue #230)', () => {
+  let manager: EnvManager;
+
+  beforeEach(() => {
+    manager = new EnvManager({
+      portManager: { startPort: 8300, endPort: 8400 },
+      defaultEnvConfig: { numEnvs: 3, useSharedMemory: false },
+    });
+  });
+
+  afterEach(async () => {
+    try { await manager.shutdownAll(); } catch { /* ignore */ }
+  });
+
+  it('stepAll and resetAll cover every internal environment of a numEnvs=3 pool', { timeout: 30000 }, async () => {
+    const envs = await manager.createPool(1);
+    expect(envs).toHaveLength(1);
+    expect(envs[0].getNumEnvs()).toBe(3);
+
+    const resetResults = await manager.resetAll([11, 22, 33]);
+    expect(resetResults).toHaveLength(3);
+
+    const stepResults = await manager.stepAll([0, 0, 0]);
+    expect(stepResults).toHaveLength(3);
+    expect(Array.isArray(stepResults[0])).toBe(false);
+    expect(typeof stepResults[0].reward).toBe('number');
+    expect(stepResults[0].observation).toBeDefined();
+
+    // The pool stays healthy across repeated batches.
+    const secondStep = await manager.stepAll([1, 2, 3]);
+    expect(secondStep).toHaveLength(3);
+    expect(secondStep.every((r: any) => !Array.isArray(r) && typeof r.reward === 'number')).toBe(true);
+  });
+
+  it('seeds a full multi-env pool deterministically and rejects a short seed list', { timeout: 30000 }, async () => {
+    await manager.createPool(1);
+
+    // A short list is rejected loudly instead of silently under-seeding.
+    await expect(manager.resetAll([11])).rejects.toThrow('Invalid seed batch');
+
+    // A full-length reset works after the rejected batch, and identical seeds
+    // reproduce identical trajectories for every internal environment.
+    await manager.resetAll([11, 22, 33]);
+    const first = await manager.stepAll([0, 0, 0]);
+    await manager.resetAll([11, 22, 33]);
+    const second = await manager.stepAll([0, 0, 0]);
+
+    expect(first).toHaveLength(3);
+    expect(second).toHaveLength(3);
+    for (let i = 0; i < 3; i++) {
+      expect(second[i].observation).toEqual(first[i].observation);
+    }
+  });
+
+  it('rejects a short action batch without failing the pool', { timeout: 30000 }, async () => {
+    await manager.createPool(1);
+    await manager.resetAll([11, 22, 33]);
+
+    await expect(manager.stepAll([0])).rejects.toThrow('Invalid action batch');
+
+    const results = await manager.stepAll([0, 0, 0]);
+    expect(results).toHaveLength(3);
+    expect(Array.isArray(results[0])).toBe(false);
+  });
+
+  it('mixes pools with different internal counts in one flat batch', { timeout: 30000 }, async () => {
+    // 2 internal + 1 internal = 3 total, addressed as one flat batch.
+    await manager.createEnv({ numEnvs: 2 });
+    await manager.createEnv({ numEnvs: 1 });
+
+    const resetResults = await manager.resetAll([1, 2, 3]);
+    expect(resetResults).toHaveLength(3);
+
+    const stepResults = await manager.stepAll([0, 0, 0]);
+    expect(stepResults).toHaveLength(3);
+    expect(stepResults.every((r: any) => !Array.isArray(r) && typeof r.reward === 'number')).toBe(true);
+  });
+
+  it('BonkEnv.reset rejects short and non-array seed batches at the wrapper layer', { timeout: 30000 }, async () => {
+    const envs = await manager.createPool(1);
+    const env = envs[0];
+
+    await expect(env.reset([11])).rejects.toThrow('Invalid seed batch');
+    await expect(env.reset('11' as any)).rejects.toThrow('expected an array of seeds');
+
+    // A full-length batch still works after the rejected ones.
+    const obs = await env.reset([11, 22, 33]);
+    expect(Array.isArray(obs)).toBe(true);
+    expect(obs).toHaveLength(3);
+  });
+
+  it('shared-memory transport batches a numEnvs=3 pool', { timeout: 30000 }, async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    manager.shutdownAll();
+    manager = new EnvManager({
+      portManager: { startPort: 8400, endPort: 8500 },
+      defaultEnvConfig: { numEnvs: 3, useSharedMemory: true },
+    });
+    await manager.createPool(1);
+
+    const resetResults = await manager.resetAll([11, 22, 33]);
+    expect(resetResults).toHaveLength(3);
+
+    const stepResults = await manager.stepAll([0, 0, 0]);
+    expect(stepResults).toHaveLength(3);
+    expect(Array.isArray(stepResults[0])).toBe(false);
+    expect(typeof stepResults[0].reward).toBe('number');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the two EnvManager batch-API defects reported by the scheduled audits. Both are exclusively in the TypeScript EnvManager/BonkEnv layer; the IPC/Python path (which validates exact counts client-side) is unaffected.

Fixes #198 — `stepAll` now returns the same flat per-environment shape as `resetAll` (a `StepResult` per element) instead of a nested `StepResult[][]`, so `results[i].reward` / `.done` / `.observation` work as documented. `BonkEnv.step` is re-typed to `Promise<StepResult[]>` to match its actual behavior, and the example/tests were updated.

Fixes #230 — the batch methods now account for each `BonkEnv`'s internal environment count (`numEnvs`). `stepAll` passes each pool a correctly-sized slice of the action batch (a full action list for multi-env pools), `resetAll` seeds every internal environment, and both APIs validate the batch length up front so an undersized batch is rejected with a clear `Invalid seed/action batch` error before any pool is touched. `BonkEnv.reset` also enforces an exact seed count so a short list can never silently leave internal environments unseeded.

## Commits

- `fix(env): stepAll returns flat StepResult array matching resetAll (#198)`
- `fix(env,manager): batch stepAll/resetAll across numEnvs pools and seed every internal env (#230)`

## Verification

- `npm run typecheck` — 0 errors
- `npm test` — 64 files, 1314 passed, 19 skipped, 0 failed
- `python -m pytest python/tests -q` — 138 passed
- `git diff --check` — clean