### PR TITLE
fix(#273): preserve spawnPoints/capZones/joints for MapDefs without a bodies array

### DIFF
--- a/src/core/map-adapter.ts
+++ b/src/core/map-adapter.ts
@@ -132,16 +132,19 @@ function isInternalMapDef(raw: any): raw is MapDef {
         && raw.spawnPoints !== null
         && typeof raw.spawnPoints === 'object'
         && !Array.isArray(raw.spawnPoints)
-        // Accept an omitted `bodies` key as internal: a programmatic MapDef
-        // with no bodies (e.g. a pure-cap-zone or spawn-only map) legitimately
-        // carries spawnPoints/capZones/joints without a bodies array and must
-        // still pass through to preserve them (#273). The `spawnPoints`-object
-        // check above already excludes the real exported format (which uses
-        // `spawns[]`), so widening here does not misclassify exported maps.
-        && (raw.bodies === undefined || Array.isArray(raw.bodies))
+        // Accept an omitted or `null` `bodies` key as internal: a programmatic
+        // MapDef with no bodies (e.g. a pure-cap-zone or spawn-only map)
+        // legitimately carries spawnPoints/capZones/joints without a bodies
+        // array and must still pass through to preserve them (#273). The
+        // `spawnPoints`-object check above already excludes the real exported
+        // format (which uses `spawns[]`), so widening here does not
+        // misclassify exported maps.
+        && (raw.bodies === undefined || raw.bodies === null || Array.isArray(raw.bodies))
         && (raw.bodies === undefined
+            || raw.bodies === null
             || raw.bodies.length === 0
-            || (typeof raw.bodies[0] === 'object'
+            || (raw.bodies[0] !== null
+                && typeof raw.bodies[0] === 'object'
                 && !('collidesGroup1' in raw.bodies[0])));
 }
 
@@ -216,7 +219,13 @@ export function normalizeMap(raw: unknown): MapDef {
     // carries `position`/`fixtures`, not x/y/width) silently producing
     // degenerate 0×0 bodies.
     const flatBodies = map.bodies && map.bodies.length ? map.bodies : null;
-    const bodies = (flatBodies || map.physicsBodies || []).map(toBodyDef);
+    // Guard the exporter path against corrupt/placeholder entries (e.g.
+    // `bodies: [null]`, valid JSON): filter them out so toBodyDef never
+    // receives a null body and the filtered list stays index-aligned with
+    // `bodies` downstream (#273).
+    const flatSource = (flatBodies || map.physicsBodies || [])
+        .filter((b): b is FlatBody => b !== null && b !== undefined);
+    const bodies = flatSource.map(toBodyDef);
 
     // Build a fixture-index -> body-name map so cap zones can resolve their
     // platform body. Export fixtures all share the name "Unnamed Shape", so a
@@ -224,7 +233,6 @@ export function normalizeMap(raw: unknown): MapDef {
     // cap-zone-referenced body a fixture-unique name (e.g. "Unnamed Shape#13")
     // so the engine's `bodies.find(b => b.name === zone.fixture)` selects the
     // actual platform rather than the first "Unnamed Shape."
-    const flatSource = flatBodies || map.physicsBodies || [];
     const nameByFixture = new Map<number, string>();
     const capFriendlyNames = new Map<number, string>();
     flatSource.forEach((b, i) => {

--- a/src/core/map-adapter.ts
+++ b/src/core/map-adapter.ts
@@ -122,7 +122,9 @@ interface ExportedMap {
 /**
  * Detect whether `raw` is already the engine's internal `MapDef` (a flattened
  * `spawnPoints` object + nested-collides `bodies[]`) versus the real exported
- * bonk format. A `spawnPoints` object with a `bodies[]` array marks MapDef.
+ * bonk format. A `spawnPoints` object marks MapDef; the real exported format
+ * keys spawns under a `spawns[]` array instead, so that positive marker alone
+ * is enough to discriminate without requiring a `bodies[]` array.
  */
 function isInternalMapDef(raw: any): raw is MapDef {
     return !!raw
@@ -130,12 +132,17 @@ function isInternalMapDef(raw: any): raw is MapDef {
         && raw.spawnPoints !== null
         && typeof raw.spawnPoints === 'object'
         && !Array.isArray(raw.spawnPoints)
-        && Array.isArray(raw.bodies)
-        // Don't require a non-empty bodies[] — a programmatic MapDef with no
-        // bodies (e.g. a pure-cap-zone or spawn-only map) must still pass
-        // through to preserve its spawnPoints/capZones/joints (#review).
-        && (raw.bodies.length === 0 || typeof raw.bodies[0] === 'object')
-        && (raw.bodies.length === 0 || !('collidesGroup1' in raw.bodies[0]));
+        // Accept an omitted `bodies` key as internal: a programmatic MapDef
+        // with no bodies (e.g. a pure-cap-zone or spawn-only map) legitimately
+        // carries spawnPoints/capZones/joints without a bodies array and must
+        // still pass through to preserve them (#273). The `spawnPoints`-object
+        // check above already excludes the real exported format (which uses
+        // `spawns[]`), so widening here does not misclassify exported maps.
+        && (raw.bodies === undefined || Array.isArray(raw.bodies))
+        && (raw.bodies === undefined
+            || raw.bodies.length === 0
+            || (typeof raw.bodies[0] === 'object'
+                && !('collidesGroup1' in raw.bodies[0])));
 }
 
 /** Convert a flat body into a MapBodyDef, preserving facade metadata. */
@@ -191,8 +198,15 @@ function toBodyDef(body: FlatBody, index: number): any {
  * normalized MapDef (returned unchanged).
  */
 export function normalizeMap(raw: unknown): MapDef {
-    // Already in engine MapDef shape — pass through unchanged.
-    if (isInternalMapDef(raw)) return raw;
+    // Already in engine MapDef shape — pass through unchanged, defaulting an
+    // omitted `bodies` to `[]` so downstream `for (const b of mapData.bodies)`
+    // loops in the environment never iterate `undefined` (#273).
+    if (isInternalMapDef(raw)) {
+        return {
+            ...raw,
+            bodies: raw.bodies ?? [],
+        };
+    }
 
     const map = (raw || {}) as ExportedMap;
 

--- a/src/core/map-adapter.ts
+++ b/src/core/map-adapter.ts
@@ -140,12 +140,17 @@ function isInternalMapDef(raw: any): raw is MapDef {
         // format (which uses `spawns[]`), so widening here does not
         // misclassify exported maps.
         && (raw.bodies === undefined || raw.bodies === null || Array.isArray(raw.bodies))
+        // Null/undefined array entries (e.g. `bodies: [null]`, valid JSON) are
+        // corrupt placeholders, not flat exported bodies — treat them as
+        // internal so authored spawnPoints/capZones/joints are preserved and
+        // only the empty remainder reaches the pass-through (which sanitizes
+        // it) or the exporter path. Any real flat body (collidesGroupN)
+        // still classifies the payload as exported (#273).
         && (raw.bodies === undefined
             || raw.bodies === null
-            || raw.bodies.length === 0
-            || (raw.bodies[0] !== null
-                && typeof raw.bodies[0] === 'object'
-                && !('collidesGroup1' in raw.bodies[0])));
+            || raw.bodies.every((b: any) => b === null
+                || b === undefined
+                || (typeof b === 'object' && !('collidesGroup1' in b))));
 }
 
 /** Convert a flat body into a MapBodyDef, preserving facade metadata. */
@@ -202,12 +207,13 @@ function toBodyDef(body: FlatBody, index: number): any {
  */
 export function normalizeMap(raw: unknown): MapDef {
     // Already in engine MapDef shape — pass through unchanged, defaulting an
-    // omitted `bodies` to `[]` so downstream `for (const b of mapData.bodies)`
-    // loops in the environment never iterate `undefined` (#273).
+    // omitted `bodies` to `[]` (and dropping corrupt null/undefined entries
+    // from a present array) so downstream `for (const b of mapData.bodies)`
+    // loops in the environment never iterate `undefined` or `null` (#273).
     if (isInternalMapDef(raw)) {
         return {
             ...raw,
-            bodies: raw.bodies ?? [],
+            bodies: (raw.bodies ?? []).filter((b: unknown) => b !== null && b !== undefined),
         };
     }
 

--- a/tests/integration/map-integration.test.ts
+++ b/tests/integration/map-integration.test.ts
@@ -728,4 +728,54 @@ describe('MapIntegration', () => {
             },
         );
     });
+
+    describe('spawn-only / pure-cap-zone MapDef (bodies key omitted) survives normalizeMap (#273)', () => {
+        const spawnOnlyMap = {
+            name: 'SpawnOnly',
+            spawnPoints: {
+                team_blue: { x: 111, y: 222 },
+                team_red: { x: 333, y: 444 },
+            },
+            capZones: [
+                { index: 0, owner: '', type: 1, fixture: 'plat_0', shapeType: 'rect' },
+            ],
+            joints: [
+                { type: 'rv', name: 'j0', bodyA: 'plat_0', bodyB: 'plat_1' },
+            ],
+            // NOTE: `bodies` key intentionally omitted (spawn-only map).
+        };
+
+        it('keeps authored spawnPoints/capZones/joints on the environment config', () => {
+            const env = new BonkEnvironment({
+                mapData: spawnOnlyMap as any,
+                numOpponents: 0,
+                randomOpponent: false,
+                seed: 1,
+            });
+            try {
+                expect((env as any).config.mapData.spawnPoints).toEqual(spawnOnlyMap.spawnPoints);
+                expect((env as any).config.mapData.capZones).toEqual(spawnOnlyMap.capZones);
+                expect((env as any).config.mapData.joints).toEqual(spawnOnlyMap.joints);
+                expect((env as any).config.mapData.bodies).toEqual([]);
+            } finally {
+                env.close();
+            }
+        });
+
+        it('spawns the AI player at the authored spawn instead of the hardcoded fallback', () => {
+            const env = new BonkEnvironment({
+                mapData: spawnOnlyMap as any,
+                numOpponents: 0,
+                randomOpponent: false,
+                seed: 1,
+            });
+            try {
+                const obs = env.getObservationFast();
+                expect(obs[0]).toBe(111);
+                expect(obs[1]).toBe(222);
+            } finally {
+                env.close();
+            }
+        });
+    });
 });

--- a/tests/unit/map-adapter.test.ts
+++ b/tests/unit/map-adapter.test.ts
@@ -1,0 +1,83 @@
+/**
+ * map-adapter.test.ts — Vitest unit tests for normalizeMap().
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normalizeMap } from '../../src/core/map-adapter';
+
+describe('normalizeMap', () => {
+    describe('internal MapDef pass-through', () => {
+        it('preserves spawnPoints/capZones/joints when the bodies array is omitted (#273)', () => {
+            const spawnOnly = {
+                name: 'SpawnOnly',
+                spawnPoints: {
+                    team_blue: { x: 111, y: 222 },
+                    team_red: { x: 333, y: 444 },
+                },
+                capZones: [
+                    { index: 0, owner: '', type: 1, fixture: 'plat_0', shapeType: 'rect' },
+                ],
+                joints: [
+                    { type: 'rv', name: 'j0', bodyA: 'plat_0', bodyB: 'plat_1' },
+                ],
+            };
+            const out = normalizeMap(spawnOnly as any);
+            expect(out.spawnPoints).toEqual(spawnOnly.spawnPoints);
+            expect(out.capZones).toEqual(spawnOnly.capZones);
+            expect(out.joints).toEqual(spawnOnly.joints);
+            // Omitted `bodies` defaults to [] so downstream loops are safe.
+            expect(out.bodies).toEqual([]);
+        });
+
+        it('passes through a MapDef with an explicit empty bodies array unchanged', () => {
+            const md = {
+                name: 'SpawnOnly',
+                spawnPoints: { team_blue: { x: 1, y: 2 }, team_red: { x: 3, y: 4 } },
+                bodies: [],
+            };
+            const out = normalizeMap(md as any);
+            expect(out.spawnPoints).toEqual(md.spawnPoints);
+            expect(out.bodies).toEqual([]);
+        });
+
+        it('passes through a MapDef with bodies unchanged', () => {
+            const md = {
+                name: 'M',
+                spawnPoints: { team_blue: { x: 1, y: 2 } },
+                bodies: [
+                    {
+                        name: 'b0', type: 'rect', x: 0, y: 0, width: 10, height: 10, static: true,
+                        collides: { g1: true, g2: true, g3: false, g4: false },
+                    },
+                ],
+            };
+            const out = normalizeMap(md as any);
+            expect(out.bodies).toEqual(md.bodies);
+            expect(out.spawnPoints).toEqual(md.spawnPoints);
+        });
+    });
+
+    describe('exported bonk format detection', () => {
+        it('still normalizes the real exported format (spawns[] + flat bodies)', () => {
+            const out = normalizeMap({
+                bodies: [
+                    { bodyIndex: 0, name: 'wall', type: 'rect', x: 0, y: 0, width: 40, height: 10, static: true },
+                ],
+                spawns: [{ x: 0, y: 0, blue: true, red: true }],
+            } as any) as any;
+            expect(out.bodies.length).toBe(1);
+            expect(out.spawnPoints.team_blue).toEqual({ x: 0, y: 0 });
+        });
+
+        it('still detects flat bodies via collidesGroup1 markers', () => {
+            const out = normalizeMap({
+                bodies: [
+                    { bodyIndex: 0, name: 'wall', type: 'rect', x: 0, y: 0, width: 40, height: 10, static: true, collidesGroup1: true },
+                ],
+                spawns: [{ x: 0, y: 0, blue: true, red: true }],
+            } as any) as any;
+            expect(out.bodies.length).toBe(1);
+            expect((out.bodies[0] as any).collides.g1).toBe(true);
+        });
+    });
+});

--- a/tests/unit/map-adapter.test.ts
+++ b/tests/unit/map-adapter.test.ts
@@ -55,6 +55,38 @@ describe('normalizeMap', () => {
             expect(out.bodies).toEqual(md.bodies);
             expect(out.spawnPoints).toEqual(md.spawnPoints);
         });
+
+        it('preserves authored data when bodies is explicitly null (#273)', () => {
+            const spawnOnly = {
+                name: 'SpawnOnly',
+                spawnPoints: { team_blue: { x: 111, y: 222 }, team_red: { x: 333, y: 444 } },
+                capZones: [
+                    { index: 0, owner: '', type: 1, fixture: 'plat_0', shapeType: 'rect' },
+                ],
+                joints: [
+                    { type: 'rv', name: 'j0', bodyA: 'plat_0', bodyB: 'plat_1' },
+                ],
+                bodies: null,
+            };
+            const out = normalizeMap(spawnOnly as any);
+            expect(out.spawnPoints).toEqual(spawnOnly.spawnPoints);
+            expect(out.capZones).toEqual(spawnOnly.capZones);
+            expect(out.joints).toEqual(spawnOnly.joints);
+            expect(out.bodies).toEqual([]);
+        });
+
+        it('does not crash on a bodies array containing null (#273)', () => {
+            // A corrupt/placeholder payload like bodies: [null] is valid JSON
+            // and must fall through to the exporter path instead of throwing.
+            const out = normalizeMap({
+                name: 'Corrupt',
+                spawnPoints: { team_blue: { x: 111, y: 222 } },
+                bodies: [null],
+            } as any);
+            expect(Array.isArray(out.bodies)).toBe(true);
+            expect(out.bodies.length).toBe(0);
+            expect(out.spawnPoints).toBeDefined();
+        });
     });
 
     describe('exported bonk format detection', () => {

--- a/tests/unit/map-adapter.test.ts
+++ b/tests/unit/map-adapter.test.ts
@@ -75,17 +75,29 @@ describe('normalizeMap', () => {
             expect(out.bodies).toEqual([]);
         });
 
-        it('does not crash on a bodies array containing null (#273)', () => {
-            // A corrupt/placeholder payload like bodies: [null] is valid JSON
-            // and must fall through to the exporter path instead of throwing.
+        it('preserves authored spawnPoints/capZones/joints for bodies: [null] (#273)', () => {
+            // A corrupt/placeholder bodies array (valid JSON) is treated as
+            // internal so authored data survives; the null entries are dropped
+            // and the empty remainder reaches the environment safely.
             const out = normalizeMap({
-                name: 'Corrupt',
-                spawnPoints: { team_blue: { x: 111, y: 222 } },
+                name: 'SpawnOnly',
+                spawnPoints: { team_blue: { x: 111, y: 222 }, team_red: { x: 333, y: 444 } },
+                capZones: [
+                    { index: 0, owner: '', type: 1, fixture: 'plat_0', shapeType: 'rect' },
+                ],
+                joints: [
+                    { type: 'rv', name: 'j0', bodyA: 'plat_0', bodyB: 'plat_1' },
+                ],
                 bodies: [null],
             } as any);
-            expect(Array.isArray(out.bodies)).toBe(true);
-            expect(out.bodies.length).toBe(0);
-            expect(out.spawnPoints).toBeDefined();
+            expect(out.spawnPoints).toEqual({ team_blue: { x: 111, y: 222 }, team_red: { x: 333, y: 444 } });
+            expect(out.capZones).toEqual([
+                { index: 0, owner: '', type: 1, fixture: 'plat_0', shapeType: 'rect' },
+            ]);
+            expect(out.joints).toEqual([
+                { type: 'rv', name: 'j0', bodyA: 'plat_0', bodyB: 'plat_1' },
+            ]);
+            expect(out.bodies).toEqual([]);
         });
     });
 

--- a/tests/unit/map-adapter.test.ts
+++ b/tests/unit/map-adapter.test.ts
@@ -123,5 +123,23 @@ describe('normalizeMap', () => {
             expect(out.bodies.length).toBe(1);
             expect((out.bodies[0] as any).collides.g1).toBe(true);
         });
+
+        it('exporter path filters null bodies before conversion (#273)', () => {
+            // No `spawnPoints` marker, so this is the real exported format even
+            // though `bodies` mixes a null placeholder with a flat body. The
+            // null entry must be filtered before toBodyDef (which would throw),
+            // and the remaining flat body converts normally.
+            const out = normalizeMap({
+                bodies: [
+                    null,
+                    { bodyIndex: 1, name: 'wall', type: 'rect', x: 0, y: 0, width: 40, height: 10, static: true, collidesGroup1: true },
+                ],
+                spawns: [{ x: 0, y: 0, blue: true, red: true }],
+            } as any) as any;
+            expect(out.bodies.length).toBe(1);
+            expect(out.bodies[0].name).toBe('wall');
+            expect((out.bodies[0] as any).collides.g1).toBe(true);
+            expect(out.spawnPoints.team_blue).toEqual({ x: 0, y: 0 });
+        });
     });
 });


### PR DESCRIPTION
Closes #273