### PR TITLE
fix(#269): validate WorkerPool.numWorkers and guard config auto-detect

### DIFF
--- a/src/config/config-loader.ts
+++ b/src/config/config-loader.ts
@@ -1075,13 +1075,19 @@ export function loadConfig(projectRoot?: string): AppConfig {
     // Layer 4: CLI flags
     config = parseCliFlags(config);
 
-    // Resolve numWorkers=0 to actual CPU count. Clamp maxWorkers to >= 1 and
-    // clamp negative numWorkers so a misconfigured workerPool can never
-    // resolve the auto-detect to 0 (which silently disables the pool) (#269).
+    // Resolve numWorkers=0 to actual CPU count. Sanitize every configured
+    // value to a positive integer so a misconfigured workerPool can never
+    // silently disable the pool or defer a NaN/float to the WorkerPool runtime
+    // guard: non-numeric maxWorkers falls back to the CPU count, and negative,
+    // non-numeric, or fractional numWorkers clamp/floor to >= 1 (#269).
     if (config.workerPool.numWorkers === 0) {
-        config.workerPool.numWorkers = Math.max(1, Math.min(os.cpus().length, Math.max(1, Math.floor(config.workerPool.maxWorkers))));
-    } else if (config.workerPool.numWorkers < 0) {
+        config.workerPool.numWorkers = Number.isFinite(config.workerPool.maxWorkers)
+            ? Math.max(1, Math.min(os.cpus().length, Math.max(1, Math.floor(config.workerPool.maxWorkers))))
+            : Math.max(1, os.cpus().length);
+    } else if (!Number.isFinite(config.workerPool.numWorkers) || config.workerPool.numWorkers < 1) {
         config.workerPool.numWorkers = 1;
+    } else if (!Number.isInteger(config.workerPool.numWorkers)) {
+        config.workerPool.numWorkers = Math.max(1, Math.floor(config.workerPool.numWorkers));
     }
 
     cachedConfig = config;

--- a/src/config/config-loader.ts
+++ b/src/config/config-loader.ts
@@ -1075,9 +1075,13 @@ export function loadConfig(projectRoot?: string): AppConfig {
     // Layer 4: CLI flags
     config = parseCliFlags(config);
 
-    // Resolve numWorkers=0 to actual CPU count
+    // Resolve numWorkers=0 to actual CPU count. Clamp maxWorkers to >= 1 and
+    // clamp negative numWorkers so a misconfigured workerPool can never
+    // resolve the auto-detect to 0 (which silently disables the pool) (#269).
     if (config.workerPool.numWorkers === 0) {
-        config.workerPool.numWorkers = Math.min(os.cpus().length, config.workerPool.maxWorkers);
+        config.workerPool.numWorkers = Math.max(1, Math.min(os.cpus().length, Math.max(1, Math.floor(config.workerPool.maxWorkers))));
+    } else if (config.workerPool.numWorkers < 0) {
+        config.workerPool.numWorkers = 1;
     }
 
     cachedConfig = config;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -206,6 +206,12 @@ export class WorkerPool {
         if (!Number.isInteger(totalEnvs) || totalEnvs < 1) {
             throw new Error(`Invalid environment count: expected a positive integer, got ${totalEnvs}`);
         }
+        // A zero or negative numWorkers would otherwise silently produce a
+        // 'ready' pool with no workers: reset() returns [] and step() rejects
+        // every batch with a count error naming 0 environments (#269).
+        if (!Number.isInteger(this.numWorkers) || this.numWorkers < 1) {
+            throw new Error(`Invalid worker count: expected a positive integer, got ${this.numWorkers}`);
+        }
         await this.closeInternal(); // Clean up existing if re-initialized
         this.state = 'initializing';
         this.failure = null;

--- a/tests/unit/config-loader-env.test.ts
+++ b/tests/unit/config-loader-env.test.ts
@@ -1200,6 +1200,38 @@ describe('config-loader env vars and CLI', () => {
             const cfg = loadConfig(testDir);
             expect(cfg.workerPool.numWorkers).toBe(3);
         });
+
+        it('maxWorkers=0 cannot resolve the auto-detect to 0 (#269)', () => {
+            fs.writeFileSync(configPath, JSON.stringify({
+                workerPool: { maxWorkers: 0 },
+            }));
+            const cfg = loadConfig(testDir);
+            expect(cfg.workerPool.numWorkers).toBeGreaterThanOrEqual(1);
+        });
+
+        it('maxWorkers=0 with numWorkers=0 resolves to at least 1 (#269)', () => {
+            fs.writeFileSync(configPath, JSON.stringify({
+                workerPool: { numWorkers: 0, maxWorkers: 0 },
+            }));
+            const cfg = loadConfig(testDir);
+            expect(cfg.workerPool.numWorkers).toBeGreaterThanOrEqual(1);
+        });
+
+        it('a negative maxWorkers cannot resolve the auto-detect to 0 (#269)', () => {
+            fs.writeFileSync(configPath, JSON.stringify({
+                workerPool: { numWorkers: 0, maxWorkers: -2 },
+            }));
+            const cfg = loadConfig(testDir);
+            expect(cfg.workerPool.numWorkers).toBeGreaterThanOrEqual(1);
+        });
+
+        it('a negative numWorkers in config.json is clamped to >= 1 (#269)', () => {
+            fs.writeFileSync(configPath, JSON.stringify({
+                workerPool: { numWorkers: -1 },
+            }));
+            const cfg = loadConfig(testDir);
+            expect(cfg.workerPool.numWorkers).toBeGreaterThanOrEqual(1);
+        });
     });
 
     // ─── Priority Order ──────────────────────────────────────────────────

--- a/tests/unit/config-loader-env.test.ts
+++ b/tests/unit/config-loader-env.test.ts
@@ -1232,6 +1232,31 @@ describe('config-loader env vars and CLI', () => {
             const cfg = loadConfig(testDir);
             expect(cfg.workerPool.numWorkers).toBeGreaterThanOrEqual(1);
         });
+
+        it('a non-numeric maxWorkers cannot resolve the auto-detect to NaN (#269)', () => {
+            fs.writeFileSync(configPath, JSON.stringify({
+                workerPool: { numWorkers: 0, maxWorkers: 'abc' },
+            }));
+            const cfg = loadConfig(testDir);
+            expect(Number.isInteger(cfg.workerPool.numWorkers)).toBe(true);
+            expect(cfg.workerPool.numWorkers).toBeGreaterThanOrEqual(1);
+        });
+
+        it('a fractional numWorkers in config.json is floored to a positive integer (#269)', () => {
+            fs.writeFileSync(configPath, JSON.stringify({
+                workerPool: { numWorkers: 1.5 },
+            }));
+            const cfg = loadConfig(testDir);
+            expect(cfg.workerPool.numWorkers).toBe(1);
+        });
+
+        it('a non-numeric numWorkers in config.json is clamped to 1 (#269)', () => {
+            fs.writeFileSync(configPath, JSON.stringify({
+                workerPool: { numWorkers: 'abc' },
+            }));
+            const cfg = loadConfig(testDir);
+            expect(cfg.workerPool.numWorkers).toBe(1);
+        });
     });
 
     // ─── Priority Order ──────────────────────────────────────────────────

--- a/tests/unit/worker-pool-failures.test.ts
+++ b/tests/unit/worker-pool-failures.test.ts
@@ -596,4 +596,66 @@ describe('WorkerPool failure state', () => {
       expect(results).toHaveLength(1);
     });
   });
+
+  describe('worker-count validation (#269)', () => {
+    it('rejects a zero-worker pool in message mode with a clear error and no workers', async () => {
+      pool = new WorkerPool(0);
+
+      await expect(pool.init(2, {}, false)).rejects.toThrow(
+        'Invalid worker count: expected a positive integer, got 0',
+      );
+
+      expect(fakes.FakeWorker.instances).toHaveLength(0);
+      expect((pool as any).state).toBe('idle');
+    });
+
+    it('rejects a zero-worker pool in shared-memory mode with the same error and no workers', async () => {
+      pool = new WorkerPool(0);
+
+      await expect(pool.init(2, {}, true)).rejects.toThrow(
+        'Invalid worker count: expected a positive integer, got 0',
+      );
+
+      expect(fakes.FakeWorker.instances).toHaveLength(0);
+      expect(fakes.FakeSharedMemoryManager.instances).toHaveLength(0);
+      expect((pool as any).state).toBe('idle');
+    });
+
+    it('rejects a negative worker count in both transports (no RangeError)', async () => {
+      for (const useShared of [false, true]) {
+        const p = new WorkerPool(-1);
+        await expect(p.init(2, {}, useShared)).rejects.toThrow(
+          'Invalid worker count: expected a positive integer, got -1',
+        );
+        expect(fakes.FakeWorker.instances).toHaveLength(0);
+        expect((p as any).state).toBe('idle');
+        await p.close();
+      }
+    });
+
+    it('rejects a non-integer worker count in both transports', async () => {
+      for (const useShared of [false, true]) {
+        const p = new WorkerPool(1.5);
+        await expect(p.init(2, {}, useShared)).rejects.toThrow(
+          'Invalid worker count: expected a positive integer, got 1.5',
+        );
+        expect(fakes.FakeWorker.instances).toHaveLength(0);
+        await p.close();
+      }
+    });
+
+    it('keeps pools usable after a rejected worker-count init', async () => {
+      pool = new WorkerPool(0);
+      await expect(pool.init(2, {}, true)).rejects.toThrow('Invalid worker count');
+      expect((pool as any).state).toBe('idle');
+      await pool.close();
+
+      const valid = new WorkerPool(2);
+      await valid.init(2, {}, true);
+      expect((valid as any).state).toBe('ready');
+      const observations = await valid.reset();
+      expect(observations).toHaveLength(2);
+      await valid.close();
+    });
+  });
 });


### PR DESCRIPTION
Closes #269