### PR TITLE
feat(physics): P0–P1 map-physics fidelity (scale audit + fixture physics)

### DIFF
--- a/docs/PHYSICS_FIDELITY_PLAN.md
+++ b/docs/PHYSICS_FIDELITY_PLAN.md
@@ -1,7 +1,8 @@
 # Physics Fidelity Plan
 
 Make `bonk-rl-env`'s map physics simulation **faithful to bonk.io**, validated
-against the deobfuscation record (`docs/DEOBFUSCATION.md`, `docs/FIX_TRACKER.md`)
+against the deobfuscation record (`docs/DEOBFUSCATION.md`,
+`docs/DEOBFUSCATION_FIX_TRACKER.md`)
 and (where possible) differential comparison against recorded native-client state.
 
 ## Ground truth
@@ -45,7 +46,7 @@ no ground joints.
 | **P2** | Joint model | implement `rv` limits/motor, `d` fh/len, `lpj/lsj/p` prismatic params, gear `g`, ground joints | joint invariant tests per §33.7 formulas |
 | **P3** | Map physics settings | per-map `pq`→solver iters, `gd`→gravity override | engine-level tests: pq changes solver behavior; gd overrides |
 | **P4** | Differential validation | capture harness (record native snapshots) + replay comparator | comparator diff ≤ tolerance; fixture/joint exact-match gates |
-| **P5** | Docs + gating | update FIX_TRACKER with ✅/❌/partial per item; every claim cited | PR review gate |
+| **P5** | Docs + gating | update DEOBFUSCATION_FIX_TRACKER with ✅/❌/partial per item; every claim cited | PR review gate |
 
 ## Dependency order
 P0 → P1 → P4(capture harness) → P2 → P3 → P4(comparison) → P5.

--- a/docs/PHYSICS_FIDELITY_PLAN.md
+++ b/docs/PHYSICS_FIDELITY_PLAN.md
@@ -1,0 +1,53 @@
+# Physics Fidelity Plan
+
+Make `bonk-rl-env`'s map physics simulation **faithful to bonk.io**, validated
+against the deobfuscation record (`docs/DEOBFUSCATION.md`, `docs/FIX_TRACKER.md`)
+and (where possible) differential comparison against recorded native-client state.
+
+## Ground truth
+
+All facts below are cited to DEOBFUSCATION §33 (state/encoder/decoder), §34
+(render), §35 (player), §38 (fixtures). Facts are separated from assumptions.
+
+### Scale model (P0) — PROVEN, abstraction-only
+- `ppm` (default 12) is the **player-disc radius in game units** (lines 174, 637, 984), NOT a px→m conversion.
+- Native world = `map px / ppm`; the disc radius = `ppm × scaleRatio` (default scaleRatio 1 → 12 units).
+- Our engine uses a **shared divisor `SCALE=30`** for both map bodies (`def.x / this.scale`) and the disc (`ppm / this.scale`). Because both share one divisor, **proportions are exact on any scale** — the ppm-vs-SCALE mismatch is a *naming/abstraction* concern, not a behavioral error, as long as the divisor stays shared.
+- **Conclusion:** keep `SCALE` as the shared divisor; **pin the invariant with tests** rather than risk a refactor of the tuned, 267-test-passing engine. Document the abstraction clearly.
+
+### Fixtures (P1) — PROVEN, §33.4
+- `density = max(fix.de ?? body.s.de, 0.0001)` (clamped, line 3269).
+- `friction`: `fix.fr ?? body.s.fric`; **negative = velocity-independent** (line 3267).
+- `restitution`: `fix.re ?? body.s.re`.
+- `filter.categoryBits = 2^(f_c+1)` (line 3270).
+- `filter.maskBits`: starts at 65535, subtracts a bit per disabled group (lines 3271-3273). **Must agree with the engine's disc category bits** — a calibration item for Phase 4 differential validation.
+
+### Joints (P2) — PROVEN, §33.7/33.8
+Native `g` = `b2GearJointDef` on created `ja/jb` with `ratio = r` (7836-7843).
+`lpj`/`lsj`/`p` all use `b2PrismaticJointDef` with exact anchor/force
+normalization (`plen, pms ÷ ppm`, `mmf *= 17280`, `ms *= 12`,
+`fh=0? 0.0001 : 1/period`, Y-flip rv limits, ground `bodyB=-1` anchors use
+`+365/250` map-px). Engine today: only `distance/rv/lpj`; no `g`, no `lsj`, no `p`,
+no ground joints.
+
+### Map physics settings (P3) — PROVEN
+- `pq` → solver iterations: native low **2/6**, high **15/15** (lines 260, 634-635); engine currently a single fixed value.
+- `gd` → gravity direction/force override (line 213, 551, 780); default stays 20.
+- `re/nc/fl` gating.
+- Death circle = 850 map px from map center, ppm-independent (lines 1557-1563) — engine already correct.
+
+## Milestones
+
+| # | Scope | Deliverable | Verification |
+|---|-------|-------------|--------------|
+| **P0** | Scale/ppm model | Audit doc + shared-divisor invariant tests; no risky refactor | unit test: body & disc proportions exact across scale; spacing/radius invariants |
+| **P1** | Fixture fidelity | density clamp ≥0.0001, friction polarity, restitution fallback, mask-bit spec | fixture-level unit tests asserting exact numbers from §33.4 |
+| **P2** | Joint model | implement `rv` limits/motor, `d` fh/len, `lpj/lsj/p` prismatic params, gear `g`, ground joints | joint invariant tests per §33.7 formulas |
+| **P3** | Map physics settings | per-map `pq`→solver iters, `gd`→gravity override | engine-level tests: pq changes solver behavior; gd overrides |
+| **P4** | Differential validation | capture harness (record native snapshots) + replay comparator | comparator diff ≤ tolerance; fixture/joint exact-match gates |
+| **P5** | Docs + gating | update FIX_TRACKER with ✅/❌/partial per item; every claim cited | PR review gate |
+
+## Dependency order
+P0 → P1 → P4(capture harness) → P2 → P3 → P4(comparison) → P5.
+P4-capture must precede P2 so joint anchors are verified against real native
+state; P1 is independent and can proceed first.

--- a/src/core/map-adapter.ts
+++ b/src/core/map-adapter.ts
@@ -34,6 +34,7 @@ interface FlatBody {
     friction?: number;
     restitution?: number;
     density?: number;
+    fricp?: boolean;              // native compact key for f_p (friction polarity)
     fricPlayers?: boolean;
     collisionGroup?: number;
     collidesGroup1?: boolean;
@@ -141,6 +142,13 @@ function toBodyDef(body: FlatBody, index: number): any {
         noGrapple: body.noGrapple,
         innerGrapple: body.innerGrapple,
         friction: body.friction,
+        // Native `f_p` (fricp) selects velocity-independent negative friction.
+        fricPolarity: body.fricp ?? body.fricPlayers ?? false,
+        // Native `f_c` (collisionGroup) passthrough for map-data fidelity; the
+        // engine's filter is driven by the exported collidesGroupN booleans
+        // (see collides{} below), so f_c is retained as provenance, not read
+        // for behavior (P4 differential validation can calibrate exact bits).
+        collisionGroup: body.collisionGroup,
         // The exporter emits flat collidesGroupN booleans; the engine reads a
         // nested `collides: { g1, g2, g3, g4 }`. Convert here.
         collides: {

--- a/src/core/map-adapter.ts
+++ b/src/core/map-adapter.ts
@@ -35,7 +35,7 @@ interface FlatBody {
     restitution?: number;
     density?: number;
     fricp?: boolean;              // native compact key for f_p (friction polarity)
-    fricPlayers?: boolean;
+    fricPlayers?: boolean | number; // native enum f_p: 0=null, 1=false, 2=true
     collisionGroup?: number;
     collidesGroup1?: boolean;
     collidesGroup2?: boolean;
@@ -142,8 +142,12 @@ function toBodyDef(body: FlatBody, index: number): any {
         noGrapple: body.noGrapple,
         innerGrapple: body.innerGrapple,
         friction: body.friction,
-        // Native `f_p` (fricp) selects velocity-independent negative friction.
-        fricPolarity: body.fricp ?? body.fricPlayers ?? false,
+        // Native `f_p` selects velocity-independent negative friction (§33.4).
+        // `fricPlayers` is enum-typed in the exporter: 2=true (polarity on),
+        // 1=false, 0=null. Treat explicit `true` or enum 2 as polarity; the
+        // boolean `fricp` form is accepted too but is not an emitted key.
+        fricPolarity: body.fricPlayers === true || body.fricPlayers === 2
+            || body.fricp === true,
         // Native `f_c` (collisionGroup) passthrough for map-data fidelity; the
         // engine's filter is driven by the exported collidesGroupN booleans
         // (see collides{} below), so f_c is retained as provenance, not read

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -692,14 +692,23 @@ export class PhysicsEngine {
        shapeDef.vertexCount = maxVertices;
      }
 
-     // Native fixture density clamp (DEOBFUSCATION §33.4, line 3269): even a
-     // zero/NaN-authored dynamic density is raised to the 0.0001 floor so a
-     // dynamic body never ends up massless. Static bodies keep density 0 (static
-     // bodies contribute no mass in Box2D regardless of this value).
-     shapeDef.density = def.static ? 0 : Math.max(def.density ?? 1.0, 0.0001);
+     // Native fixture density clamp (DEOBFUSCATION §33.4, line 3269): a non-finite
+     // or sub-0.0001 authored dynamic density is raised to the 0.0001 floor so a
+     // dynamic body never ends up massless. `Math.max(NaN, ...)` is NaN, so guard
+     // non-finite values explicitly. Static bodies keep density 0 (static bodies
+     // contribute no mass in Box2D regardless of this value).
+     const authoredDensity = def.density;
+     const dynamicDensity = Number.isFinite(authoredDensity ?? NaN)
+       ? Math.max(authoredDensity!, 0.0001)
+       : 0.0001;
+     shapeDef.density = def.static ? 0 : dynamicDensity;
      // Native friction (DEOBFUSCATION §33.4): `fix.fr ?? body.s.fric`, and when
-     // `f_p` (fricPolarity) is truthy the signed friction is negative to select
-     // velocity-independent friction.
+     // `f_p` (fricPolarity) is set the signed friction is negative. The native
+     // client mixes friction via `b2MixFriction = sqrt(f1*f2)`, so a negative
+     // authored value drives the mix to NaN, which disables the solver's friction
+     // clamp ("velocity-independent friction"). This port reproduces the SIGN
+     // only; the actual sliding behavior depends on the solver MixFriction and
+     // is validated differentially in P4, not unit-tested here.
      shapeDef.friction = def.fricPolarity
        ? -(def.friction ?? 0.3)
        : (def.friction ?? 0.3);

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -185,6 +185,12 @@ export interface MapBodyDef {
   noGrapple?: boolean;           // When true, cannot be grappled
   innerGrapple?: boolean;        // When true, grappable from inside the shape (§32.1 gate); outside grappling is unaffected
   friction?: number;             // Surface friction coefficient
+  /** Native `f_p` (fricp): when true the friction is signed negative to select
+   *  velocity-independent friction (DEOBFUSCATION §33.4). */
+  fricPolarity?: boolean;
+  /** Native `f_c` collision-group passthrough (provenance only; the engine
+   *   filter is driven by `collides.gN`). */
+  collisionGroup?: number;
   collides?: {                   // Collision group filtering
     g1: boolean;
     g2: boolean;
@@ -686,8 +692,17 @@ export class PhysicsEngine {
        shapeDef.vertexCount = maxVertices;
      }
 
-     shapeDef.density = def.static ? 0 : (def.density ?? 1.0);
-     shapeDef.friction = def.friction ?? 0.3;
+     // Native fixture density clamp (DEOBFUSCATION §33.4, line 3269): even a
+     // zero/NaN-authored dynamic density is raised to the 0.0001 floor so a
+     // dynamic body never ends up massless. Static bodies keep density 0 (static
+     // bodies contribute no mass in Box2D regardless of this value).
+     shapeDef.density = def.static ? 0 : Math.max(def.density ?? 1.0, 0.0001);
+     // Native friction (DEOBFUSCATION §33.4): `fix.fr ?? body.s.fric`, and when
+     // `f_p` (fricPolarity) is truthy the signed friction is negative to select
+     // velocity-independent friction.
+     shapeDef.friction = def.fricPolarity
+       ? -(def.friction ?? 0.3)
+       : (def.friction ?? 0.3);
       const restitutionValue = def.restitution === -1 ? 0.8 : (def.restitution ?? 0.8);
      shapeDef.restitution = restitutionValue;
 

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -698,9 +698,18 @@ export class PhysicsEngine {
      // non-finite values explicitly. Static bodies keep density 0 (static bodies
      // contribute no mass in Box2D regardless of this value).
      const authoredDensity = def.density;
-     const dynamicDensity = Number.isFinite(authoredDensity ?? NaN)
-       ? Math.max(authoredDensity!, 0.0001)
-       : 0.0001;
+     let dynamicDensity: number;
+     if (authoredDensity === undefined) {
+       // No authored density: default to the native surface default 1.0.
+       // Do NOT floor to 0.0001 here.
+       dynamicDensity = 1.0;
+     } else if (Number.isFinite(authoredDensity)) {
+       // Finite authored value, clamped up to the 0.0001 floor (§33.4).
+       dynamicDensity = Math.max(authoredDensity, 0.0001);
+     } else {
+       // NaN/Infinity would poison mass; floor per the clamp guard.
+       dynamicDensity = 0.0001;
+     }
      shapeDef.density = def.static ? 0 : dynamicDensity;
      // Native friction (DEOBFUSCATION §33.4): `fix.fr ?? body.s.fric`, and when
      // `f_p` (fricPolarity) is set the signed friction is negative. The native

--- a/tests/integration/physics-fidelity-p0.test.ts
+++ b/tests/integration/physics-fidelity-p0.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { PhysicsEngine, SCALE } from '../../src/core/physics-engine';
+
+/**
+ * P0 — scale/ppm model invariant.
+ *
+ * The engine uses ONE shared divisor (`SCALE=30`) for both map bodies
+ * (`x / this.scale`) and the player disc (`ppm / this.scale`). As long as the
+ * divisor stays shared, body↔disc proportions are exact on any scale — which is
+ * the basis for the plan's conclusion that the deobfuscated "ppm vs SCALE" note
+ * is an abstraction/naming issue, not a behavior bug. These tests PIN that
+ * invariant via the engine's OBSERVABLE output (body world positions and player
+ * state in map px), avoiding Box2D-internal shape field names.
+ */
+describe('physics fidelity P0: shared-divisor scale invariant', () => {
+  it('exposes the documented shared SCALE=30 constant', () => {
+    expect(SCALE).toBe(30);
+  });
+
+  it('places a map body at its authored map-px position (x/SCALE world, x map out)', () => {
+    const e = new PhysicsEngine();
+    // Add a static platform 260 map px from the origin; its World position
+    // (world = px/SCALE) must be 260/30, and multiplying back by SCALE returns
+    // the authored 260 map px — confirming the shared px->world<->map round-trip.
+    e.addBody({ name: 'plat', type: 'rect', x: 260, y: -40, width: 40, height: 20, static: true } as any);
+    const plat = e.getBodyMap().get('plat') as any;
+    const pos = plat.GetPosition();
+    expect(pos.x * SCALE).toBeCloseTo(260, 3);
+    expect(pos.y * SCALE).toBeCloseTo(-40, 3);
+  });
+
+  it('a 260px box spans exactly 260 map px in world space', () => {
+    const e = new PhysicsEngine();
+    const halfWidth = 130;
+    e.addBody({ name: 'plat', type: 'rect', x: 0, y: 0, width: halfWidth * 2, height: 20, static: true } as any);
+    const plat = e.getBodyMap().get('plat') as any;
+    const shape = plat.GetShapeList();
+    // The box's world half-width is (130)/SCALE; its full width maps back to 260.
+    // We don't depend on the exact internal field — instead assert the body's
+    // half-width in world units is halfWidth/SCALE by checking a fixture vertex
+    // is at x = +halfWidth/SCALE in world coords (box2d stores box corners).
+    const v = shape.m_vertices ? shape.m_vertices[1] : shape.GetVertex(1);
+    expect(Math.abs(v.x) * SCALE).toBeCloseTo(halfWidth, 1);
+  });
+
+  it('reports player state in map px (scale cancelled via *SCALE round-trip)', () => {
+    const e = new PhysicsEngine();
+    e.addPlayer(0, 150, 250);
+    // addPlayer uses x/this.scale internally; getPlayerState must return map px.
+    const st = e.getPlayerState(0);
+    expect(typeof st.x).toBe('number');
+    expect(Number.isFinite(st.x)).toBe(true);
+    // The absolute position round-trips through SCALE (not through ppm = 12).
+    // A ppm-based (erroneous) model would place it at px/12*30 = 2.5x too far.
+    expect(Math.abs(st.x)).toBeGreaterThanOrEqual(0);
+    expect(st.y).toBeGreaterThanOrEqual(-10000); // just sanity: finite, not NaN
+  });
+});

--- a/tests/integration/physics-fidelity-p0.test.ts
+++ b/tests/integration/physics-fidelity-p0.test.ts
@@ -46,13 +46,13 @@ describe('physics fidelity P0: shared-divisor scale invariant', () => {
   it('reports player state in map px (scale cancelled via *SCALE round-trip)', () => {
     const e = new PhysicsEngine();
     e.addPlayer(0, 150, 250);
-    // addPlayer uses x/this.scale internally; getPlayerState must return map px.
+    // addPlayer uses x/this.scale internally; getPlayerState must return the
+    // authored map-px coordinate EXACTLY (SCALE round-trip), not a ppm-scaled
+    // value. A ppm-erroneous model placing the disc at px/ppm*SCALE would give
+    // 150/12*30 = 375 (2.5x), so asserting the exact 150 proves the shared
+    // SCALE divisor (not ppm) drives map<->world conversion.
     const st = e.getPlayerState(0);
-    expect(typeof st.x).toBe('number');
-    expect(Number.isFinite(st.x)).toBe(true);
-    // The absolute position round-trips through SCALE (not through ppm = 12).
-    // A ppm-based (erroneous) model would place it at px/12*30 = 2.5x too far.
-    expect(Math.abs(st.x)).toBeGreaterThanOrEqual(0);
-    expect(st.y).toBeGreaterThanOrEqual(-10000); // just sanity: finite, not NaN
+    expect(st.x).toBeCloseTo(150, 3);
+    expect(st.y).toBeCloseTo(250, 3);
   });
 });

--- a/tests/integration/physics-fidelity-p1.test.ts
+++ b/tests/integration/physics-fidelity-p1.test.ts
@@ -20,6 +20,15 @@ function fixtureOf(body: any): any {
 }
 
 describe('physics fidelity P1: fixture physics (DEOBFUSCATION §33.4)', () => {
+  it('keeps an unknown dynamic density at the native 1.0 default (not floored)', () => {
+    const e = makeEngine();
+    e.addBody({ name: 'undefined-density', type: 'rect', x: 400, y: 0, width: 40, height: 20, static: false } as any);
+    const shape = fixtureOf(e.getBodyMap().get('undefined-density')) as any;
+    // A body without an authored density must NOT fall to the 0.0001 floor
+    // (that would be a 10,000x mass reduction); it keeps the 1.0 default.
+    expect(shape.m_density).toBeCloseTo(1.0, 3);
+  });
+
   it('clamps dynamic density to the 0.0001 floor', () => {
     const e = makeEngine();
     e.addBody({ name: 'zero-density', type: 'rect', x: 0, y: 0, width: 40, height: 20, static: false, density: 0 } as any);

--- a/tests/integration/physics-fidelity-p1.test.ts
+++ b/tests/integration/physics-fidelity-p1.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { PhysicsEngine } from '../../src/core/physics-engine';
+
+/**
+ * P1 — Fixture-physics fidelity from DEOBFUSCATION §33.4.
+ *
+ * Assert exact native behaviors that are PROVEN in the deobfuscation record:
+ *   - density is clamped to a floor of 0.0001 for dynamic bodies (line 3269)
+ *   - `f_p` (fricPolarity) makes surface friction sign-negative (velocity-
+ *     independent friction) (line 3267)
+ *   - static bodies keep density 0 (no mass contribution)
+ */
+
+function makeEngine(): PhysicsEngine {
+  return new PhysicsEngine();
+}
+
+function fixtureOf(body: any): any {
+  return body.GetShapeList ? body.GetShapeList() : body.GetFixtureList().GetShape();
+}
+
+describe('physics fidelity P1: fixture physics (DEOBFUSCATION §33.4)', () => {
+  it('clamps dynamic density to the 0.0001 floor', () => {
+    const e = makeEngine();
+    e.addBody({ name: 'zero-density', type: 'rect', x: 0, y: 0, width: 40, height: 20, static: false, density: 0 } as any);
+    e.addBody({ name: 'neg-density', type: 'rect', x: 200, y: 0, width: 40, height: 20, static: false, density: -5 } as any);
+    const bm = e.getBodyMap();
+    expect((fixtureOf(bm.get('zero-density')) as any).m_density).toBe(0.0001);
+    expect((fixtureOf(bm.get('neg-density')) as any).m_density).toBe(0.0001);
+  });
+
+  it('keeps a normal positive density unclamped', () => {
+    const e = makeEngine();
+    e.addBody({ name: 'dyn', type: 'circle', x: 0, y: 0, radius: 5, static: false, density: 3 } as any);
+    const shape = fixtureOf(e.getBodyMap().get('dyn')) as any;
+    expect(shape.m_density).toBe(3);
+  });
+
+  it('keeps static bodies at density 0', () => {
+    const e = makeEngine();
+    e.addBody({ name: 'stat', type: 'rect', x: 0, y: 0, width: 40, height: 20, static: true, density: 2 } as any);
+    const shape = fixtureOf(e.getBodyMap().get('stat')) as any;
+    expect(shape.m_density).toBe(0);
+  });
+
+  it('negates friction when f_p (fricPolarity) is set', () => {
+    const e = makeEngine();
+    e.addBody({ name: 'polar', type: 'rect', x: 0, y: 0, width: 40, height: 20, static: true, friction: 0.3, fricPolarity: true } as any);
+    e.addBody({ name: 'normal', type: 'rect', x: 200, y: 0, width: 40, height: 20, static: true, friction: 0.3, fricPolarity: false } as any);
+    const polarShape = fixtureOf(e.getBodyMap().get('polar')) as any;
+    const normalShape = fixtureOf(e.getBodyMap().get('normal')) as any;
+    expect(polarShape.m_friction).toBeCloseTo(-0.3);
+    expect(normalShape.m_friction).toBeCloseTo(0.3);
+  });
+
+  it('defaults friction to the native surface default when unset', () => {
+    const e = makeEngine();
+    e.addBody({ name: 'def', type: 'rect', x: 0, y: 0, width: 40, height: 20, static: true } as any);
+    const shape = fixtureOf(e.getBodyMap().get('def')) as any;
+    expect(shape.m_friction).toBeCloseTo(0.3);
+  });
+});
+
+/**
+ * P1b — collision-filter semantics (§33.4). The engine's mask is built from the
+ * exported collidesGroupN booleans (map category 0x0001 + player group bits),
+ * which is the internal representation of the native "start full, subtract per
+ * disabled group" rule. These tests pin that behavior so a refactor cannot
+ * silently change map/player collision.
+ */
+describe('physics fidelity P1b: collision filters (DEOBFUSCATION §33.4)', () => {
+  it('all groups true -> map category 0x0001 + all group bits in mask', () => {
+    const e = makeEngine();
+    e.addBody({ name: 'solid', type: 'rect', x: 0, y: 0, width: 40, height: 20, static: true, collides: { g1: true, g2: true, g3: true, g4: true } } as any);
+    const filter = (fixtureOf(e.getBodyMap().get('solid')) as any).GetFilterData();
+    expect(filter.categoryBits).toBe(0x0001);
+    expect(filter.maskBits).toBe(0x0001 | 0x0002 | 0x0004 | 0x0008 | 0x0010);
+  });
+
+  it('all groups false (ghost) -> mask 0 (legacy visual geometry)', () => {
+    const e = makeEngine();
+    e.addBody({ name: 'ghost', type: 'rect', x: 0, y: 0, width: 40, height: 20, static: true, collides: { g1: false, g2: false, g3: false, g4: false } } as any);
+    const filter = (fixtureOf(e.getBodyMap().get('ghost')) as any).GetFilterData();
+    expect(filter.categoryBits).toBe(0x0001);
+    expect(filter.maskBits).toBe(0x0000);
+  });
+
+  it('partial groups -> only the enabled group bits are added', () => {
+    const e = makeEngine();
+    e.addBody({ name: 'g1', type: 'rect', x: 0, y: 0, width: 40, height: 20, static: true, collides: { g1: true, g2: false, g3: false, g4: false } } as any);
+    const filter = (fixtureOf(e.getBodyMap().get('g1')) as any).GetFilterData();
+    expect(filter.maskBits).toBe(0x0001 | 0x0002);
+  });
+});

--- a/tests/integration/physics-fidelity-p1.test.ts
+++ b/tests/integration/physics-fidelity-p1.test.ts
@@ -63,10 +63,13 @@ describe('physics fidelity P1: fixture physics (DEOBFUSCATION §33.4)', () => {
 
 /**
  * P1b — collision-filter semantics (§33.4). The engine's mask is built from the
- * exported collidesGroupN booleans (map category 0x0001 + player group bits),
- * which is the internal representation of the native "start full, subtract per
- * disabled group" rule. These tests pin that behavior so a refactor cannot
- * silently change map/player collision.
+ * exported collidesGroupN booleans (map category 0x0001 + player group bits).
+ * This is the engine's internal representation of the native "start full,
+ * subtract per disabled group" rule — it is NOT claimed to be native-exact
+ * (the native encoding is `categoryBits = 2^(f_c+1)` and a 65535-minus mask;
+ * exact bit parity is deferred to P4 differential validation). These tests pin
+ * the ENGINE's invariant so a refactor cannot silently change map/player
+ * collision.
  */
 describe('physics fidelity P1b: collision filters (DEOBFUSCATION §33.4)', () => {
   it('all groups true -> map category 0x0001 + all group bits in mask', () => {


### PR DESCRIPTION
## Summary

First two milestones of the **map-physics fidelity** plan (`docs/PHYSICS_FIDELITY_PLAN.md`), grounded in the `DEOBFUSCATION` record. Delivers P0 (scale-model audit) and P1 (fixture physics), each verified by tests.

## P0 — Scale/ppm model audit

The deobfuscation record (DEOBFUSCATION §637, §984) notes `ppm` (default 12) is the **player-disc radius**, not a px→m conversion. Audit conclusion: our engine uses a **shared `SCALE=30` divisor** for both map bodies (`x / this.scale`) and the disc (`ppm / this.scale`), so **proportions are exact on any scale** — the ppm-vs-SCALE point is an abstraction/naming issue, not a behavior bug. Documented in the plan; **no risky refactor** of the tuned, 267-test engine.

## P1 — Fixture physics fidelity (DEOBFUSCATION §33.4)

- **Density clamp**: dynamic bodies use `max(density, 0.0001)` (native floor, line 3269); static stays 0.
- **Friction polarity**: `f_p`/`fricPlayers`/`fricp` → velocity-independent **negative** friction (line 3267). Added `MapBodyDef.fricPolarity`; adapter forwards it.
- **Collision filters**: pinned by invariant tests — map category `0x0001` + per-group bits from `collides.gN`; all-false ghost → mask `0x0000` (internal form of the native "start full, subtract per disabled group" rule).
- **`collisionGroup` (`f_c`)** forwarded as provenance passthrough for map-data fidelity.

## Validation

- New `tests/integration/physics-fidelity-p1.test.ts` — 8 tests asserting exact density-clamp, friction-polarity, and mask-bit behavior.
- Existing map + render suites still green (87 combined).
- `npx tsc --noEmit` → exit 0.
- `git diff --check` clean.

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update

## Pre-flight Checklist

- [X] Typecheck passes
- [X] New F1 tests + existing map/render suites pass
- [X] Fidelity plan documented
- [X] Scope limited to the P0–P1 slice (adapter, engine, test, docs)