### PR TITLE
feat(physics): P2 native joint model (rv/d/lpj/lsj/p/gear g + ground)

### DIFF
--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -439,7 +439,15 @@ export class BonkEnvironment {
         if ((mapDef as any).joints && (mapDef as any).joints.length > 0) {
             const bodyMap = (this.physics as any).getBodyMap?.();
             if (bodyMap) {
+                // Create non-gear joints FIRST so gear referents (which the
+                // engine resolves from the created-joint map) always exist,
+                // regardless of the joint array order.
+                const gearJoints: any[] = [];
                 for (const j of (mapDef as any).joints) {
+                    if (j.type === 'g' || j.type === 'gear') gearJoints.push(j);
+                    else (this.physics as any).addJoint(j, bodyMap);
+                }
+                for (const j of gearJoints) {
                     (this.physics as any).addJoint(j, bodyMap);
                 }
             }
@@ -510,7 +518,12 @@ export class BonkEnvironment {
         if ((this.config.mapData as any).joints && (this.config.mapData as any).joints.length > 0) {
             const bodyMap = (this.physics as any).getBodyMap?.();
             if (bodyMap) {
+                const gearJoints: any[] = [];
                 for (const j of (this.config.mapData as any).joints) {
+                    if (j.type === 'g' || j.type === 'gear') gearJoints.push(j);
+                    else (this.physics as any).addJoint(j, bodyMap);
+                }
+                for (const j of gearJoints) {
                     (this.physics as any).addJoint(j, bodyMap);
                 }
             }

--- a/src/core/map-adapter.ts
+++ b/src/core/map-adapter.ts
@@ -89,6 +89,8 @@ interface FlatJoint {
     data?: Record<string, unknown>;
     // Native per-type fields (§33.8) surfaced flattened by the exporter:
     angle?: number;
+    axis?: { x: number; y: number };       // prismatic local axis
+    referenceAngle?: number;               // prismatic reference angle
     lowerTranslation?: number;
     upperTranslation?: number;
     lowerLimit?: number;
@@ -311,13 +313,15 @@ export function normalizeMap(raw: unknown): MapDef {
             // reference `physicsJoints` by index) resolve consistently.
             name: `joint_${jointIdx}`,
             bodyA: bodyA ?? '',
-            bodyB: bodyB ?? (isGround ? '' : ''),
+            bodyB: bodyB ?? '',
             isGround,
             anchorA: j.anchorA,
             anchorB: j.anchorB,
             collideConnected: j.collideConnected ?? j.data?.cc ?? false,
             // Native per-type fields (§33.8) forwarded for exact construction:
             angle: j.angle,
+            axis: j.axis,                          // prismatic local axis
+            referenceAngle: j.referenceAngle,       // prismatic reference angle
             lowerTranslation: j.lowerTranslation,
             upperTranslation: j.upperTranslation,
             lowerLimit: j.lowerLimit,
@@ -340,7 +344,7 @@ export function normalizeMap(raw: unknown): MapDef {
             if (jb !== undefined && src[jb]) out.jointB = `joint_${jb}`;
         }
         return out;
-    }).filter((j): j is NonNullable<typeof j> => j !== null && !!j.bodyA);
+    });
 
     const ph = map.physics || {};
     const bounds = {

--- a/src/core/map-adapter.ts
+++ b/src/core/map-adapter.ts
@@ -87,6 +87,21 @@ interface FlatJoint {
     dampingRatio?: number;
     collideConnected?: boolean;
     data?: Record<string, unknown>;
+    // Native per-type fields (§33.8) surfaced flattened by the exporter:
+    angle?: number;
+    lowerTranslation?: number;
+    upperTranslation?: number;
+    lowerLimit?: number;
+    upperLimit?: number;
+    maxMotorForce?: number;
+    maxMotorTorque?: number;
+    motorSpeed?: number;
+    enableMotor?: boolean;
+    enableLimit?: boolean;
+    // Gear (g):
+    ja?: number;
+    jb?: number;
+    ratio?: number;
 }
 
 interface ExportedMap {
@@ -275,39 +290,57 @@ export function normalizeMap(raw: unknown): MapDef {
     flatSource.forEach((b, i) => {
         if (b) bodiesByName.set(b.bodyIndex ?? i, bodies[i]?.name ?? b.name ?? `body_${i}`);
     });
-    const joints = (map.physicsJoints || []).map(j => {
+    const joints = (map.physicsJoints || []).map((j, jointIdx) => {
         // bodyA must be a valid, non-negative body index; an out-of-range or
         // negative bodyA is a malformed reference and cannot resolve.
         const bodyA = j.bodyA !== undefined && j.bodyA >= 0
             ? bodiesByName.get(j.bodyA)
             : undefined;
-        // bodyB: -1 means the joint is anchored to the ground (world), which
-        // the engine's addJoint cannot represent (it requires two named bodies).
+        // bodyB: -1 means the joint is anchored to the ground (world). Forward
+        // it as a ground joint (empty bodyB) rather than dropping it — P2
+        // supports ground-anchored joints via a synthetic static ground body.
         const isGround = j.bodyB !== undefined && j.bodyB < 0;
         const bodyB = j.bodyB !== undefined && j.bodyB >= 0
             ? bodiesByName.get(j.bodyB)
             : undefined;
-        if (isGround) {
-            // Ground-anchored joints are unsupported by the engine's joint model;
-            // surface them loudly instead of silently dropping them (#review).
-            const bodyAName = bodyA ?? (j.bodyA !== undefined ? `body#${j.bodyA}` : '?');
-            console.warn(`[map-adapter] Skipping ground-anchored ${j.type ?? 'joint'} (bodyA=${bodyAName}, bodyB=ground): the engine has no ground-joint support`);
-            return null;
-        }
-        const safeType = (t: string | undefined): 'rv' | 'distance' | 'lpj' | string =>
+        const safeType = (t: string | undefined): string =>
             t === undefined ? 'rv' : t;
         const out: Record<string, unknown> = {
             type: safeType(j.type),
+            // Joints are named by their array position so gear referents (which
+            // reference `physicsJoints` by index) resolve consistently.
+            name: `joint_${jointIdx}`,
             bodyA: bodyA ?? '',
-            bodyB: bodyB ?? '',
+            bodyB: bodyB ?? (isGround ? '' : ''),
+            isGround,
             anchorA: j.anchorA,
             anchorB: j.anchorB,
-            collideConnected: j.collideConnected ?? false,
+            collideConnected: j.collideConnected ?? j.data?.cc ?? false,
+            // Native per-type fields (§33.8) forwarded for exact construction:
+            angle: j.angle,
+            lowerTranslation: j.lowerTranslation,
+            upperTranslation: j.upperTranslation,
+            lowerLimit: j.lowerLimit,
+            upperLimit: j.upperLimit,
+            maxMotorForce: j.maxMotorForce,
+            maxMotorTorque: j.maxMotorTorque,
+            motorSpeed: j.motorSpeed,
+            enableMotor: j.enableMotor,
+            enableLimit: j.enableLimit,
+            length: j.length,
+            rayCast: (j as any).rayCast,
         };
-        if (j.frequencyHz !== undefined) out.frequencyHz = j.frequencyHz;
-        if (j.dampingRatio !== undefined) out.dampingRatio = j.dampingRatio;
+        // Gear (g) referents: ja/jb index into the SAME joints array.
+        if (j.type === 'g' || safeType(j.type) === 'g') {
+            out.ratio = j.ratio ?? 1;
+            const src = map.physicsJoints || [];
+            const ja = (j as any).ja !== undefined ? (j as any).ja : undefined;
+            const jb = (j as any).jb !== undefined ? (j as any).jb : undefined;
+            if (ja !== undefined && src[ja]) out.jointA = `joint_${ja}`;
+            if (jb !== undefined && src[jb]) out.jointB = `joint_${jb}`;
+        }
         return out;
-    }).filter((j): j is NonNullable<typeof j> => j !== null);
+    }).filter((j): j is NonNullable<typeof j> => j !== null && !!j.bodyA);
 
     const ph = map.physics || {};
     const bounds = {

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -989,7 +989,10 @@ export class PhysicsEngine {
 
   /** Lazily create the shared static ground body (b2Body with no fixtures). */
   private ensureGroundBody(): any {
-    if (!this.groundBody || this.groundBody.m_world === null) {
+    // Invariant: `groundBody` only ever points at a body in the CURRENT world.
+    // We null it in reset() (and guard here) so a stale body from a destroyed
+    // world can never be reused across episodes.
+    if (!this.groundBody || this.groundBody.m_world === null || this.groundBody.m_world !== this.world) {
       const bd = new b2BodyDef();
       this.groundBody = this.world.CreateBody(bd);
     }
@@ -998,39 +1001,60 @@ export class PhysicsEngine {
 
   addJoint(def: Record<string, any>, bodyMap: Map<string, any>): void {
     const bodyA = bodyMap.get(def.bodyA);
-    const isGround = def.isGround === true || def.bodyB === '' || def.bodyB === null || def.bodyB === undefined;
-    const ground = isGround ? this.ensureGroundBody() : null;
-    const bodyB = ground ?? bodyMap.get(def.bodyB);
-    if (!bodyA || !bodyB) {
-      console.warn(`Joint references unknown body: ${def.bodyA} or ${def.bodyB}`);
+    // A joint is ground-anchored ONLY when explicitly marked `isGround` (the
+    // adapter sets it for bodyB = -1). `bodyB` being empty/undefined for any
+    // OTHER reason is a malformed reference and must warn+skip, NOT silently
+    // become a ground joint.
+    const isGround = def.isGround === true;
+    let bodyB: any = null;
+    if (isGround) {
+      bodyB = this.ensureGroundBody();
+    } else {
+      bodyB = bodyMap.get(def.bodyB);
+      if (!bodyB) {
+        console.warn(`Joint references unknown body "${def.bodyB}" (bodyA="${def.bodyA}")`);
+        return;
+      }
+    }
+    if (!bodyA) {
+      console.warn(`Joint references unknown body "${def.bodyA}" — skipping joint`);
       return;
     }
 
     const cd = def.collideConnected ?? false;
-    const makeAnchor = (a?: { x: number; y: number }) =>
+    const makeAnchorA = (a?: { x: number; y: number }) =>
       a ? new b2Vec2(a.x / this.scale, a.y / this.scale) : (bodyA.GetPosition().Copy());
+    const makeAnchorB = (a?: { x: number; y: number }, b?: any) =>
+      a ? new b2Vec2(a.x / this.scale, a.y / this.scale) : (b.GetPosition().Copy());
 
     const type = def.type;
     let created: any = null;
     if (type === 'distance' || type === 'd') {
       const jd = new b2DistanceJointDef();
       // Ground anchors use native map-px coords (ab += [365/ppm, 250/ppm]).
-      const a = makeAnchor(def.anchorA);
-      const b = ground
+      const a = makeAnchorA(def.anchorA);
+      const b = isGround
         ? new b2Vec2((def.anchorB?.x ?? 0) / this.scale, (def.anchorB?.y ?? 0) / this.scale)
-        : makeAnchor(def.anchorB);
+        : makeAnchorB(def.anchorB, bodyB);
       jd.Initialize(bodyA, bodyB, a, b);
+      // apply an explicit authored length after Initialize (Initialize sets
+      // length from the anchor distance) (§33.7 d: len→0.01-floor).
+      if (typeof def.length === 'number' && Number.isFinite(def.length)) {
+        jd.length = def.length / this.scale;
+      }
       jd.collideConnected = cd;
       jd.frequencyHz = def.frequencyHz ?? 0;
       jd.dampingRatio = def.dampingRatio ?? 0;
       created = this.world.CreateJoint(jd);
     } else if (type === 'rv' || type === 'revolute') {
       const jd = new b2RevoluteJointDef();
-      jd.Initialize(bodyA, bodyB, makeAnchor(def.anchorA));
+      jd.Initialize(bodyA, bodyB, makeAnchorA(def.anchorA));
       jd.collideConnected = cd;
       jd.enableLimit = !!def.enableLimit;
-      jd.lowerAngle = def.lowerAngle ?? 0;
-      jd.upperAngle = def.upperAngle ?? 0;
+      // Adapter forwards the exporter's lower/upperLimit (which map to the
+      // revolute lower/upper ANGLE).
+      jd.lowerAngle = def.lowerAngle ?? def.lowerLimit ?? 0;
+      jd.upperAngle = def.upperAngle ?? def.upperLimit ?? 0;
       jd.enableMotor = !!def.enableMotor;
       jd.motorSpeed = def.motorSpeed ?? 0;
       jd.maxMotorTorque = def.maxMotorTorque ?? 0;
@@ -1038,7 +1062,7 @@ export class PhysicsEngine {
     } else if (type === 'lpj' || type === 'lsj' || type === 'p' || type === 'prismatic') {
       const jd = new b2PrismaticJointDef();
       const axis = def.axis ? new b2Vec2(def.axis.x, def.axis.y) : new b2Vec2(1, 0);
-      jd.Initialize(bodyA, bodyB, makeAnchor(def.anchorA), axis);
+      jd.Initialize(bodyA, bodyB, makeAnchorA(def.anchorA), axis);
       jd.collideConnected = cd;
       if (def.referenceAngle !== undefined) jd.referenceAngle = def.referenceAngle;
       jd.enableLimit = !!def.enableLimit;
@@ -1056,6 +1080,17 @@ export class PhysicsEngine {
         return;
       }
       const gd = new b2GearJointDef();
+      // b2GearJoint computes coordinate1/coordinate2 from the referent type;
+      // a distance (or other) referent leaves coordinate undefined and the
+      // constant NaN — a silently broken joint. Validate the referents are
+      // revolute or prismatic before constructing (§33.8 g).
+      const gearOk = (j: any): boolean =>
+        j.m_type === box2d.b2Joint.e_revoluteJoint || j.m_type === box2d.b2Joint.e_prismaticJoint;
+      if (!gearOk(j1) || !gearOk(j2)) {
+        console.warn(
+          `Gear joint referents must be revolute or prismatic (${def.jointA}:${j1.m_type}, ${def.jointB}:${j2.m_type}) — skipping joint`);
+        return;
+      }
       gd.joint1 = j1;
       gd.joint2 = j2;
       gd.ratio = def.ratio ?? 1;
@@ -1660,6 +1695,11 @@ export class PhysicsEngine {
     // re-applies setAiPlayerId() before spawning players each episode.
     this.aiSlot = 0;
     this.capZoneSensors = [];
+    // Joint state belongs to the old world: drop the ground body and the
+    // created-joint map so a fresh episode cannot reuse a stale ground body
+    // (ensureGroundBody also guards on this.world) or stale gear referents.
+    this.groundBody = null;
+    this.createdJoints.clear();
     this.capZoneState.clear();
     this.capZoneTouches = [];
     this.lastScoredTeam = null;

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -28,6 +28,7 @@ const {
   b2DistanceJointDef,
   b2RevoluteJointDef,
   b2PrismaticJointDef,
+  b2GearJointDef,
   b2ContactListener,
   b2FilterData,
 } = box2d;
@@ -215,7 +216,24 @@ export interface MapDef {
   spawnPoints: MapSpawnPoints;
   bodies: MapBodyDef[];
   capZones?: Array<{ index: number; owner: string; type: number; fixture: string; shapeType: string; l?: number }>;
-  joints?: Array<{ type: string; bodyA: string; bodyB: string; anchorA?: { x: number; y: number }; anchorB?: { x: number; y: number }; localAnchorA?: { x: number; y: number }; localAnchorB?: { x: number; y: number }; length?: number; frequencyHz?: number; dampingRatio?: number; collideConnected?: boolean }>;
+  joints?: Array<{
+    type: string; bodyA: string; bodyB: string;
+    anchorA?: { x: number; y: number }; anchorB?: { x: number; y: number };
+    localAnchorA?: { x: number; y: number }; localAnchorB?: { x: number; y: number };
+    length?: number; frequencyHz?: number; dampingRatio?: number; collideConnected?: boolean;
+    // Native joint fields (§33.8) forwarded for exact construction:
+    enableLimit?: boolean; lowerAngle?: number; upperAngle?: number;
+    enableMotor?: boolean; motorSpeed?: number; maxMotorTorque?: number; maxMotorForce?: number;
+    lowerTranslation?: number; upperTranslation?: number;
+    axis?: { x: number; y: number };
+    // Native indices: bodyA/bodyB are already resolved to names by the adapter,
+    // bodyB === '' (or bodyB === GROUND_BODY_NAME) means the joint is ground-anchored.
+    ratio?: number;               // gear (g) joint ratio
+    jointA?: string; jointB?: string;  // gear referent joint names
+    referenceAngle?: number;      // prismatic reference angle
+    // ground: when bodyB is the synthetic ground body
+    isGround?: boolean;
+  }>;
   physics?: {
     ppm?: number;
     bounds?: { width: number; height: number };
@@ -966,42 +984,96 @@ export class PhysicsEngine {
    * Add a joint between two named bodies from the map definition.
    * Looks up bodies by name in the platformBodyMap.
    */
-  addJoint(def: { type: string; bodyA: string; bodyB: string; anchorA?: { x: number; y: number }; anchorB?: { x: number; y: number }; frequencyHz?: number; dampingRatio?: number; collideConnected?: boolean }, bodyMap: Map<string, any>): void {
+  /** Synthetic static body used as the "ground" for ground-anchored joints. */
+  private groundBody: any = null;
+
+  /** Lazily create the shared static ground body (b2Body with no fixtures). */
+  private ensureGroundBody(): any {
+    if (!this.groundBody || this.groundBody.m_world === null) {
+      const bd = new b2BodyDef();
+      this.groundBody = this.world.CreateBody(bd);
+    }
+    return this.groundBody;
+  }
+
+  addJoint(def: Record<string, any>, bodyMap: Map<string, any>): void {
     const bodyA = bodyMap.get(def.bodyA);
-    const bodyB = bodyMap.get(def.bodyB);
+    const isGround = def.isGround === true || def.bodyB === '' || def.bodyB === null || def.bodyB === undefined;
+    const ground = isGround ? this.ensureGroundBody() : null;
+    const bodyB = ground ?? bodyMap.get(def.bodyB);
     if (!bodyA || !bodyB) {
       console.warn(`Joint references unknown body: ${def.bodyA} or ${def.bodyB}`);
       return;
     }
-    
-    const anchorA = def.anchorA
-      ? new b2Vec2(def.anchorA.x / this.scale, def.anchorA.y / this.scale)
-      : bodyA.GetPosition();
-    const anchorB = def.anchorB
-      ? new b2Vec2(def.anchorB.x / this.scale, def.anchorB.y / this.scale)
-      : bodyB.GetPosition();
-    
-    if (def.type === 'distance') {
+
+    const cd = def.collideConnected ?? false;
+    const makeAnchor = (a?: { x: number; y: number }) =>
+      a ? new b2Vec2(a.x / this.scale, a.y / this.scale) : (bodyA.GetPosition().Copy());
+
+    const type = def.type;
+    let created: any = null;
+    if (type === 'distance' || type === 'd') {
       const jd = new b2DistanceJointDef();
-      jd.Initialize(bodyA, bodyB, anchorA, anchorB);
-      jd.collideConnected = def.collideConnected ?? false;
+      // Ground anchors use native map-px coords (ab += [365/ppm, 250/ppm]).
+      const a = makeAnchor(def.anchorA);
+      const b = ground
+        ? new b2Vec2((def.anchorB?.x ?? 0) / this.scale, (def.anchorB?.y ?? 0) / this.scale)
+        : makeAnchor(def.anchorB);
+      jd.Initialize(bodyA, bodyB, a, b);
+      jd.collideConnected = cd;
       jd.frequencyHz = def.frequencyHz ?? 0;
       jd.dampingRatio = def.dampingRatio ?? 0;
-      this.world.CreateJoint(jd);
-    } else if (def.type === 'rv') {
+      created = this.world.CreateJoint(jd);
+    } else if (type === 'rv' || type === 'revolute') {
       const jd = new b2RevoluteJointDef();
-      jd.Initialize(bodyA, bodyB, anchorA);
-      jd.collideConnected = def.collideConnected ?? false;
-      this.world.CreateJoint(jd);
-    } else if (def.type === 'lpj') {
+      jd.Initialize(bodyA, bodyB, makeAnchor(def.anchorA));
+      jd.collideConnected = cd;
+      jd.enableLimit = !!def.enableLimit;
+      jd.lowerAngle = def.lowerAngle ?? 0;
+      jd.upperAngle = def.upperAngle ?? 0;
+      jd.enableMotor = !!def.enableMotor;
+      jd.motorSpeed = def.motorSpeed ?? 0;
+      jd.maxMotorTorque = def.maxMotorTorque ?? 0;
+      created = this.world.CreateJoint(jd);
+    } else if (type === 'lpj' || type === 'lsj' || type === 'p' || type === 'prismatic') {
       const jd = new b2PrismaticJointDef();
-      const axisDef = (def as any).axis;
-      const axisVec = axisDef ? new b2Vec2(axisDef.x, axisDef.y) : new b2Vec2(1, 0);
-      jd.Initialize(bodyA, bodyB, anchorA, axisVec);
-      jd.collideConnected = def.collideConnected ?? false;
-      this.world.CreateJoint(jd);
+      const axis = def.axis ? new b2Vec2(def.axis.x, def.axis.y) : new b2Vec2(1, 0);
+      jd.Initialize(bodyA, bodyB, makeAnchor(def.anchorA), axis);
+      jd.collideConnected = cd;
+      if (def.referenceAngle !== undefined) jd.referenceAngle = def.referenceAngle;
+      jd.enableLimit = !!def.enableLimit;
+      jd.lowerTranslation = def.lowerTranslation ?? 0;
+      jd.upperTranslation = def.upperTranslation ?? 0;
+      jd.enableMotor = !!def.enableMotor;
+      jd.motorSpeed = def.motorSpeed ?? 0;
+      jd.maxMotorForce = def.maxMotorForce ?? 0;
+      created = this.world.CreateJoint(jd);
+    } else if (type === 'g' || type === 'gear') {
+      const j1 = def.jointA ? (this.createdJoints.get(def.jointA) ?? null) : null;
+      const j2 = def.jointB ? (this.createdJoints.get(def.jointB) ?? null) : null;
+      if (!j1 || !j2) {
+        console.warn(`Gear joint references missing referent joints: ${def.jointA}, ${def.jointB}`);
+        return;
+      }
+      const gd = new b2GearJointDef();
+      gd.joint1 = j1;
+      gd.joint2 = j2;
+      gd.ratio = def.ratio ?? 1;
+      gd.bodyA = bodyA;
+      gd.bodyB = bodyB;
+      created = this.world.CreateJoint(gd);
+    } else {
+      console.warn(`Unknown joint type: ${type}`);
+    }
+
+    // Register the created joint by name for gear (g) referent resolution.
+    if (created && def.name) {
+      this.createdJoints.set(def.name, created);
     }
   }
+
+  /** Map of created joints by name for gear (g) referent resolution. */
+  private createdJoints: Map<string, any> = new Map();
 
   /**
    * Add a dynamic circular player body.

--- a/tests/integration/physics-fidelity-p2.test.ts
+++ b/tests/integration/physics-fidelity-p2.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { PhysicsEngine } from '../../src/core/physics-engine';
+import { normalizeMap } from '../../src/core/map-adapter';
 
 /**
  * P2 — Native joint-model fidelity (DEOBFUSCATION §33.8).
@@ -83,5 +84,102 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
     const yMapPx = after.y * 30;
     expect(Math.abs(yMapPx - 150)).toBeLessThan(5);
     expect(Number.isFinite(after.x)).toBe(true);
+  });
+
+  it('constructs a gear (g) joint over two revolute referents with the authored ratio', () => {
+    const e = makeEngine();
+    const bm = makeBodyMap(e);
+    const warnings = captureWarn(() => {
+      e.addJoint({ type: 'rv', name: 'r1', bodyA: 'plat_0', bodyB: 'cart_0', anchorA: { x: 0, y: 100 }, enableLimit: false, collideConnected: false }, bm);
+      e.addJoint({ type: 'rv', name: 'r2', bodyA: 'plat_1', bodyB: 'cart_1', anchorA: { x: 100, y: 100 }, enableLimit: false, collideConnected: false }, bm);
+      e.addJoint({ type: 'g', name: 'g0', bodyA: 'plat_0', bodyB: 'cart_0', jointA: 'r1', jointB: 'r2', ratio: 2, collideConnected: false }, bm);
+    });
+    expect(warnings).toHaveLength(0);
+    const gear = (e as any).createdJoints.get('g0');
+    expect(gear).toBeTruthy();
+    expect(gear.m_type).toBe(6); // b2Joint.e_gearJoint
+    expect(gear.m_ratio).toBe(2);
+  });
+
+  it('warns and skips a gear joint whose referent is a distance joint (not revolute/prismatic)', () => {
+    const e = makeEngine();
+    const bm = makeBodyMap(e);
+    const warnings = captureWarn(() => {
+      e.addJoint({ type: 'rv', name: 'r1', bodyA: 'plat_0', bodyB: 'cart_0', anchorA: { x: 0, y: 100 }, enableLimit: false, collideConnected: false }, bm);
+      e.addJoint({ type: 'd', name: 'd1', bodyA: 'plat_0', bodyB: 'cart_0', anchorA: { x: 0, y: 100 }, anchorB: { x: 0, y: 140 }, collideConnected: false }, bm);
+      e.addJoint({ type: 'g', name: 'bad_gear', bodyA: 'plat_0', bodyB: 'cart_0', jointA: 'r1', jointB: 'd1', ratio: 1, collideConnected: false }, bm);
+    });
+    // The distance referent must be rejected BEFORE b2GearJoint construction
+    // (the port would otherwise throw on GetJointTranslation).
+    expect(warnings.some(w => /revolute or prismatic/.test(w))).toBe(true);
+    expect((e as any).createdJoints.has('bad_gear')).toBe(false);
+  });
+
+  it('forwards revolute limits, prismatic axis/referenceAngle, and distance length through normalizeMap', () => {
+    const e = makeEngine();
+    // Real exported-bonk format: bodies referenced by index, joints by type
+    // with the flattened native field names the exporter emits (§33.8).
+    const md = normalizeMap({
+      bodies: [
+        { bodyIndex: 0, name: 'wall', type: 'rect', x: 0, y: 0, width: 40, height: 10, static: true },
+        { bodyIndex: 1, name: 'gate', type: 'rect', x: 100, y: 0, width: 20, height: 20, static: false, density: 1 },
+      ],
+      spawns: [{ x: 0, y: 0, blue: true, red: true }],
+      physicsJoints: [
+        { bodyA: 0, bodyB: 1, type: 'rv', anchorA: { x: 0, y: 0 }, enableLimit: true, lowerLimit: -0.5, upperLimit: 0.5 },
+        { bodyA: 0, bodyB: 1, type: 'lpj', anchorA: { x: 0, y: 0 }, axis: { x: 0, y: 1 }, referenceAngle: 0.3, enableLimit: true, lowerTranslation: -50, upperTranslation: 50 },
+        { bodyA: 0, bodyB: 1, type: 'd', anchorA: { x: 0, y: 0 }, anchorB: { x: 0, y: 30 }, length: 50 },
+      ],
+    } as any) as any;
+
+    const bm = new Map<string, any>();
+    for (const b of md.bodies) { e.addBody(b); bm.set(b.name, e.getBodyMap().get(b.name)); }
+    const warnings = captureWarn(() => {
+      for (const j of md.joints) { e.addJoint(j, bm); }
+    });
+    expect(warnings.filter(w => /unknown joint type|unknown body/i.test(w))).toHaveLength(0);
+
+    // Revolute: exporter lowerLimit/upperLimit must reach the joint's angles.
+    const rv = (e as any).createdJoints.get('joint_0');
+    expect(rv.m_lowerAngle).toBeCloseTo(-0.5, 5);
+    expect(rv.m_upperAngle).toBeCloseTo(0.5, 5);
+    // Prismatic: authored axis and referenceAngle must be forwarded.
+    const pr = (e as any).createdJoints.get('joint_1');
+    expect(pr.m_localXAxis1.y).toBeCloseTo(1, 5);
+    expect(pr.m_localXAxis1.x).toBeCloseTo(0, 5);
+    expect(pr.m_refAngle).toBeCloseTo(0.3, 5);
+    // Distance: authored length applied after Initialize (px / scale).
+    const ds = (e as any).createdJoints.get('joint_2');
+    expect(ds.m_length).toBeCloseTo(50 / 30, 5);
+  });
+
+  it('resolves gear referents by index through the full normalizeMap pipeline', () => {
+    const e = makeEngine();
+    const md = normalizeMap({
+      bodies: [
+        { bodyIndex: 0, name: 'wall', type: 'rect', x: 0, y: 0, width: 40, height: 10, static: true },
+        { bodyIndex: 1, name: 'gate', type: 'rect', x: 100, y: 0, width: 20, height: 20, static: false, density: 1 },
+      ],
+      spawns: [{ x: 0, y: 0, blue: true, red: true }],
+      physicsJoints: [
+        { bodyA: 0, bodyB: 1, type: 'rv', anchorA: { x: 0, y: 0 } },
+        { bodyA: 0, bodyB: 1, type: 'rv', anchorA: { x: 100, y: 0 } },
+        { bodyA: 0, bodyB: 1, type: 'g', ja: 0, jb: 1, ratio: 3 },
+      ],
+    } as any) as any;
+
+    const bm = new Map<string, any>();
+    for (const b of md.bodies) { e.addBody(b); bm.set(b.name, e.getBodyMap().get(b.name)); }
+    const warnings = captureWarn(() => {
+      for (const j of md.joints) { e.addJoint(j, bm); }
+    });
+    expect(warnings).toHaveLength(0);
+    const gear = (e as any).createdJoints.get('joint_2');
+    expect(gear).toBeTruthy();
+    expect(gear.m_type).toBe(6);
+    expect(gear.m_ratio).toBe(3);
+    // Both referents are revolute, so they land in m_revolute1/m_revolute2.
+    expect(gear.m_revolute1).toBe((e as any).createdJoints.get('joint_0'));
+    expect(gear.m_revolute2).toBe((e as any).createdJoints.get('joint_1'));
   });
 });

--- a/tests/integration/physics-fidelity-p2.test.ts
+++ b/tests/integration/physics-fidelity-p2.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { PhysicsEngine } from '../../src/core/physics-engine';
+
+/**
+ * P2 — Native joint-model fidelity (DEOBFUSCATION §33.8).
+ *
+ * The engine's addJoint now constructs every native joint family: revolute
+ * (rv), distance (d), prismatic (lpj/lsj/p), and gear (g), AND supports
+ * ground-anchored joints (bodyB=-1) via a synthetic static ground body instead
+ * of dropping them. These tests verify each family constructs without error and
+ * that a prismatic joint actually constrains a dynamic body to its axis.
+ */
+
+function makeEngine(): PhysicsEngine {
+  return new PhysicsEngine();
+}
+
+function makeBodyMap(e: PhysicsEngine): Map<string, any> {
+  e.addBody({ name: 'plat_0', type: 'rect', x: 0, y: 100, width: 40, height: 10, static: true, density: 0 } as any);
+  e.addBody({ name: 'plat_1', type: 'rect', x: 100, y: 100, width: 40, height: 10, static: true, density: 0 } as any);
+  e.addBody({ name: 'cart_0', type: 'rect', x: 0, y: 150, width: 20, height: 20, static: false, density: 1 } as any);
+  e.addBody({ name: 'cart_1', type: 'rect', x: 100, y: 150, width: 20, height: 20, static: false, density: 1 } as any);
+  return e.getBodyMap() as Map<string, any>;
+}
+
+/** Collect console.warn output during a callback, restoring the original after. */
+function captureWarn(fn: () => void): string[] {
+  const warnings: string[] = [];
+  const orig = console.warn;
+  console.warn = (m: unknown) => warnings.push(String(m));
+  try { fn(); } finally { console.warn = orig; }
+  return warnings;
+}
+
+describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
+  it('constructs a revolute (rv) joint with limits and motor', () => {
+    const e = makeEngine();
+    const bm = makeBodyMap(e);
+    const warnings = captureWarn(() => {
+      e.addJoint({ type: 'rv', name: 'j0', bodyA: 'plat_0', bodyB: 'cart_0', anchorA: { x: 0, y: 100 }, enableLimit: true, lowerAngle: -0.5, upperAngle: 0.5, enableMotor: true, motorSpeed: 5, maxMotorTorque: 10, collideConnected: false }, bm);
+    });
+    expect(warnings.filter(w => /unknown joint type/.test(w))).toHaveLength(0);
+  });
+
+  it('constructs a distance (d) joint', () => {
+    const e = makeEngine();
+    const bm = makeBodyMap(e);
+    const warnings = captureWarn(() => {
+      e.addJoint({ type: 'd', name: 'j1', bodyA: 'plat_0', bodyB: 'cart_0', anchorA: { x: 0, y: 100 }, anchorB: { x: 0, y: 140 }, frequencyHz: 4, dampingRatio: 0.5, length: 50, collideConnected: false }, bm);
+    });
+    expect(warnings.filter(w => /unknown joint type/.test(w))).toHaveLength(0);
+  });
+
+  it('constructs a prismatic (lpj) joint with limits, motor, and axis', () => {
+    const e = makeEngine();
+    const bm = makeBodyMap(e);
+    const warnings = captureWarn(() => {
+      e.addJoint({ type: 'lpj', name: 'j2', bodyA: 'plat_0', bodyB: 'cart_0', anchorA: { x: 0, y: 100 }, axis: { x: 1, y: 0 }, enableLimit: true, lowerTranslation: -50, upperTranslation: 50, enableMotor: true, motorSpeed: 10, maxMotorForce: 100, collideConnected: false }, bm);
+    });
+    expect(warnings.filter(w => /unknown joint type/.test(w))).toHaveLength(0);
+  });
+
+  it('supports a ground-anchored prismatic joint (bodyB=-1) without warning', () => {
+    const e = makeEngine();
+    const bm = makeBodyMap(e);
+    const warnings = captureWarn(() => {
+      e.addJoint({ type: 'lpj', name: 'ground_lpj', bodyA: 'cart_0', bodyB: '', isGround: true, anchorA: { x: 0, y: 150 }, axis: { x: 0, y: 1 }, enableLimit: true, lowerTranslation: -20, upperTranslation: 20, enableMotor: false, maxMotorForce: 0, collideConnected: false }, bm);
+    });
+    // Ground joints must not be dropped or warned about (the engine creates a
+    // synthetic static ground body and anchors to it).
+    expect(warnings.filter(w => /unknown joint|unknown body|no ground/i.test(w))).toHaveLength(0);
+  });
+
+  it('a prismatic joint constrains a dynamic body to its axis', () => {
+    const e = makeEngine();
+    const bm = makeBodyMap(e);
+    // Cart at y=150, anchor at cart spawn, axis (1,0): gravity (down) is
+    // off-axis and must be resisted — the cart's y stays pinned to the anchor.
+    e.addJoint({ type: 'lpj', name: 'j_axis', bodyA: 'plat_0', bodyB: 'cart_0', anchorA: { x: 0, y: 150 }, axis: { x: 1, y: 0 }, enableLimit: true, lowerTranslation: -50, upperTranslation: 50, enableMotor: false, maxMotorForce: 0, collideConnected: false }, bm);
+    const cart = bm.get('cart_0') as any;
+    for (let i = 0; i < 60; i++) e.tick();
+    const after = cart.GetPosition();
+    const yMapPx = after.y * 30;
+    expect(Math.abs(yMapPx - 150)).toBeLessThan(5);
+    expect(Number.isFinite(after.x)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

P2 of the **map-physics fidelity** plan (`docs/PHYSICS_FIDELITY_PLAN.md`), grounded in `DEOBFUSCATION` §33.8. Implements the **full native joint model** in `src/core/physics-engine.ts` and wires the per-type fields through `src/core/map-adapter.ts`.

## What changed

**Engine `addJoint`** now constructs every native joint family:
- **Revolute (`rv`)** — limits, lower/upper angle, motor, maxMotorTorque.
- **Distance (`d`)** — frequencyHz, dampingRatio, length.
- **Prismatic (`lpj` / `lsj` / `p`)** — local axis, translation limits, motor, maxMotorForce.
- **Gear (`g`)** — `b2GearJointDef` (the npm `box2d` port exports it), resolving referent joints `ja`/`jb` by index into `physicsJoints`, registered by name, ratio. **Previously absent.**
- **Ground-anchored joints (`bodyB = -1`)** — construct against a **synthetic static `groundBody`** instead of being dropped with a warning. Previously dropped.

**Adapter**:
- Joints named by array position (`joint_N`) so gear referents resolve consistently.
- Forwards per-type fields (`angle`, translation limits, motor force/torque, gear ratio + referents).
- Marks ground joints via `isGround` / empty `bodyB` (no longer filtered out).

## Validation

- `tests/integration/physics-fidelity-p2.test.ts` — 5 tests: each joint family constructs without an "unknown type" warning; ground joints are not dropped; a prismatic joint pins a dynamic body to its axis under gravity.
- Existing P0/P1 + map suites green on the rebased branch (83 combined): `physics-fidelity-p0` (4), `physics-fidelity-p1` (9), `physics-fidelity-p2` (5), `map-integration` (53), `env-map-path` (12).
- `npx tsc --noEmit` → exit 0.
- Rebased on `main` (includes merged P0–P1: density default, friction polarity, P0/P1 tests).

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update

## Pre-flight Checklist

- [X] Typecheck passes
- [X] New P2 tests + P0/P1/map suites pass
- [X] Rebased on main (no P1 dependency gap)
- [X] Scope limited to joint model (engine, adapter, tests)