### PR TITLE
fix(#283): skip null physicsJoints entries in normalizeMap

### DIFF
--- a/src/core/map-adapter.ts
+++ b/src/core/map-adapter.ts
@@ -294,7 +294,18 @@ export function normalizeMap(raw: unknown): MapDef {
     flatSource.forEach((b, i) => {
         if (b) bodiesByName.set(b.bodyIndex ?? i, bodies[i]?.name ?? b.name ?? `body_${i}`);
     });
+    // The exporter (Webscripts/mapexporter.js) emits a literal `null` for any
+    // joint it cannot export to keep raw-array indices stable, so `physicsJoints`
+    // may contain falsy entries. Skip them (with a warning) instead of throwing
+    // on dereference — a map with an unexportable joint must still load its
+    // bodies, spawns and cap zones. The raw array position (`jointIdx`) is kept
+    // for joint naming and gear-referent lookups so filtered-out nulls cannot
+    // mis-wire gear referents.
     const joints = (map.physicsJoints || []).map((j, jointIdx) => {
+        if (!j) {
+            console.warn(`[map-adapter] Skipping null/empty physicsJoints entry at index ${jointIdx}`);
+            return null;
+        }
         // bodyA: -1 means the joint is anchored to the static ground body on the
         // A side (§33.8: ba/bb of -1 = ground on either side). Emit the reserved
         // ground name; addJoint resolves it to the synthetic ground body. Any
@@ -378,7 +389,7 @@ export function normalizeMap(raw: unknown): MapDef {
             }
         }
         return out;
-    });
+    }).filter((j): j is Record<string, unknown> => j !== null);
 
     const ph = map.physics || {};
     const bounds = {

--- a/src/core/map-adapter.ts
+++ b/src/core/map-adapter.ts
@@ -300,12 +300,14 @@ export function normalizeMap(raw: unknown): MapDef {
     // The exporter (Webscripts/mapexporter.js) emits a literal `null` for any
     // joint it cannot export to keep raw-array indices stable, so `physicsJoints`
     // may contain `null` entries (per the `(FlatJoint | null)` contract). A
-    // programmatic `mapData` may also hand us a sparse array, whose holes
-    // iterate as `undefined`. Skip both (with a warning) instead of throwing on
-    // dereference — a map with an unexportable joint must still load its bodies,
-    // spawns and cap zones. The raw array position (`jointIdx`) is kept for
-    // joint naming and gear-referent lookups so filtered-out entries cannot
-    // mis-wire gear referents.
+    // programmatic `mapData` may also hand us a dense array containing literal
+    // `undefined` entries (Array.prototype.map skips sparse holes without
+    // invoking its callback, so holes never reach this code). Skip both null
+    // and undefined (with a warning) instead of throwing on dereference — a map
+    // with an unexportable joint must still load its bodies, spawns and cap
+    // zones. The raw array position (`jointIdx`) is kept for joint naming and
+    // gear-referent lookups so filtered-out entries cannot mis-wire gear
+    // referents.
     const joints = (map.physicsJoints || []).map((j, jointIdx) => {
         if (j === null || j === undefined) {
             console.warn(`[map-adapter] Skipping null/undefined physicsJoints entry at index ${jointIdx}`);

--- a/src/core/map-adapter.ts
+++ b/src/core/map-adapter.ts
@@ -116,7 +116,10 @@ interface ExportedMap {
     capZones?: FlatCapZone[];
     bodies?: FlatBody[];
     physicsBodies?: FlatBody[];
-    physicsJoints?: FlatJoint[];
+    // The exporter (Webscripts/mapexporter.js) pushes a literal `null` for any
+    // joint it cannot export to keep raw-array indices stable, so entries may
+    // be null as well as FlatJoint.
+    physicsJoints?: (FlatJoint | null)[];
     physicsFixtures?: unknown[];
     physicsShapes?: unknown[];
 }
@@ -296,14 +299,14 @@ export function normalizeMap(raw: unknown): MapDef {
     });
     // The exporter (Webscripts/mapexporter.js) emits a literal `null` for any
     // joint it cannot export to keep raw-array indices stable, so `physicsJoints`
-    // may contain falsy entries. Skip them (with a warning) instead of throwing
-    // on dereference — a map with an unexportable joint must still load its
-    // bodies, spawns and cap zones. The raw array position (`jointIdx`) is kept
-    // for joint naming and gear-referent lookups so filtered-out nulls cannot
-    // mis-wire gear referents.
+    // may contain `null` entries (per the `(FlatJoint | null)` contract). Skip
+    // them (with a warning) instead of throwing on dereference — a map with an
+    // unexportable joint must still load its bodies, spawns and cap zones. The
+    // raw array position (`jointIdx`) is kept for joint naming and gear-referent
+    // lookups so filtered-out nulls cannot mis-wire gear referents.
     const joints = (map.physicsJoints || []).map((j, jointIdx) => {
-        if (!j) {
-            console.warn(`[map-adapter] Skipping null/empty physicsJoints entry at index ${jointIdx}`);
+        if (j === null) {
+            console.warn(`[map-adapter] Skipping null physicsJoints entry at index ${jointIdx}`);
             return null;
         }
         // bodyA: -1 means the joint is anchored to the static ground body on the

--- a/src/core/map-adapter.ts
+++ b/src/core/map-adapter.ts
@@ -299,14 +299,16 @@ export function normalizeMap(raw: unknown): MapDef {
     });
     // The exporter (Webscripts/mapexporter.js) emits a literal `null` for any
     // joint it cannot export to keep raw-array indices stable, so `physicsJoints`
-    // may contain `null` entries (per the `(FlatJoint | null)` contract). Skip
-    // them (with a warning) instead of throwing on dereference — a map with an
-    // unexportable joint must still load its bodies, spawns and cap zones. The
-    // raw array position (`jointIdx`) is kept for joint naming and gear-referent
-    // lookups so filtered-out nulls cannot mis-wire gear referents.
+    // may contain `null` entries (per the `(FlatJoint | null)` contract). A
+    // programmatic `mapData` may also hand us a sparse array, whose holes
+    // iterate as `undefined`. Skip both (with a warning) instead of throwing on
+    // dereference — a map with an unexportable joint must still load its bodies,
+    // spawns and cap zones. The raw array position (`jointIdx`) is kept for
+    // joint naming and gear-referent lookups so filtered-out entries cannot
+    // mis-wire gear referents.
     const joints = (map.physicsJoints || []).map((j, jointIdx) => {
-        if (j === null) {
-            console.warn(`[map-adapter] Skipping null physicsJoints entry at index ${jointIdx}`);
+        if (j === null || j === undefined) {
+            console.warn(`[map-adapter] Skipping null/undefined physicsJoints entry at index ${jointIdx}`);
             return null;
         }
         // bodyA: -1 means the joint is anchored to the static ground body on the

--- a/tests/integration/physics-fidelity-p2.test.ts
+++ b/tests/integration/physics-fidelity-p2.test.ts
@@ -746,10 +746,12 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
     expect(md.joints).toBeUndefined();
   });
 
-  it('tolerates a sparse physicsJoints array (holes iterate as undefined)', () => {
-    // A programmatic mapData can hand normalizeMap a sparse physicsJoints;
-    // array holes iterate as `undefined` and must be skipped like nulls, not
-    // reach j.bodyA and throw the #283 TypeError (#283).
+  it('tolerates dense physicsJoints entries that are literal undefined', () => {
+    // A programmatic mapData can hand normalizeMap a DENSE physicsJoints array
+    // containing literal `undefined` entries. (Sparse holes never reach the map
+    // callback — Array.prototype.map skips them — so only a dense undefined can
+    // exercise the guard.) The old null-only guard dereferenced these at
+    // j.bodyA and threw the #283 TypeError; they must be skipped like nulls.
     const md = normalizeMap({
       bodies: [
         { bodyIndex: 0, name: 'wall', type: 'rect', x: 0, y: 0, width: 40, height: 10, static: true },
@@ -757,7 +759,7 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
       spawns: [{ x: 0, y: 0, blue: true, red: true }],
       physicsJoints: [
         null,
-        ,
+        undefined,
         { bodyA: 0, bodyB: -1, type: 'lpj', anchorA: { x: 0, y: 0 } },
       ],
     } as any) as any;

--- a/tests/integration/physics-fidelity-p2.test.ts
+++ b/tests/integration/physics-fidelity-p2.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { PhysicsEngine, SCALE } from '../../src/core/physics-engine';
 import { normalizeMap } from '../../src/core/map-adapter';
+import { BonkEnvironment } from '../../src/core/environment';
 
 /**
  * P2 — Native joint-model fidelity (DEOBFUSCATION §33.8).
@@ -597,5 +598,97 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
       expect(j.m_upperTranslation).toBe(0);
       expect(j.m_lowerTranslation).toBeLessThanOrEqual(j.m_upperTranslation);
     }
+  });
+
+  it('skips null physicsJoints entries that the exporter emits for unexportable joints', () => {
+    // The mapexporter (Webscripts/mapexporter.js:528-532) pushes a literal
+    // `null` into physicsJoints for any joint it cannot export, keeping
+    // raw-array indices stable. normalizeMap must skip these instead of
+    // throwing on `j.bodyA`, so a map with an unexportable joint still
+    // loads its bodies, spawns and cap zones (#283).
+    const md = normalizeMap({
+      bodies: [
+        { bodyIndex: 0, name: 'wall', type: 'rect', x: 0, y: 0, width: 40, height: 10, static: true },
+      ],
+      spawns: [{ x: 0, y: 0, blue: true, red: true }],
+      physicsJoints: [
+        null,
+        { bodyA: 0, bodyB: -1, type: 'lpj', anchorA: { x: 0, y: 0 } },
+      ],
+    } as any) as any;
+
+    expect(md.joints).toHaveLength(1);
+    // The surviving joint keeps its RAW array index so gear referents and
+    // the engine's createdJoints resolution stay consistent.
+    expect(md.joints[0].name).toBe('joint_1');
+    expect(md.joints[0].type).toBe('lpj');
+    expect(md.joints[0].isGround).toBe(true);
+
+    const e = makeEngine();
+    const bm = new Map<string, any>();
+    for (const b of md.bodies) { e.addBody(b); bm.set(b.name, e.getBodyMap().get(b.name)); }
+    const warnings = captureWarn(() => {
+      for (const j of md.joints) { e.addJoint(j, bm); }
+    });
+    expect(warnings.filter(w => /unknown joint type|unknown body|no ground/i.test(w))).toHaveLength(0);
+  });
+
+  it('keeps gear referents indexed by the raw physicsJoints array when nulls are skipped', () => {
+    // The gear's ja/jb are indices into the RAW exported physicsJoints array
+    // (which includes the null the exporter pushed at position 0). Filtering
+    // the null must not re-number the surviving joints, or joint_1/joint_2
+    // would silently mis-wire to the wrong referents (#283).
+    const e = makeEngine();
+    const md = normalizeMap({
+      bodies: [
+        { bodyIndex: 0, name: 'wall', type: 'rect', x: 0, y: 0, width: 40, height: 10, static: true },
+        { bodyIndex: 1, name: 'gate', type: 'rect', x: 100, y: 0, width: 20, height: 20, static: false, density: 1 },
+      ],
+      spawns: [{ x: 0, y: 0, blue: true, red: true }],
+      physicsJoints: [
+        null,
+        { bodyA: 0, bodyB: 1, type: 'rv', anchorA: { x: 0, y: 0 } },
+        { bodyA: 0, bodyB: 1, type: 'rv', anchorA: { x: 100, y: 0 } },
+        { bodyA: 0, bodyB: 1, type: 'g', ja: 1, jb: 2, ratio: 3 },
+      ],
+    } as any) as any;
+
+    const bm = new Map<string, any>();
+    for (const b of md.bodies) { e.addBody(b); bm.set(b.name, e.getBodyMap().get(b.name)); }
+    const warnings = captureWarn(() => {
+      for (const j of md.joints) { e.addJoint(j, bm); }
+    });
+    expect(warnings).toHaveLength(0);
+    const gear = (e as any).createdJoints.get('joint_3');
+    expect(gear).toBeTruthy();
+    expect(gear.m_type).toBe(6);
+    expect(gear.m_ratio).toBe(3);
+    // Raw indices 1 and 2 are the two revolute referents, NOT the post-filter
+    // positions 0 and 1.
+    expect(gear.m_revolute1).toBe((e as any).createdJoints.get('joint_1'));
+    expect(gear.m_revolute2).toBe((e as any).createdJoints.get('joint_2'));
+  });
+
+  it('constructs a BonkEnvironment from a map with a null joint without throwing', () => {
+    // The programmatic mapData path (environment.ts) calls normalizeMap
+    // unguarded, so a map with an unexportable joint must never crash the
+    // BonkEnvironment constructor (#283).
+    const exportedMap = {
+      bodies: [
+        { bodyIndex: 0, name: 'wall', type: 'rect', x: 0, y: 0, width: 40, height: 10, static: true },
+      ],
+      spawns: [{ x: 0, y: 0, blue: true, red: true }],
+      physicsJoints: [
+        null,
+        { bodyA: 0, bodyB: -1, type: 'lpj', anchorA: { x: 0, y: 0 } },
+      ],
+    };
+    let env: BonkEnvironment | undefined;
+    expect(() => {
+      env = new BonkEnvironment({ mapData: exportedMap as any, numOpponents: 0, seed: 1, maxTicks: 10 });
+    }).not.toThrow();
+    // The map is actually used (not silently replaced by the box fallback).
+    expect((env as any).config.mapData.joints).toHaveLength(1);
+    expect((env as any).config.mapData.bodies.map((b: any) => b.name)).toContain('wall');
   });
 });

--- a/tests/integration/physics-fidelity-p2.test.ts
+++ b/tests/integration/physics-fidelity-p2.test.ts
@@ -745,4 +745,37 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
     expect(md.bodies.map((b: any) => b.name)).toContain('wall');
     expect(md.joints).toBeUndefined();
   });
+
+  it('tolerates a sparse physicsJoints array (holes iterate as undefined)', () => {
+    // A programmatic mapData can hand normalizeMap a sparse physicsJoints;
+    // array holes iterate as `undefined` and must be skipped like nulls, not
+    // reach j.bodyA and throw the #283 TypeError (#283).
+    const md = normalizeMap({
+      bodies: [
+        { bodyIndex: 0, name: 'wall', type: 'rect', x: 0, y: 0, width: 40, height: 10, static: true },
+      ],
+      spawns: [{ x: 0, y: 0, blue: true, red: true }],
+      physicsJoints: [
+        null,
+        ,
+        { bodyA: 0, bodyB: -1, type: 'lpj', anchorA: { x: 0, y: 0 } },
+      ],
+    } as any) as any;
+
+    expect(md).toBeTruthy();
+    expect(md.joints).toHaveLength(1);
+    // The surviving joint keeps its RAW array index (2), not the post-filter
+    // position 0.
+    expect(md.joints[0].name).toBe('joint_2');
+    expect(md.joints[0].type).toBe('lpj');
+    expect(md.joints[0].isGround).toBe(true);
+
+    const e = makeEngine();
+    const bm = new Map<string, any>();
+    for (const b of md.bodies) { e.addBody(b); bm.set(b.name, e.getBodyMap().get(b.name)); }
+    const warnings = captureWarn(() => {
+      for (const j of md.joints) { e.addJoint(j, bm); }
+    });
+    expect(warnings.filter(w => /unknown joint type|unknown body|no ground/i.test(w))).toHaveLength(0);
+  });
 });

--- a/tests/integration/physics-fidelity-p2.test.ts
+++ b/tests/integration/physics-fidelity-p2.test.ts
@@ -691,4 +691,58 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
     expect((env as any).config.mapData.joints).toHaveLength(1);
     expect((env as any).config.mapData.bodies.map((b: any) => b.name)).toContain('wall');
   });
+
+  it('drops a gear whose referents point at skipped null entries, with a warning', () => {
+    // A gear's ja/jb are raw physicsJoints indices; when they land on a null
+    // the exporter emitted, the referents resolve to nothing and the engine
+    // must drop the gear with a warn instead of constructing a broken joint.
+    const e = makeEngine();
+    const md = normalizeMap({
+      bodies: [
+        { bodyIndex: 0, name: 'wall', type: 'rect', x: 0, y: 0, width: 40, height: 10, static: true },
+        { bodyIndex: 1, name: 'gate', type: 'rect', x: 100, y: 0, width: 20, height: 20, static: false, density: 1 },
+      ],
+      spawns: [{ x: 0, y: 0, blue: true, red: true }],
+      physicsJoints: [
+        null,
+        { bodyA: 0, bodyB: 1, type: 'rv', anchorA: { x: 0, y: 0 } },
+        null,
+        { bodyA: 0, bodyB: 1, type: 'g', ja: 0, jb: 2, ratio: 3 },
+      ],
+    } as any) as any;
+
+    // The gear keeps its raw index (joint_3) but neither referent resolves
+    // because src[0] and src[2] are the skipped nulls.
+    const gearDef = md.joints.find((j: any) => j.type === 'g');
+    expect(gearDef).toBeTruthy();
+    expect(gearDef.name).toBe('joint_3');
+    expect(gearDef.jointA).toBeUndefined();
+    expect(gearDef.jointB).toBeUndefined();
+
+    const bm = new Map<string, any>();
+    for (const b of md.bodies) { e.addBody(b); bm.set(b.name, e.getBodyMap().get(b.name)); }
+    const warnings = captureWarn(() => {
+      for (const j of md.joints) { e.addJoint(j, bm); }
+    });
+    expect(warnings.some(w => /Gear joint references missing referent joints/.test(w))).toBe(true);
+    expect((e as any).createdJoints.has('joint_3')).toBe(false);
+  });
+
+  it('handles an all-null physicsJoints array without crashing', () => {
+    // Every entry skipped -> joints is empty and the MapDef drops the field
+    // entirely (joints.length > 0 guard), while the map still normalizes.
+    const md = normalizeMap({
+      bodies: [
+        { bodyIndex: 0, name: 'wall', type: 'rect', x: 0, y: 0, width: 40, height: 10, static: true },
+      ],
+      spawns: [{ x: 0, y: 0, blue: true, red: true }],
+      physicsJoints: [null, null, null],
+    } as any) as any;
+
+    expect(md).toBeTruthy();
+    expect(md.name).toBe('Untitled Map');
+    expect(md.spawnPoints).toBeTruthy();
+    expect(md.bodies.map((b: any) => b.name)).toContain('wall');
+    expect(md.joints).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Closes #283