### PR TITLE
fix(tests): make physics-config-consumed deterministic and un-hang the suite

### DIFF
--- a/tests/integration/physics-config-consumed.test.ts
+++ b/tests/integration/physics-config-consumed.test.ts
@@ -12,9 +12,10 @@
  * map file is absent, env falls back to the built-in box map" premise no
  * longer holds: the shipped map's spawn rests inside the floor and its 11
  * moving platforms trip an infinite loop in this Box2D port's broadphase
- * when stepped with a small world AABB. TEST_MAP is four static walls whose
- * shape AABBs span exactly x ±515 / y ±300 map px — the same extents the
- * box map produced — so the documented arena numbers hold:
+ * when stepped with a small world AABB. TEST_MAP is two static walls whose
+ * shape AABBs span exactly x ±515 / y ±300 map px — the y extent comes from
+ * the walls' 600 px height — the same extents the box map produced — so the
+ * documented arena numbers hold:
  * arenaHalfWidth/Height = maxExtentPx + boundsMargin * scale:
  *   515 + 5*30 = 665 / 300 + 5*30 = 450 (defaults),
  *   515 / 300 (margin 0), 515 + 5*60 = 815 / 300 + 5*60 = 600 (scale 60).

--- a/tests/integration/physics-config-consumed.test.ts
+++ b/tests/integration/physics-config-consumed.test.ts
@@ -7,11 +7,19 @@
  * simulation. These tests prove the configured value is actually used, per
  * wired key. Defaults are also pinned so the no-config behavior is unchanged.
  *
- * The environment's default map file is absent from this repository, so every
- * env falls back to the built-in box map (floor x±400@y200, walls at x±500 and
- * y±300). Its arena bounds are therefore deterministic: halfWidth/halfHeight
- * in observation px = maxMapExtentPx + boundsMargin * scale, i.e. 515+5*30=665
- * and 300+5*30=450 at the defaults (scale 30, margin 5).
+ * Every environment in this file loads TEST_MAP explicitly. The repo now
+ * ships a default map file (mapexporter PR #264), so the original "default
+ * map file is absent, env falls back to the built-in box map" premise no
+ * longer holds: the shipped map's spawn rests inside the floor and its 11
+ * moving platforms trip an infinite loop in this Box2D port's broadphase
+ * when stepped with a small world AABB. TEST_MAP is four static walls whose
+ * shape AABBs span exactly x ±515 / y ±300 map px — the same extents the
+ * box map produced — so the documented arena numbers hold:
+ * arenaHalfWidth/Height = maxExtentPx + boundsMargin * scale:
+ *   515 + 5*30 = 665 / 300 + 5*30 = 450 (defaults),
+ *   515 / 300 (margin 0), 515 + 5*60 = 815 / 300 + 5*60 = 600 (scale 60).
+ * Velocity deltas are sampled over a single tick (v2 - v1), which keeps
+ * every measurement inside the 850-px death circle and away from the walls.
  */
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { BonkEnvironment } from '../../src/core/environment';
@@ -19,18 +27,28 @@ import { PhysicsEngine } from '../../src/core/physics-engine';
 import { BonkEnv } from '../../src/env/bonk-env';
 import type { MapDef } from '../../src/core/physics-engine';
 
+/** Deterministic static-wall arena (x ±515 / y ±300 map px, no floor). */
+const TEST_MAP: MapDef = {
+    name: 'config-consumed-test-map',
+    spawnPoints: {
+        team_blue: { x: -200, y: -100 },
+        team_red: { x: 200, y: -100 },
+    },
+    bodies: [
+        { name: 'left', type: 'rect', x: -500, y: 0, width: 30, height: 600, static: true },
+        { name: 'right', type: 'rect', x: 500, y: 0, width: 30, height: 600, static: true },
+    ],
+};
+
 /** Free-fall vertical acceleration, in observation px/s per tick (g * dt * scale). */
 function measureFallAccel(physics: Record<string, number> = {}): number {
-    const env = new BonkEnvironment({ numOpponents: 0, seed: 1, physics });
+    const env = new BonkEnvironment({ numOpponents: 0, seed: 1, mapData: TEST_MAP, physics });
     try {
         env.reset(1);
-        let v1 = 0;
-        for (let i = 0; i < 12; i++) {
-            const res = env.step(0);
-            if (i === 1) v1 = res.observation.playerVelY;
-            if (i === 11) return (res.observation.playerVelY - v1) / 10;
-        }
-        throw new Error('unreachable');
+        env.step(0);
+        const v1 = env.step(0).observation.playerVelY;
+        const v2 = env.step(0).observation.playerVelY;
+        return v2 - v1;
     } finally {
         env.close();
     }
@@ -38,16 +56,13 @@ function measureFallAccel(physics: Record<string, number> = {}): number {
 
 /** Horizontal thrust acceleration, in observation px/s per tick, for `action`. */
 function measureThrustAccel(player: Record<string, number>, action: number): number {
-    const env = new BonkEnvironment({ numOpponents: 0, seed: 1, player });
+    const env = new BonkEnvironment({ numOpponents: 0, seed: 1, mapData: TEST_MAP, player });
     try {
         env.reset(1);
-        let v1 = 0;
-        for (let i = 0; i < 12; i++) {
-            const res = env.step(action);
-            if (i === 1) v1 = res.observation.playerVelX;
-            if (i === 11) return (res.observation.playerVelX - v1) / 10;
-        }
-        throw new Error('unreachable');
+        env.step(0);
+        const v1 = env.step(action).observation.playerVelX;
+        const v2 = env.step(action).observation.playerVelX;
+        return v2 - v1;
     } finally {
         env.close();
     }
@@ -55,7 +70,7 @@ function measureThrustAccel(player: Record<string, number>, action: number): num
 
 /** Observation arena bounds for a given tuning config. */
 function arenaBounds(cfg: Record<string, any>): { w: number; h: number } {
-    const env = new BonkEnvironment({ numOpponents: 0, seed: 1, ...cfg });
+    const env = new BonkEnvironment({ numOpponents: 0, seed: 1, mapData: TEST_MAP, ...cfg });
     try {
         env.reset(1);
         const o = env.step(0).observation;
@@ -82,19 +97,15 @@ describe('physics/arena/player config is consumed by the engine (#217)', () => {
     });
 
     it('physics.gravityX produces horizontal drift', () => {
-        const env = new BonkEnvironment({ numOpponents: 0, seed: 1, physics: { gravityX: 5 } });
+        const env = new BonkEnvironment({ numOpponents: 0, seed: 1, mapData: TEST_MAP, physics: { gravityX: 5 } });
         try {
             env.reset(1);
-            let v1 = 0;
-            for (let i = 0; i < 12; i++) {
-                const res = env.step(0);
-                if (i === 1) v1 = res.observation.playerVelX;
-                if (i === 11) {
-                    const accel = (res.observation.playerVelX - v1) / 10;
-                    expect(accel).toBeCloseTo(5, 6);
-                    expect(accel).not.toBeCloseTo(0, 1);
-                }
-            }
+            env.step(0);
+            const v1 = env.step(0).observation.playerVelX;
+            const v2 = env.step(0).observation.playerVelX;
+            const accel = v2 - v1;
+            expect(accel).toBeCloseTo(5, 6);
+            expect(accel).not.toBeCloseTo(0, 1);
         } finally {
             env.close();
         }
@@ -168,6 +179,7 @@ describe('physics/arena/player config is consumed by the engine (#217)', () => {
         const env = new BonkEnvironment({
             numOpponents: 0,
             seed: 1,
+            mapData: TEST_MAP,
             physics: { enableSleeping: false, worldAabbExtent: 250, solverIterations: 12 },
         });
         const eng: any = (env as any).physics;
@@ -192,6 +204,7 @@ describe('physics/arena/player config is consumed by the engine (#217)', () => {
         const env = new BonkEnvironment({
             numOpponents: 0,
             seed: 1,
+            mapData: TEST_MAP,
             physics: { gravityX: 3, gravityY: 7, enableSleeping: false, worldAabbExtent: 250 },
         });
         const eng: any = (env as any).physics;
@@ -345,8 +358,8 @@ describe('physics/arena/player config is consumed by the engine (#217)', () => {
         // cap-zone `(l ?? 3)*30`) are tick-counted: raising ticksPerSecond
         // changes the per-tick sim step, NOT the tick counters. This locks the
         // documented #217 contract so a future rescaling regression is caught.
-        const env30 = new BonkEnvironment({ numOpponents: 0, seed: 1 });
-        const env60 = new BonkEnvironment({ numOpponents: 0, seed: 1, physics: { ticksPerSecond: 60 } });
+        const env30 = new BonkEnvironment({ numOpponents: 0, seed: 1, mapData: TEST_MAP });
+        const env60 = new BonkEnvironment({ numOpponents: 0, seed: 1, mapData: TEST_MAP, physics: { ticksPerSecond: 60 } });
         try {
             expect((env30 as any).config.maxTicks).toBe(900);
             // 60 TPS must NOT silently double the episode length to 1800.
@@ -371,7 +384,7 @@ describe('physics/arena/player config reaches workers through the pool (#217)', 
         const env = new BonkEnv({
             numEnvs: 1,
             useSharedMemory: false,
-            config: { arena: { boundsMargin: 0 } },
+            config: { mapData: TEST_MAP, arena: { boundsMargin: 0 } },
         });
         envs.push(env);
         await env.start();
@@ -385,29 +398,24 @@ describe('physics/arena/player config reaches workers through the pool (#217)', 
         const env = new BonkEnv({
             numEnvs: 1,
             useSharedMemory: false,
-            config: { physics: { gravityY: 5 }, numOpponents: 0 },
+            config: { mapData: TEST_MAP, physics: { gravityY: 5 }, numOpponents: 0 },
         });
         envs.push(env);
         await env.start();
 
         const obs0 = (await env.reset([1])) as any[];
         expect(obs0[0].playerVelY).toBeCloseTo(0, 6);
-        let v1 = 0;
-        let v2 = 0;
-        for (let i = 0; i < 12; i++) {
-            const res = (await env.step([0])) as any[];
-            if (i === 1) v1 = res[0].observation.playerVelY;
-            if (i === 11) v2 = res[0].observation.playerVelY;
-        }
-        const accel = (v2 - v1) / 10;
-        expect(accel).toBeCloseTo(5, 1);
+        await env.step([0]);
+        const v1 = ((await env.step([0])) as any[])[0].observation.playerVelY;
+        const v2 = ((await env.step([0])) as any[])[0].observation.playerVelY;
+        expect(v2 - v1).toBeCloseTo(5, 1);
     });
 
     it('physics.scale set in the per-env config changes worker arena observations', { timeout: 30000 }, async () => {
         const env = new BonkEnv({
             numEnvs: 1,
             useSharedMemory: false,
-            config: { physics: { scale: 60 } },
+            config: { mapData: TEST_MAP, physics: { scale: 60 } },
         });
         envs.push(env);
         await env.start();
@@ -421,60 +429,48 @@ describe('physics/arena/player config reaches workers through the pool (#217)', 
         const env = new BonkEnv({
             numEnvs: 1,
             useSharedMemory: false,
-            config: { physics: { ticksPerSecond: 60 }, numOpponents: 0 },
+            config: { mapData: TEST_MAP, physics: { ticksPerSecond: 60 }, numOpponents: 0 },
         });
         envs.push(env);
         await env.start();
 
         await env.reset([1]);
-        let v1 = 0;
-        let v2 = 0;
-        for (let i = 0; i < 12; i++) {
-            const res = (await env.step([0])) as any[];
-            if (i === 1) v1 = res[0].observation.playerVelY;
-            if (i === 11) v2 = res[0].observation.playerVelY;
-        }
+        await env.step([0]);
+        const v1 = ((await env.step([0])) as any[])[0].observation.playerVelY;
+        const v2 = ((await env.step([0])) as any[])[0].observation.playerVelY;
         // Per-tick Δv = g * dt * scale with dt = 1/60: 10, half of the 30-TPS 20.
-        expect((v2 - v1) / 10).toBeCloseTo(10, 1);
+        expect(v2 - v1).toBeCloseTo(10, 1);
     });
 
     it('player.moveForce set in the per-env config changes worker thrust', { timeout: 30000 }, async () => {
         const env = new BonkEnv({
             numEnvs: 1,
             useSharedMemory: false,
-            config: { player: { moveForce: 60 }, numOpponents: 0 },
+            config: { mapData: TEST_MAP, player: { moveForce: 60 }, numOpponents: 0 },
         });
         envs.push(env);
         await env.start();
 
         await env.reset([1]);
-        let v1 = 0;
-        let v2 = 0;
-        for (let i = 0; i < 12; i++) {
-            const res = (await env.step([2])) as any[]; // action 2 = right
-            if (i === 1) v1 = res[0].observation.playerVelX;
-            if (i === 11) v2 = res[0].observation.playerVelX;
-        }
-        expect((v2 - v1) / 10).toBeCloseTo(60, 1);
+        await env.step([2]); // action 2 = right
+        const v1 = ((await env.step([2])) as any[])[0].observation.playerVelX;
+        const v2 = ((await env.step([2])) as any[])[0].observation.playerVelX;
+        expect(v2 - v1).toBeCloseTo(60, 1);
     });
 
     it('player.heavyMassMultiplier set in the per-env config changes worker heavy thrust', { timeout: 30000 }, async () => {
         const env = new BonkEnv({
             numEnvs: 1,
             useSharedMemory: false,
-            config: { player: { heavyMassMultiplier: 0.35 }, numOpponents: 0 },
+            config: { mapData: TEST_MAP, player: { heavyMassMultiplier: 0.35 }, numOpponents: 0 },
         });
         envs.push(env);
         await env.start();
 
         await env.reset([1]);
-        let v1 = 0;
-        let v2 = 0;
-        for (let i = 0; i < 12; i++) {
-            const res = (await env.step([18])) as any[]; // action 18 = right + heavy
-            if (i === 1) v1 = res[0].observation.playerVelX;
-            if (i === 11) v2 = res[0].observation.playerVelX;
-        }
-        expect((v2 - v1) / 10).toBeCloseTo(10.5, 1);
+        await env.step([18]); // action 18 = right + heavy
+        const v1 = ((await env.step([18])) as any[])[0].observation.playerVelX;
+        const v2 = ((await env.step([18])) as any[])[0].observation.playerVelX;
+        expect(v2 - v1).toBeCloseTo(10.5, 1);
     });
 });


### PR DESCRIPTION
Fixes the physics-config-consumed.test.ts suite hang and stale-map-premise failures.

## Problem
- The suite hung forever: stepping a world that loads the shipped default map (bonk_WDB__No_Mapshake__716916.json - 40 bodies, 11 moving platforms with velocities) with the config tests' small world AABB (250) hits an infinite loop in the bundled box2d port's b2BroadPhase.Commit, pegging a vitest worker at 100% CPU and blocking the whole test suite.
- The first ~8 tests also failed: they assumed the default map file was absent (env falls back to the box map), but the mapexporter PR (#264) shipped the map file, so the env loaded it instead (spawn inside the floor), breaking every gravity/bounds measurement.

## Fix (test file only)
- Deterministic TEST_MAP: two static side walls at x=+-500 (600 tall) whose shape AABBs span exactly x +-515 / y +-300 map px - the same extents the documented arena numbers (665x450, 515x300, 815x600) were based on, so all original expectations are preserved.
- Every env in the file now passes mapData: TEST_MAP explicitly, in-process and through the worker pool, removing the shipped-map dependence entirely (no moving platforms -> no broadphase loop; deterministic spawn).
- Velocity measurements sample a single tick (v2 - v1) instead of 12-tick windows, which fell into the 850-px death circle at tick ~9 and hit walls in the high-thrust cases.

## Verification
- File: 22/22 pass in ~1.4s (was: hung forever + ~8 failing assertions).
- Full suite: completes in ~38s, 1576/1578 pass; the only 2 remaining failures are pre-existing and unrelated (env-ai-player-id fails identically at baseline commit 1848b82; snapshot-ring-stress is a timing-flaky stress test that passes in isolation).
- tsc --noEmit clean.