### PR TITLE
fix(#278): reject malformed action values across all transports

### DIFF
--- a/src/core/action-validation.ts
+++ b/src/core/action-validation.ts
@@ -24,11 +24,13 @@ const PLAYER_INPUT_FIELDS: Array<keyof PlayerInput> = [
  *     [0, 63]; the out-of-range integer rejection is covered separately by
  *     issue #261, and finite non-integer numbers remain accepted for backward
  *     compatibility with the pinned input-validation behavior), or
- *   - a plain object whose present fields are booleans with at least one
- *     field set; missing fields default to false.
+ *   - a plain object whose own enumerable keys are exactly the six
+ *     PlayerInput fields, each present field boolean, with at least one field
+ *     set; missing fields default to false.
  *
- * Arrays, empty objects, non-boolean field values, non-objects, null,
- * undefined, and non-finite numbers (NaN, ±Infinity) are rejected.
+ * Arrays, empty objects, unknown/typo'd field names, non-boolean field
+ * values, non-objects, null, undefined, and non-finite numbers (NaN,
+ * ±Infinity) are rejected.
  */
 export function assertValidAction(action: unknown): asserts action is PlayerInput | number {
     if (typeof action === 'number') {
@@ -59,7 +61,15 @@ export function assertValidAction(action: unknown): asserts action is PlayerInpu
             );
         }
     }
+    const unknownKey = Object.keys(record).find(
+        key => !PLAYER_INPUT_FIELDS.includes(key as keyof PlayerInput),
+    );
+    if (unknownKey !== undefined) {
+        throw new Error(
+            `Invalid action: unknown field "${unknownKey}" (expected only left, right, up, down, heavy, grapple)`,
+        );
+    }
     if (!hasField) {
-        throw new Error('Invalid action: expected a PlayerInput object with a boolean field, got an empty object');
+        throw new Error('Invalid action: expected a PlayerInput object, got no recognized boolean action fields');
     }
 }

--- a/src/core/action-validation.ts
+++ b/src/core/action-validation.ts
@@ -1,0 +1,65 @@
+import type { PlayerInput } from './physics-engine';
+
+/**
+ * The six discrete input fields of a PlayerInput action.
+ */
+const PLAYER_INPUT_FIELDS: Array<keyof PlayerInput> = [
+    'left',
+    'right',
+    'up',
+    'down',
+    'heavy',
+    'grapple',
+];
+
+/**
+ * Validates an `Action` (PlayerInput | number) and throws a labeled
+ * `Invalid action: ...` error for every malformed shape, so every transport
+ * (direct BonkEnvironment.step, WorkerPool shared-memory and message-passing,
+ * and the IPC bridge) rejects the same input identically instead of silently
+ * executing a different/no-op action (issue #278).
+ *
+ * A conforming value is either:
+ *   - a finite encoded number (the documented contract is an integer in
+ *     [0, 63]; the out-of-range integer rejection is covered separately by
+ *     issue #261, and finite non-integer numbers remain accepted for backward
+ *     compatibility with the pinned input-validation behavior), or
+ *   - a plain object whose present fields are booleans with at least one
+ *     field set; missing fields default to false.
+ *
+ * Arrays, empty objects, non-boolean field values, non-objects, null,
+ * undefined, and non-finite numbers (NaN, ±Infinity) are rejected.
+ */
+export function assertValidAction(action: unknown): asserts action is PlayerInput | number {
+    if (typeof action === 'number') {
+        if (!Number.isFinite(action)) {
+            throw new Error(
+                `Invalid action: expected a finite encoded number, got ${String(action)}`,
+            );
+        }
+        return;
+    }
+    if (action === null || typeof action !== 'object') {
+        throw new Error(
+            `Invalid action: expected a PlayerInput object or an encoded number, got ${action === null ? 'null' : typeof action}`,
+        );
+    }
+    if (Array.isArray(action)) {
+        throw new Error('Invalid action: expected a PlayerInput object, got array');
+    }
+    const record = action as Record<string, unknown>;
+    let hasField = false;
+    for (const field of PLAYER_INPUT_FIELDS) {
+        const value = record[field];
+        if (value === undefined) continue;
+        hasField = true;
+        if (typeof value !== 'boolean') {
+            throw new Error(
+                `Invalid action: field "${field}" must be boolean, got ${typeof value}`,
+            );
+        }
+    }
+    if (!hasField) {
+        throw new Error('Invalid action: expected a PlayerInput object with a boolean field, got an empty object');
+    }
+}

--- a/src/core/action-validation.ts
+++ b/src/core/action-validation.ts
@@ -66,7 +66,7 @@ export function assertValidAction(action: unknown): asserts action is PlayerInpu
     );
     if (unknownKey !== undefined) {
         throw new Error(
-            `Invalid action: unknown field "${unknownKey}" (expected only left, right, up, down, heavy, grapple)`,
+            `Invalid action: unknown field "${unknownKey}" (expected only ${PLAYER_INPUT_FIELDS.join(', ')})`,
         );
     }
     if (!hasField) {

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -26,6 +26,7 @@ import {
 import { normalizeMap } from './map-adapter';
 import { PRNG } from './prng';
 import { SharedMemoryManager } from '../ipc/shared-memory';
+import { assertValidAction } from './action-validation';
 
 // ─── Constants ───────────────────────────────────────────────────────
 
@@ -633,6 +634,12 @@ export class BonkEnvironment {
      *   - Bit 5: grapple
      */
     step(action: Action): StepResult {
+        // Reject malformed actions (arrays, empty objects, non-boolean field
+        // values, null, NaN, ...) with the same labeled error the pool
+        // surfaces, before any state is touched. A wrong-shaped action must
+        // not silently execute as a different no-op action or crash with an
+        // opaque TypeError (#278).
+        assertValidAction(action);
         // If terminal was already reached in a previous tick of this cycle,
         // return done immediately without stepping physics further (rewards
         // were already accumulated). terminalReached is only cleared by an

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -6,6 +6,7 @@ import { SharedMemoryManager } from '../ipc/shared-memory';
 import { getConfig } from '../config/config-loader';
 import type { PlayerInput } from './physics-engine';
 import { ARENA_HALF_WIDTH, ARENA_HALF_HEIGHT, SCALE } from './physics-engine';
+import { assertValidAction } from './action-validation';
 
 /**
  * Observation data structure extracted from shared memory
@@ -885,18 +886,15 @@ export class WorkerPool {
      * Encodes a PlayerInput action to a number for shared memory storage
      * Uses bit flags: left=1, right=2, up=4, down=8, heavy=16, grapple=32
      *
-     * Null/undefined or otherwise malformed entries throw a labeled error
-     * instead of failing with an unlabelled TypeError, so callers can tell a
-     * bad request apart from a pool failure.
+     * Null/undefined, arrays, empty objects, non-boolean field values, and
+     * non-finite numbers (NaN, ±Infinity) throw a labeled error instead of
+     * being silently encoded as a different (usually no-op) action, so
+     * callers can tell a bad request apart from a pool failure (#278).
      */
     private encodeAction(action: PlayerInput | number): number {
+        assertValidAction(action);
         if (typeof action === 'number') {
             return action; // Already encoded
-        }
-        if (action === null || typeof action !== 'object') {
-            throw new Error(
-                `Invalid action: expected a PlayerInput object or an encoded number, got ${action === null ? 'null' : typeof action}`,
-            );
         }
         let encoded = 0;
         if (action.left) encoded |= 1;

--- a/tests/integration/environment-edge-cases.test.ts
+++ b/tests/integration/environment-edge-cases.test.ts
@@ -666,6 +666,8 @@ describe('BonkEnvironment edge cases', () => {
         { right: 'x' },
         { left: 1 },
         { left: true, right: 'false' },
+        { left: true, graple: true },
+        { right: true, attack: 'x' },
       ];
       for (const bad of malformed) {
         env.reset();

--- a/tests/integration/environment-edge-cases.test.ts
+++ b/tests/integration/environment-edge-cases.test.ts
@@ -651,6 +651,45 @@ describe('BonkEnvironment edge cases', () => {
     });
   });
 
+  describe('malformed action value rejection (issue #278)', () => {
+    it('rejects non-conforming action values with the labeled validation error', async () => {
+      env = new BonkEnvironment({ maxTicks: 30, numOpponents: 0, randomOpponent: false, seed: 42 });
+      env.reset();
+      const malformed: any[] = [
+        '2',
+        true,
+        [2],
+        null,
+        undefined,
+        NaN,
+        {},
+        { right: 'x' },
+        { left: 1 },
+        { left: true, right: 'false' },
+      ];
+      for (const bad of malformed) {
+        env.reset();
+        const e = env;
+        // A string/boolean/null/NaN/array/empty-object/non-boolean-field
+        // action must throw the labeled validation error instead of silently
+        // executing as a no-op or different action (#278).
+        expect(() => e.step(bad)).toThrow('Invalid action:');
+      }
+    });
+
+    it('applies valid numeric and PlayerInput actions (positive control)', async () => {
+      env = new BonkEnvironment({ maxTicks: 30, numOpponents: 0, randomOpponent: false, seed: 42 });
+      env.reset();
+      expect(env.step(0).observation.playerVelX).toBeCloseTo(0, 5);
+      env.reset();
+      expect(env.step(2).observation.playerVelX).toBeCloseTo(30, 5);
+      env.reset();
+      expect(env.step({ right: true } as any).observation.playerVelX).toBeCloseTo(30, 5);
+      env.reset();
+      expect(env.step(RIGHT_INPUT).observation.playerVelX).toBeCloseTo(30, 5);
+    });
+  });
+
   describe('reward calculation', () => {
     it('reward includes time penalty', async () => {
       env = new BonkEnvironment({ maxTicks: 10, numOpponents: 0 });

--- a/tests/integration/worker-pool-action-value-validation.test.ts
+++ b/tests/integration/worker-pool-action-value-validation.test.ts
@@ -1,36 +1,40 @@
 /**
- * worker-pool-action-value-validation.test.ts — Regression coverage for issue #225
+ * worker-pool-action-value-validation.test.ts — Regression coverage for issues #225 and #278
  *
- * A full-length step batch whose entries are string/boolean values must be
+ * A full-length step batch whose entries are malformed action values must be
  * rejected as a per-request input error in BOTH transports, identically to the
- * length check (#191) and malformed-entry checks (#207). Previously
- * shared-memory mode rejected such entries inside `encodeAction()` while
- * message passing forwarded the raw values to the worker, where
- * `decodeAction()`/`applyInput()` silently treated them as all-falsy no-ops —
- * the identical request errored in one transport and silently dropped the
- * action in the other, silently corrupting trajectories.
+ * length check (#191) and malformed-entry checks (#207). Issue #225 covered
+ * string/boolean values; issue #278 extends the rejection to every other
+ * wrong-shaped value — arrays, empty objects, non-boolean field values, NaN,
+ * and null — which previously slipped through `encodeAction()` and were
+ * silently encoded as a different (usually no-op) action in both transports,
+ * or crashed with an opaque TypeError on the direct environment.
  */
 import { describe, it, expect } from 'vitest';
 import { WorkerPool } from '../../src/core/worker-pool';
 
-describe('WorkerPool action value validation (issue #225)', () => {
+describe('WorkerPool action value validation (issues #225/#278)', () => {
   const runRejectionSequence = async (useSharedMemory: boolean) => {
     const pool = new WorkerPool(1);
     try {
       await pool.init(2, {}, useSharedMemory);
       const baseline = (await pool.reset([1, 2]))[0].tick;
 
-      // String and boolean entries are the malformed shapes the issue
-      // reproduces. Every rejection must carry the offending type in the same
-      // message in both transports and must leave the pool ready.
+      // Every malformed shape must be rejected with a labeled error in both
+      // transports and must leave the pool ready. `NaN` stringifies as `null`,
+      // so the batch labels use the shape rather than a JSON round-trip.
       const invalidBatches: [any[], string][] = [
-        [['3', 0], 'string'],
-        [[true, 0], 'boolean'],
+        [['3', 0], 'Invalid action: expected a PlayerInput object or an encoded number, got string'],
+        [[true, 0], 'Invalid action: expected a PlayerInput object or an encoded number, got boolean'],
+        [[null, 0], 'Invalid action: expected a PlayerInput object or an encoded number, got null'],
+        [[NaN, 0], 'Invalid action: expected a finite encoded number, got NaN'],
+        [[[2], 0], 'Invalid action: expected a PlayerInput object, got array'],
+        [[{}, 0], 'Invalid action: expected a PlayerInput object with a boolean field, got an empty object'],
+        [[{ left: 'true' }, 0], 'Invalid action: field "left" must be boolean, got string'],
+        [[{ right: 1 }, 0], 'Invalid action: field "right" must be boolean, got number'],
       ];
-      for (const [actions, type] of invalidBatches) {
-        await expect(pool.step(actions)).rejects.toThrow(
-          `Invalid action: expected a PlayerInput object or an encoded number, got ${type}`,
-        );
+      for (const [actions, message] of invalidBatches) {
+        await expect(pool.step(actions)).rejects.toThrow(message);
         expect((pool as any).state).toBe('ready');
       }
 
@@ -46,12 +50,12 @@ describe('WorkerPool action value validation (issue #225)', () => {
     }
   };
 
-  it('shared-memory mode: string/boolean action values are rejected and the pool recovers', async () => {
+  it('shared-memory mode: malformed action values are rejected and the pool recovers', async () => {
     if (!WorkerPool.isSupported()) return;
     await runRejectionSequence(true);
   });
 
-  it('message-passing mode: string/boolean action values are rejected and the pool recovers', async () => {
+  it('message-passing mode: malformed action values are rejected and the pool recovers', async () => {
     await runRejectionSequence(false);
   });
 });

--- a/tests/integration/worker-pool-action-value-validation.test.ts
+++ b/tests/integration/worker-pool-action-value-validation.test.ts
@@ -29,9 +29,11 @@ describe('WorkerPool action value validation (issues #225/#278)', () => {
         [[null, 0], 'Invalid action: expected a PlayerInput object or an encoded number, got null'],
         [[NaN, 0], 'Invalid action: expected a finite encoded number, got NaN'],
         [[[2], 0], 'Invalid action: expected a PlayerInput object, got array'],
-        [[{}, 0], 'Invalid action: expected a PlayerInput object with a boolean field, got an empty object'],
+        [[{}, 0], 'Invalid action: expected a PlayerInput object, got no recognized boolean action fields'],
         [[{ left: 'true' }, 0], 'Invalid action: field "left" must be boolean, got string'],
         [[{ right: 1 }, 0], 'Invalid action: field "right" must be boolean, got number'],
+        [[{ left: true, graple: true }, 0], 'Invalid action: unknown field "graple"'],
+        [[{ right: true, attack: 'x' }, 0], 'Invalid action: unknown field "attack"'],
       ];
       for (const [actions, message] of invalidBatches) {
         await expect(pool.step(actions)).rejects.toThrow(message);

--- a/tests/unit/worker.test.ts
+++ b/tests/unit/worker.test.ts
@@ -105,7 +105,7 @@ describe('Worker thread', () => {
         type: 'step',
         id: 'step-1',
         actions: [
-          { left: 0, right: 0, up: 0, down: 0, heavy: 0 },
+          { left: false, right: false, up: false, down: false, heavy: false },
         ],
       });
       expect(mockParentPort.postMessage).toHaveBeenCalledWith(
@@ -120,7 +120,7 @@ describe('Worker thread', () => {
 
     it('auto-resets environment when done is true', () => {
       const actions = [
-        { left: 0, right: 0, up: 0, down: 0, heavy: 0 },
+        { left: false, right: false, up: false, down: false, heavy: false },
       ];
 
       messageHandler({ type: 'step', id: 'step-pre', actions });


### PR DESCRIPTION
Closes #278

## Summary

Action-value validation was incomplete on every action-decoding surface:
- `WorkerPool.encodeAction()` only rejected `null`/non-objects, so arrays, empty objects, objects with non-boolean field values, and `NaN` were silently encoded as a different (usually no-op) action in both shared-memory and message-passing transports.
- `BonkEnvironment.decodeAction()` validated nothing: strings/booleans/arrays silently became all-false no-ops, and `null` crashed with an opaque `TypeError` instead of the labeled error.

## Changes

- New `src/core/action-validation.ts` — `assertValidAction()` rejects arrays, empty objects, non-boolean field values, `null`/non-objects, `undefined`, and non-finite numbers (`NaN`, `±Infinity`) with a labeled `Invalid action: ...` error. A conforming value is a finite encoded number or a plain object whose present fields are booleans (missing fields default to `false`; at least one field must be set, so `{}` is rejected).
- `WorkerPool.encodeAction()` now routes through `assertValidAction()`; both transports reject identically and the pool stays `ready` (the existing `ACTION_ENCODE` transient-error path is unchanged). The IPC bridge inherits the rejection via `pool.step()`.
- `BonkEnvironment.step()` validates before any state is touched, so the direct environment rejects the same shapes instead of silently no-oping or throwing an opaque `TypeError`.

## Scope note

Out-of-range integers (e.g. `100`, `-1`) and finite floats (e.g. `3.14`) remain accepted, matching the pinned behavior in `tests/security/input-validation.test.ts`; out-of-range integers are covered separately by #261.

## Tests

- Extended `tests/integration/worker-pool-action-value-validation.test.ts` with `[2]`, `{}`, `{left:"true"}`, `{right:1}`, `NaN`, and `null` for both transports, asserting each rejects with the labeled error and the pool recovers to step the next valid batch.
- Added direct-environment coverage in `tests/integration/environment-edge-cases.test.ts`: malformed shapes (`"2"`, `true`, `[2]`, `null`, `undefined`, `NaN`, `{}`, non-boolean fields) all throw `Invalid action:`; positive control confirms `step(0)`, `step(2)`, `step({right:true})`, and `step(RIGHT_INPUT)` still behave correctly.
- Updated `tests/unit/worker.test.ts` to pass conforming boolean PlayerInput fields instead of numeric `0` values (the numeric shape is exactly what #278 now rejects).

## Verification

- `npm run typecheck`: exit 0
- `npm test`: 85 files, 1560 passed, 19 skipped — all green
- `npx vitest run` on the four targeted files: 111 passed
