### PR TITLE
fix(env,config): wire map path, seed 0, and aiPlayerId through the environment constructor (#199, #200, #221)

### DIFF
--- a/src/config/config-loader.ts
+++ b/src/config/config-loader.ts
@@ -438,6 +438,13 @@ function applyEnvOverrides(config: AppConfig): AppConfig {
         const v = parseInt(env.SEED, 10);
         if (!isNaN(v) && v >= 0) config.environment.seed = v;
     }
+    // AI player slot (documented surface, config.example.json: range 0-7).
+    // The slot must also be within [0, numOpponents]; that interplay is
+    // validated by BonkEnvironment at construction.
+    if (env.AI_PLAYER_ID !== undefined) {
+        const v = parseInt(env.AI_PLAYER_ID, 10);
+        if (!isNaN(v) && v >= 0 && v <= 7) config.environment.aiPlayerId = v;
+    }
     // Opponent random-policy probabilities (documented env vars)
     const oppProbEnvVars: Array<[string, keyof EnvironmentConfig]> = [
         ['RANDOM_OPP_MOVE_PROB', 'randomOppMoveProb'],
@@ -566,6 +573,16 @@ function parseCliFlags(config: AppConfig): AppConfig {
                 if (next) {
                     config.environment.defaultMapPath = next;
                     i++;
+                }
+                break;
+
+            case '--ai-player-id':
+                if (next) {
+                    const v = parseInt(next, 10);
+                    if (!isNaN(v) && v >= 0 && v <= 7) {
+                        config.environment.aiPlayerId = v;
+                        i++;
+                    }
                 }
                 break;
 

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -101,6 +101,14 @@ export interface EnvironmentConfig {
      * environment config verbatim, so this is the end-to-end documented surface (#199).
      */
     defaultMapPath?: string;
+    /**
+     * Player slot index controlled by the RL agent (0-7, default 0). The agent
+     * observes, controls, and is rewarded for this slot; every other spawned
+     * slot is an opponent (`AI_PLAYER_ID` | `--ai-player-id` |
+     * `environment.aiPlayerId`). Must be within [0, numOpponents], the AI slot
+     * plus one slot per opponent (#221).
+     */
+    aiPlayerId?: number;
     /** Opponent random-policy probabilities */
     oppMoveProb?: number;
     oppUpProb?: number;
@@ -227,6 +235,7 @@ export class BonkEnvironment {
             ppm: this.ppm,
             mapPath: mapFile,
             defaultMapPath: config.defaultMapPath ?? '',
+            aiPlayerId: config.aiPlayerId ?? 0,
             oppMoveProb,
             oppUpProb,
             oppDownProb,
@@ -240,6 +249,22 @@ export class BonkEnvironment {
             teamsEnabled: config.teamsEnabled ?? ((mapDef as any).physics?.teams ?? false),
             noCollide: config.noCollide ?? ((mapDef as any).physics?.nc ?? false),
         };
+
+        // The AI slot is config-driven, never hardcoded to 0 (#221). An
+        // out-of-range slot fails loudly here instead of being silently
+        // ignored: with numOpponents opponents the spawned players occupy
+        // slots [0, numOpponents] (the AI plus one slot per opponent).
+        this.aiPlayerId = this.config.aiPlayerId;
+        if (!Number.isInteger(this.aiPlayerId) || this.aiPlayerId < 0) {
+            throw new Error(
+                `Invalid aiPlayerId ${this.aiPlayerId}: expected a non-negative integer player slot`,
+            );
+        }
+        if (this.aiPlayerId > this.config.numOpponents) {
+            throw new Error(
+                `Invalid aiPlayerId ${this.aiPlayerId}: with ${this.config.numOpponents} opponent(s) the player slots are 0..${this.config.numOpponents}`,
+            );
+        }
 
         this.rng = new PRNG(this.config.seed);
         this.physics = new PhysicsEngine();
@@ -373,8 +398,10 @@ export class BonkEnvironment {
         const teamB = spawnPoints.team_blue || (spawnKeys.length > 0 ? spawnPoints[spawnKeys[0]] : null) || { x: -200, y: -100 };
         const teamR = spawnPoints.team_red || { x: 200, y: -100 };
 
-        // Add AI player
-        this.aiPlayerId = 0;
+        // Add the AI player on its configured slot (never reassigned to 0
+        // here), then one opponent per remaining slot of [0, numOpponents]
+        // (#221). The AI spawns on the blue team spawn and opponents on the
+        // red team spawn regardless of slot numbering, as before.
         this.physics.addPlayer(
             this.aiPlayerId,
             teamB.x,
@@ -383,14 +410,14 @@ export class BonkEnvironment {
 
         // Add opponent(s)
         this.opponentIds = [];
-        for (let i = 0; i < this.config.numOpponents; i++) {
-            const id = i + 1;
+        for (let slot = 0; slot <= this.config.numOpponents; slot++) {
+            if (slot === this.aiPlayerId) continue;
             this.physics.addPlayer(
-                id,
+                slot,
                 teamR.x,
                 teamR.y,
             );
-            this.opponentIds.push(id);
+            this.opponentIds.push(slot);
         }
 
         // Set team assignments

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -95,6 +95,12 @@ export interface EnvironmentConfig {
     ppm?: number;
     /** Optional path to a map JSON file, used when mapData is absent */
     mapPath?: string;
+    /**
+     * Config-loader map path (`--map` | `DEFAULT_MAP_PATH` | `environment.defaultMapPath`),
+     * used when both mapData and mapPath are absent. The worker forwards the merged
+     * environment config verbatim, so this is the end-to-end documented surface (#199).
+     */
+    defaultMapPath?: string;
     /** Opponent random-policy probabilities */
     oppMoveProb?: number;
     oppUpProb?: number;
@@ -169,16 +175,23 @@ export class BonkEnvironment {
         const rawConfig = config as any;
         const frameSkip = config.frameSkip ?? rawConfig.frame_skip;
 
-        // Load map from file or use provided config
+        // Load map from file or use provided config. `mapData` (programmatic)
+        // wins; otherwise the documented map-path surface is honored end to
+        // end: the config-loader resolves `--map` / `DEFAULT_MAP_PATH` /
+        // `environment.defaultMapPath` into `defaultMapPath`, which the worker
+        // forwards verbatim. `mapPath` is the per-env programmatic override;
+        // the hardcoded WDB path is only the last-resort fallback.
         let mapDef: MapDef;
+        let mapFile = '';
         if (config.mapData) {
             mapDef = config.mapData;
         } else {
-            const mapPath = config.mapPath || path.join(__dirname, '..', '..', 'maps', 'bonk_WDB__No_Mapshake__716916.json');
+            const mapPath = config.mapPath || config.defaultMapPath || path.join(__dirname, '..', '..', 'maps', 'bonk_WDB__No_Mapshake__716916.json');
             try {
                 mapDef = JSON.parse(fs.readFileSync(mapPath, 'utf8'));
+                mapFile = mapPath;
             } catch (e) {
-                console.warn("Could not load default map, using fallback box");
+                console.warn(`Could not load map "${mapPath}", using fallback box`);
                 mapDef = getDefaultMap();
             }
         }
@@ -204,7 +217,8 @@ export class BonkEnvironment {
             seed: (config.seed && config.seed !== 0) ? config.seed : Math.floor(Math.random() * 1000000),
             frameSkip: frameSkip ?? 1,
             ppm: this.ppm,
-            mapPath: config.mapPath ?? '',
+            mapPath: mapFile,
+            defaultMapPath: config.defaultMapPath ?? '',
             oppMoveProb,
             oppUpProb,
             oppDownProb,

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -130,16 +130,21 @@ export interface EnvironmentConfig {
 // ─── Default Arena ───────────────────────────────────────────────────
 
 /**
- * Resolve a possibly repo-relative map path against the project root so a
- * relative path (such as the loader default `maps/...`) works regardless of
- * the process cwd. The worker inherits the parent's cwd, so a cwd-relative
- * default map path would otherwise silently box-fall-back when the server is
- * launched from a different directory (#199).
+ * Resolve a possibly relative map path for loading. Absolute paths are used
+ * as-is. Relative paths keep their legacy process-cwd meaning when the file
+ * exists there (programmatic `mapPath` compatibility); otherwise they are
+ * re-anchored against the project root so a repo-relative path such as the
+ * loader default `maps/...` cannot silently box-fall-back when the worker's
+ * inherited cwd differs from the repository root (#199).
  */
 function resolveMapPath(mapFile: string): string {
-    return path.isAbsolute(mapFile)
-        ? mapFile
-        : path.resolve(__dirname, '..', '..', mapFile);
+    if (path.isAbsolute(mapFile)) {
+        return mapFile;
+    }
+    if (fs.existsSync(mapFile)) {
+        return mapFile;
+    }
+    return path.resolve(__dirname, '..', '..', mapFile);
 }
 
 /**

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -130,6 +130,19 @@ export interface EnvironmentConfig {
 // ─── Default Arena ───────────────────────────────────────────────────
 
 /**
+ * Resolve a possibly repo-relative map path against the project root so a
+ * relative path (such as the loader default `maps/...`) works regardless of
+ * the process cwd. The worker inherits the parent's cwd, so a cwd-relative
+ * default map path would otherwise silently box-fall-back when the server is
+ * launched from a different directory (#199).
+ */
+function resolveMapPath(mapFile: string): string {
+    return path.isAbsolute(mapFile)
+        ? mapFile
+        : path.resolve(__dirname, '..', '..', mapFile);
+}
+
+/**
  * Creates a simple default map config if none is provided.
  */
 function getDefaultMap(): MapDef {
@@ -194,7 +207,13 @@ export class BonkEnvironment {
         if (config.mapData) {
             mapDef = config.mapData;
         } else {
-            const mapPath = config.mapPath || config.defaultMapPath || path.join(__dirname, '..', '..', 'maps', 'bonk_WDB__No_Mapshake__716916.json');
+            // Resolve relative paths against the project root (see
+            // resolveMapPath) so the loader's cwd-relative default cannot
+            // shadow the cwd-independent fallback in worker mode.
+            const configuredPath = config.mapPath || config.defaultMapPath || '';
+            const mapPath = configuredPath
+                ? resolveMapPath(configuredPath)
+                : path.join(__dirname, '..', '..', 'maps', 'bonk_WDB__No_Mapshake__716916.json');
             try {
                 mapDef = JSON.parse(fs.readFileSync(mapPath, 'utf8'));
                 mapFile = mapPath;

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -421,6 +421,11 @@ export class BonkEnvironment {
         // here), then one opponent per remaining slot of [0, numOpponents]
         // (#221). The AI spawns on the blue team spawn and opponents on the
         // red team spawn regardless of slot numbering, as before.
+        //
+        // Re-apply the AI slot to the engine every reset (setPlayerTeam below
+        // is re-applied per episode too): the default collision categories
+        // keep the AI disc on g1 and opponents on g2 whatever their slots.
+        this.physics.setAiPlayerId(this.aiPlayerId);
         this.physics.addPlayer(
             this.aiPlayerId,
             teamB.x,

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -214,7 +214,15 @@ export class BonkEnvironment {
             maxTicks: config.maxTicks ?? rawConfig.max_ticks ?? MAX_TICKS,
             randomOpponent: config.randomOpponent ?? rawConfig.random_opponent ?? true,
             mapData: mapDef,
-            seed: (config.seed && config.seed !== 0) ? config.seed : Math.floor(Math.random() * 1000000),
+            // Seed 0 is a valid deterministic seed and must reach the PRNG: a
+            // truthiness check would map `--seed 0` / `SEED=0` /
+            // `environment.seed: 0` onto a random seed while reset(0) and
+            // pool.reset([0]) stay deterministic, silently breaking
+            // constructed-env replay (#200). Only an absent seed (undefined/
+            // null) falls back to a random one.
+            seed: config.seed !== undefined && config.seed !== null
+                ? config.seed
+                : Math.floor(Math.random() * 1000000),
             frameSkip: frameSkip ?? 1,
             ppm: this.ppm,
             mapPath: mapFile,

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -242,6 +242,13 @@ export class PhysicsEngine {
    */
   private swingJustStarted: Set<number> = new Set();
   private playerTeams: Map<number, string> = new Map();
+  /**
+   * Slot id treated as the "AI" disc for the default collision categories
+   * (g1 for the AI disc, g2 for every other disc, matching the legacy
+   * `id === 0` mapping). The environment configures this via setAiPlayerId()
+   * so a nonzero aiPlayerId (issue #221) does not invert the categories.
+   */
+  private aiSlot: number = 0;
   private capZoneSensors: any[] = [];
   private lastScoredTeam: string | null = null;
   /** An instant goal ends the round; later sensor jitter must not re-score it. */
@@ -377,7 +384,7 @@ export class PhysicsEngine {
 
     const filter = new b2FilterData();
     if (this.noCollide) {
-      filter.categoryBits = playerId === 0 ? 0x0002 : 0x0004;
+      filter.categoryBits = playerId === this.aiSlot ? 0x0002 : 0x0004;
       filter.maskBits = 0xFFFF & ~PhysicsEngine.ALL_PLAYER_BITS;
     } else if (this.teamsEnabled) {
       const team = this.playerTeams.get(playerId);
@@ -386,15 +393,26 @@ export class PhysicsEngine {
         filter.categoryBits = teamBit;
         filter.maskBits = 0xFFFF & ~teamBit;
       } else {
-        filter.categoryBits = playerId === 0 ? 0x0002 : 0x0004;
+        filter.categoryBits = playerId === this.aiSlot ? 0x0002 : 0x0004;
         filter.maskBits = 0xFFFF;
       }
     } else {
-      filter.categoryBits = playerId === 0 ? 0x0002 : 0x0004;
+      filter.categoryBits = playerId === this.aiSlot ? 0x0002 : 0x0004;
       filter.maskBits = 0xFFFF;
     }
     shape.SetFilterData(filter);
     this.world.Refilter(shape);
+  }
+
+  /**
+   * Sets the slot treated as the AI disc for default (non-team) collision
+   * categories (g1 for the AI, g2 for every other disc). The environment calls
+   * this with its configured aiPlayerId so nonzero slots keep the AI on g1
+   * instead of inverting the legacy `id === 0` mapping (issue #221). The
+   * default 0 keeps engine-only callers on the legacy mapping.
+   */
+  setAiPlayerId(playerId: number): void {
+    this.aiSlot = playerId;
   }
 
   private updateAllPlayerFilters(): void {
@@ -816,10 +834,12 @@ export class PhysicsEngine {
     circleDef.friction = PLAYER_FRICTION;
     circleDef.restitution = PLAYER_RESTITUTION;
 
-    // Assign collision category based on player ID
-    // Player 0 = team g1 (category 0x0002), Player 1+ = team g2 (category 0x0004)
+    // Assign collision category based on the AI slot: AI disc = team g1
+    // (category 0x0002), every other disc = team g2 (category 0x0004). The
+    // category follows the configured AI slot (setAiPlayerId), not a hardcoded
+    // id 0, so a nonzero aiPlayerId keeps the g1 mapping on the AI (#221).
     const filter = new b2FilterData();
-    filter.categoryBits = id === 0 ? 0x0002 : 0x0004;
+    filter.categoryBits = id === this.aiSlot ? 0x0002 : 0x0004;
     filter.maskBits = 0xFFFF; // Collide with everything by default
     circleDef.filter = filter;
 

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -409,10 +409,13 @@ export class PhysicsEngine {
    * categories (g1 for the AI, g2 for every other disc). The environment calls
    * this with its configured aiPlayerId so nonzero slots keep the AI on g1
    * instead of inverting the legacy `id === 0` mapping (issue #221). The
-   * default 0 keeps engine-only callers on the legacy mapping.
+   * default 0 keeps engine-only callers on the legacy mapping. Existing discs
+   * are re-filtered immediately, so callers may set the slot after adding
+   * players.
    */
   setAiPlayerId(playerId: number): void {
     this.aiSlot = playerId;
+    this.updateAllPlayerFilters();
   }
 
   private updateAllPlayerFilters(): void {
@@ -1396,6 +1399,10 @@ export class PhysicsEngine {
     this.grappleEnergy.clear();
     this.swingJustStarted.clear();
     this.playerTeams.clear();
+    // The AI-slot category mapping belongs to the episode: a fresh world
+    // starts with the legacy default (slot 0 = AI), and the environment
+    // re-applies setAiPlayerId() before spawning players each episode.
+    this.aiSlot = 0;
     this.capZoneSensors = [];
     this.capZoneState.clear();
     this.capZoneTouches = [];

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -152,6 +152,11 @@ parentPort.on('message', (msg) => {
         if (msg.type === 'init') {
             const numEnvsParam = msg.numEnvs;
             const config = msg.config || {};
+            // The global env index base must be assigned BEFORE the env loop:
+            // construction seeds are derived from it, and workers k ≥ 1 would
+            // otherwise reuse the previous/zero offset and duplicate worker 0's
+            // streams (review of #200).
+            globalOffset = msg.startId || 0;
             // Size the shared-memory observation buffer and manager for the
             // configured opponent count so all opponents are transported.
             _obsNumOpponents = SharedMemoryManager.normalizeNumOpponents(config.numOpponents);
@@ -168,7 +173,6 @@ parentPort.on('message', (msg) => {
                 envs.push(new BonkEnvironment({ ...config, seed: (config.seed ?? 0) + globalOffset + i }));
             }
             numEnvs = numEnvsParam;
-            globalOffset = msg.startId || 0;
 
             // If sharedBuffer is provided and is a valid SharedArrayBuffer, initialize SharedMemoryManager
             // Note: When passed via postMessage, SharedArrayBuffer becomes an empty object.

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -158,7 +158,14 @@ parentPort.on('message', (msg) => {
             _obsBuffer = new Float32Array(16 + 6 * Math.max(0, _obsNumOpponents - 1));
             envs = [];
             for (let i = 0; i < numEnvsParam; i++) {
-                envs.push(new BonkEnvironment(config));
+                // Each global environment gets its own deterministic
+                // construction seed: the configured seed (the loader default 0
+                // is now honored, #200) plus the global env index. Pooled
+                // environments therefore never all share an identical PRNG
+                // stream, while every environment's construction stream stays
+                // reproducible for the same config. The worker's later reset()
+                // with per-env seeds overrides this stream exactly as before.
+                envs.push(new BonkEnvironment({ ...config, seed: (config.seed ?? 0) + globalOffset + i }));
             }
             numEnvs = numEnvsParam;
             globalOffset = msg.startId || 0;

--- a/tests/integration/env-ai-player-id.test.ts
+++ b/tests/integration/env-ai-player-id.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { BonkEnvironment } from '../../src/core/environment';
 import { safeDestroy, EMPTY_INPUT } from '../utils/test-helpers';
+import type { MapDef } from '../../src/core/physics-engine';
 
 describe('Environment aiPlayerId wiring (#221)', () => {
   let env: BonkEnvironment | null = null;
@@ -43,6 +44,30 @@ describe('Environment aiPlayerId wiring (#221)', () => {
     expect(after.velX).toBeGreaterThan(before.velX);
     expect((env as any).aiPlayerId).toBe(1);
     expect((env as any).opponentIds).toEqual([0]);
+  });
+
+  it('keeps the AI disc on the g1 collision category whatever its slot', () => {
+    // A g1-only barrier between the blue and red spawns: the AI (slot 1 here)
+    // must still be blocked (AI disc = category g1), or the slot-based
+    // category rule would let it pass as g2 (#221).
+    const mapData: MapDef = {
+      name: 'g1-barrier',
+      spawnPoints: {
+        team_blue: { x: -150, y: 0 },
+        team_red: { x: 250, y: 0 },
+      },
+      bodies: [
+        { name: 'barrier', type: 'rect', x: 0, y: 50, width: 20, height: 1200, static: true, collides: { g1: true, g2: false, g3: false, g4: false } },
+        { name: 'floor', type: 'rect', x: 0, y: 500, width: 1000, height: 40, static: true },
+      ],
+    };
+    env = new BonkEnvironment({ aiPlayerId: 1, numOpponents: 1, mapData, maxTicks: 400, randomOpponent: false });
+    env.reset();
+    for (let i = 0; i < 150; i++) {
+      env.step({ ...EMPTY_INPUT, right: true });
+    }
+    const final = env.step(EMPTY_INPUT).observation;
+    expect(final.playerX).toBeLessThan(0);
   });
 
   it('out-of-range aiPlayerId fails loudly instead of being silently ignored', () => {

--- a/tests/integration/env-ai-player-id.test.ts
+++ b/tests/integration/env-ai-player-id.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { BonkEnvironment } from '../../src/core/environment';
+import { safeDestroy, EMPTY_INPUT } from '../utils/test-helpers';
+
+describe('Environment aiPlayerId wiring (#221)', () => {
+  let env: BonkEnvironment | null = null;
+
+  afterEach(async () => {
+    if (env) {
+      await env.close();
+      env = null;
+    }
+  });
+
+  it('aiPlayerId 1 makes the agent observe player 1 (blue spawn) while player 0 is the opponent (red spawn)', () => {
+    env = new BonkEnvironment({ aiPlayerId: 1, numOpponents: 1, maxTicks: 100, randomOpponent: false });
+    const obs = env.reset();
+
+    // Default_Box blue AI spawn is (-200, -100) and the red opponent spawn
+    // is (200, -100).
+    expect(obs.opponents).toHaveLength(1);
+    expect(obs.playerX).toBeCloseTo(-200, 6);
+    expect(obs.playerY).toBeCloseTo(-100, 6);
+    expect(obs.opponents[0].x).toBeCloseTo(200, 6);
+    expect(obs.opponents[0].y).toBeCloseTo(-100, 6);
+
+    // The observation's player fields must be the physics state of slot 1
+    // (the configured AI slot), NOT the hardcoded slot 0. With the buggy
+    // behavior slot 1 held the red-spawned opponent, so this fails loudly.
+    const physics = (env as any).physics;
+    const aiSlotState = physics.getPlayerState(1);
+    expect(obs.playerX).toBe(aiSlotState.x);
+    expect(obs.playerY).toBe(aiSlotState.y);
+    const oppSlotState = physics.getPlayerState(0);
+    expect(obs.opponents[0].x).toBe(oppSlotState.x);
+    expect(obs.opponents[0].y).toBe(oppSlotState.y);
+
+    // Inputs also land on the configured slot: a held right input moves the
+    // slot-1 AI disc.
+    const before = physics.getPlayerState(1);
+    env.step({ ...EMPTY_INPUT, right: true });
+    const after = physics.getPlayerState(1);
+    expect(after.velX).toBeGreaterThan(before.velX);
+    expect((env as any).aiPlayerId).toBe(1);
+    expect((env as any).opponentIds).toEqual([0]);
+  });
+
+  it('out-of-range aiPlayerId fails loudly instead of being silently ignored', () => {
+    // With 1 opponent the spawned slots are 0..1, so slot 2 cannot be the AI.
+    expect(() => new BonkEnvironment({ aiPlayerId: 2, numOpponents: 1, maxTicks: 100 }))
+      .toThrow(/aiPlayerId 2/);
+  });
+
+  it('non-integer aiPlayerId fails loudly', () => {
+    expect(() => new BonkEnvironment({ aiPlayerId: 1.5 as any, numOpponents: 1, maxTicks: 100 }))
+      .toThrow(/aiPlayerId 1.5/);
+  });
+});

--- a/tests/integration/env-map-path.test.ts
+++ b/tests/integration/env-map-path.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import * as path from 'path';
+import * as os from 'os';
 import { BonkEnvironment } from '../../src/core/environment';
 import { safeDestroy } from '../utils/test-helpers';
 
@@ -31,6 +32,29 @@ describe('Environment map-path wiring (#199)', () => {
 
   it('loads the file referenced by mapPath (programmatic per-env override)', () => {
     env = new BonkEnvironment({ mapPath: SIMPLE_1V1, numOpponents: 0 });
+
+    expect((env as any).physics.getBodyMap().size).toBe(1);
+    expect((env as any).config.mapData.name).toBe('Simple 1v1');
+  });
+
+  it('loads a repo-relative map path independently of the process cwd', () => {
+    const original = process.cwd();
+    try {
+      process.chdir(os.tmpdir());
+      env = new BonkEnvironment({ mapPath: 'maps/bonk_Simple_1v1_123.json', numOpponents: 0 });
+    } finally {
+      process.chdir(original);
+    }
+
+    expect((env as any).config.mapPath).toBe(
+      path.join(process.cwd(), 'maps', 'bonk_Simple_1v1_123.json'),
+    );
+    expect((env as any).physics.getBodyMap().size).toBe(1);
+    expect((env as any).config.mapData.name).toBe('Simple 1v1');
+  });
+
+  it('loads a repo-relative defaultMapPath (--map / DEFAULT_MAP_PATH surface)', () => {
+    env = new BonkEnvironment({ defaultMapPath: 'maps/bonk_Simple_1v1_123.json', numOpponents: 0 });
 
     expect((env as any).physics.getBodyMap().size).toBe(1);
     expect((env as any).config.mapData.name).toBe('Simple 1v1');

--- a/tests/integration/env-map-path.test.ts
+++ b/tests/integration/env-map-path.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as path from 'path';
+import { BonkEnvironment } from '../../src/core/environment';
+import { safeDestroy } from '../utils/test-helpers';
+
+// A real bundled map, used as the end-to-end map-path fixture. The default
+// config map (bonk_WDB__No_Mapshake__716916.json) is absent from maps/, so a
+// path surface that reaches the loader must load this file instead of falling
+// back to the Default_Box map (#199).
+const SIMPLE_1V1 = path.join(process.cwd(), 'maps', 'bonk_Simple_1v1_123.json');
+
+describe('Environment map-path wiring (#199)', () => {
+  let env: BonkEnvironment | null = null;
+
+  afterEach(async () => {
+    if (env) {
+      await env.close();
+      env = null;
+    }
+  });
+
+  it('loads the file referenced by defaultMapPath (--map / DEFAULT_MAP_PATH surface)', () => {
+    env = new BonkEnvironment({ defaultMapPath: SIMPLE_1V1, numOpponents: 0 });
+
+    // Simple 1v1 has exactly 1 map body (Default_Box has 3), so the body
+    // count proves the file was actually loaded rather than box-fallback.
+    expect((env as any).physics.getBodyMap().size).toBe(1);
+    expect((env as any).config.mapData.name).toBe('Simple 1v1');
+    expect((env as any).config.mapPath).toBe(SIMPLE_1V1);
+  });
+
+  it('loads the file referenced by mapPath (programmatic per-env override)', () => {
+    env = new BonkEnvironment({ mapPath: SIMPLE_1V1, numOpponents: 0 });
+
+    expect((env as any).physics.getBodyMap().size).toBe(1);
+    expect((env as any).config.mapData.name).toBe('Simple 1v1');
+  });
+});

--- a/tests/integration/env-seed-zero-constructor.test.ts
+++ b/tests/integration/env-seed-zero-constructor.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { BonkEnvironment } from '../../src/core/environment';
+import { safeDestroy } from '../utils/test-helpers';
+
+function trajectory(env: BonkEnvironment, steps: number): number[][] {
+  const obs = env.reset();
+  const out: number[][] = [[obs.playerX, obs.playerY, obs.playerVelX, obs.playerVelY]];
+  for (let i = 0; i < steps; i++) {
+    const r = env.step(0);
+    out.push([
+      r.observation.playerX,
+      r.observation.playerY,
+      r.observation.playerVelX,
+      r.observation.playerVelY,
+    ]);
+  }
+  return out;
+}
+
+describe('Constructor seed 0 determinism (#200)', () => {
+  let envs: BonkEnvironment[] = [];
+
+  afterEach(async () => {
+    for (const env of envs) {
+      await env.close();
+    }
+    envs = [];
+  });
+
+  it('two constructor-seeded-0 environments produce identical trajectories', () => {
+    const a = new BonkEnvironment({ seed: 0, numOpponents: 1, maxTicks: 200 });
+    const b = new BonkEnvironment({ seed: 0, numOpponents: 1, maxTicks: 200 });
+    envs = [a, b];
+
+    expect(trajectory(a, 60)).toEqual(trajectory(b, 60));
+  });
+
+  it('constructor seed 0 uses the same PRNG seeding as reset(0)', () => {
+    const seeded0 = new BonkEnvironment({ seed: 0, numOpponents: 1, maxTicks: 200 });
+    // Constructor picks a random seed here, but reset(0) reseeds to 0 exactly
+    // like the seeded-0 constructor path must.
+    const reseeded = new BonkEnvironment({ numOpponents: 1, maxTicks: 200 });
+    reseeded.reset(0);
+    envs = [seeded0, reseeded];
+
+    expect(trajectory(seeded0, 60)).toEqual(trajectory(reseeded, 60));
+  });
+});

--- a/tests/integration/worker-pool-seed-diversity.test.ts
+++ b/tests/integration/worker-pool-seed-diversity.test.ts
@@ -38,6 +38,33 @@ describe('Worker-pool per-env construction seeds (review of #200)', () => {
     }
   });
 
+  it('keeps construction streams distinct across multiple workers too', async () => {
+    const pool = new WorkerPool(2);
+    try {
+      // Two workers, one environment each: global env indices 0 and 1. The
+      // second worker must seed from its own startId; reading a stale/zero
+      // globalOffset would duplicate worker 0's stream (review of #200).
+      await pool.init(2, {}, false);
+      await pool.reset();
+
+      const signatures: number[][][] = [[], []];
+      for (let step = 0; step < 20; step++) {
+        const results = await pool.step([0, 0]);
+        for (let envIdx = 0; envIdx < 2; envIdx++) {
+          const o = results[envIdx].observation;
+          signatures[envIdx].push([
+            o.playerX, o.playerY,
+            o.opponents[0].x, o.opponents[0].y,
+          ]);
+        }
+      }
+
+      expect(signatures[0]).not.toEqual(signatures[1]);
+    } finally {
+      await pool.close();
+    }
+  });
+
   it('per-env construction streams are reproducible across pool runs', async () => {
     const runOnce = async (): Promise<number[][]> => {
       const pool = new WorkerPool(1);

--- a/tests/integration/worker-pool-seed-diversity.test.ts
+++ b/tests/integration/worker-pool-seed-diversity.test.ts
@@ -1,0 +1,63 @@
+/**
+ * worker-pool-seed-diversity.test.ts — Regression coverage for the #200 review
+ *
+ * The constructor now honors seed 0 (the config-loader default), so pooled
+ * environments must not all construct on the identical seed-0 PRNG stream:
+ * every environment gets a deterministic per-env construction seed (config
+ * seed + global env index), which keeps each env reproducible while removing
+ * the all-identical-trajectories hazard.
+ */
+import { describe, it, expect } from 'vitest';
+import { WorkerPool } from '../../src/core/worker-pool';
+
+describe('Worker-pool per-env construction seeds (review of #200)', () => {
+  it('pooled environments stepped without reset seeds do not run identical trajectories', async () => {
+    const pool = new WorkerPool(1);
+    try {
+      // Message mode exercises the same per-env construction path with the
+      // default config (seed 0) and no SAB dependency.
+      await pool.init(2, {}, false);
+      await pool.reset();
+
+      const signatures: number[][][] = [[], []];
+      for (let step = 0; step < 30; step++) {
+        const results = await pool.step([0, 0]);
+        for (let envIdx = 0; envIdx < 2; envIdx++) {
+          const o = results[envIdx].observation;
+          signatures[envIdx].push([
+            o.playerX, o.playerY,
+            o.opponents[0].x, o.opponents[0].y,
+          ]);
+        }
+      }
+
+      // Before the fix both envs shared the seed-0 stream and were identical.
+      expect(signatures[0]).not.toEqual(signatures[1]);
+    } finally {
+      await pool.close();
+    }
+  });
+
+  it('per-env construction streams are reproducible across pool runs', async () => {
+    const runOnce = async (): Promise<number[][]> => {
+      const pool = new WorkerPool(1);
+      try {
+        await pool.init(2, { seed: 7 }, false);
+        await pool.reset();
+        const signatures: number[][] = [];
+        for (let step = 0; step < 20; step++) {
+          const results = await pool.step([0, 0]);
+          const o = results[1].observation;
+          signatures.push([o.playerX, o.playerY, o.opponents[0].x, o.opponents[0].y]);
+        }
+        return signatures;
+      } finally {
+        await pool.close();
+      }
+    };
+
+    const first = await runOnce();
+    const second = await runOnce();
+    expect(first).toEqual(second);
+  });
+});

--- a/tests/unit/config-loader-env.test.ts
+++ b/tests/unit/config-loader-env.test.ts
@@ -11,7 +11,7 @@ describe('config-loader env vars and CLI', () => {
         'PORT', 'BIND_ADDRESS', 'MAX_RUNTIME', 'NUM_WORKERS', 'SEED',
         'DEFAULT_MAP_PATH', 'USE_SHARED_MEMORY', 'MANIFOLD_TELEMETRY',
         'MANIFOLD_TELEMETRY_OUTPUT', 'MANIFOLD_PROFILE', 'MANIFOLD_DEBUG',
-        'TEST_MODE',
+        'TEST_MODE', 'AI_PLAYER_ID',
         'RANDOM_OPP_MOVE_PROB', 'RANDOM_OPP_UP_PROB', 'RANDOM_OPP_DOWN_PROB',
         'RANDOM_OPP_HEAVY_PROB', 'RANDOM_OPP_GRAPPLE_PROB',
     ];
@@ -93,6 +93,30 @@ describe('config-loader env vars and CLI', () => {
             process.env.DEFAULT_MAP_PATH = 'maps/custom_map.json';
             const cfg = loadConfig(testDir);
             expect(cfg.environment.defaultMapPath).toBe('maps/custom_map.json');
+        });
+
+        it('AI_PLAYER_ID overrides the default AI player slot', () => {
+            process.env.AI_PLAYER_ID = '3';
+            const cfg = loadConfig(testDir);
+            expect(cfg.environment.aiPlayerId).toBe(3);
+        });
+
+        it('invalid AI_PLAYER_ID (negative) is ignored', () => {
+            process.env.AI_PLAYER_ID = '-1';
+            const cfg = loadConfig(testDir);
+            expect(cfg.environment.aiPlayerId).toBe(0);
+        });
+
+        it('invalid AI_PLAYER_ID (non-numeric) is ignored', () => {
+            process.env.AI_PLAYER_ID = 'abc';
+            const cfg = loadConfig(testDir);
+            expect(cfg.environment.aiPlayerId).toBe(0);
+        });
+
+        it('invalid AI_PLAYER_ID (out of the 0-7 player-slot range) is ignored', () => {
+            process.env.AI_PLAYER_ID = '9';
+            const cfg = loadConfig(testDir);
+            expect(cfg.environment.aiPlayerId).toBe(0);
         });
 
         it('RANDOM_OPP_MOVE_PROB overrides the opponent move probability', () => {
@@ -533,6 +557,31 @@ describe('config-loader env vars and CLI', () => {
             process.argv = ['node', 'script.js', '--map'];
             const cfg = loadConfig(testDir);
             expect(cfg.environment.defaultMapPath).toBe('maps/bonk_WDB__No_Mapshake__716916.json');
+        });
+
+        it('--ai-player-id sets the AI player slot', () => {
+            process.argv = ['node', 'script.js', '--ai-player-id', '2'];
+            const cfg = loadConfig(testDir);
+            expect(cfg.environment.aiPlayerId).toBe(2);
+        });
+
+        it('--ai-player-id rejects negative and out-of-range values', () => {
+            process.argv = ['node', 'script.js', '--ai-player-id', '-1'];
+            expect(loadConfig(testDir).environment.aiPlayerId).toBe(0);
+
+            resetConfig();
+            process.argv = ['node', 'script.js', '--ai-player-id', '8'];
+            expect(loadConfig(testDir).environment.aiPlayerId).toBe(0);
+
+            resetConfig();
+            process.argv = ['node', 'script.js', '--ai-player-id', 'abc'];
+            expect(loadConfig(testDir).environment.aiPlayerId).toBe(0);
+        });
+
+        it('missing value for --ai-player-id is ignored', () => {
+            process.argv = ['node', 'script.js', '--ai-player-id'];
+            const cfg = loadConfig(testDir);
+            expect(cfg.environment.aiPlayerId).toBe(0);
         });
 
         it('missing value for --profile is ignored', () => {


### PR DESCRIPTION
## Summary

Three constructor-wiring fixes in `src/core/environment.ts` for documented surfaces that were silently ignored.

Fixes #199, Fixes #200, Fixes #221.

## Changes

### 1. #199 — `--map` / `DEFAULT_MAP_PATH` / `environment.defaultMapPath` now reach the environment
`BonkEnvironment` loaded an absent `bonk_WDB__No_Mapshake__716916.json` and fell back to the box map, ignoring the documented map-path surface (tracker R2M8). The constructor now honors `config.defaultMapPath` (the key the config-loader resolves for `--map` / `DEFAULT_MAP_PATH` / `environment.defaultMapPath` and the worker forwards verbatim) alongside the programmatic `mapPath` override, and records the effective path.
- `src/core/environment.ts:96` (`defaultMapPath` config key)
- `src/core/environment.ts:186` (map loading chain)
- Regression test: `tests/integration/env-map-path.test.ts` loads `maps/bonk_Simple_1v1_123.json` via both keys and asserts the map body count and name.

### 2. #200 — seed 0 is deterministic in the constructor too
The constructor used `(config.seed && config.seed !== 0) ? config.seed : random`, so `--seed 0` / `SEED=0` / `environment.seed: 0` ran random while `reset(0)` / `pool.reset([0])` stayed deterministic. The constructor now forwards an explicit 0 to the PRNG exactly like `reset()`.
- `src/core/environment.ts:225` (seed resolution)
- Regression test: `tests/integration/env-seed-zero-constructor.test.ts` asserts two constructor-seeded-0 environments produce identical 60-step trajectories, and that the constructor path matches `reset(0)` seeding.

### 3. #221 — `environment.aiPlayerId` is no longer silently ignored
`BonkEnvironment` hardcoded player 0 as the RL agent. The AI slot is now config-driven (`config.aiPlayerId`, the `AI_PLAYER_ID` / `--ai-player-id` / `environment.aiPlayerId` surface): the agent observes/controls/rewards the configured slot, opponents occupy every other slot in `[0, numOpponents]`. Out-of-range or non-integer ids fail loudly.
- `src/core/environment.ts:110` (`aiPlayerId` config key)
- `src/core/environment.ts:255` (slot validation)
- `src/core/environment.ts:395` (spawn wiring)
- Regression test: `tests/integration/env-ai-player-id.test.ts` asserts aiPlayerId 1 observes player 1's state (blue spawn) while player 0 is the red-spawned opponent, inputs land on slot 1, and invalid ids throw.

## Validation
- `npm run typecheck`: 0 errors
- `npm test` (vitest): 66 files, 1313 passed / 19 skipped
- `git diff --check`: clean
- No changes under `.deobf/` or `docs/DEOBFUSCATION*`