### PR TITLE
fix(#267): make BonkEnv.start() reject overlapping calls

### DIFF
--- a/src/env/bonk-env.ts
+++ b/src/env/bonk-env.ts
@@ -45,6 +45,7 @@ export class BonkEnv {
     private bridge: IpcBridge | null = null;
     private portManager: PortManager;
     private isRunning: boolean = false;
+    private starting: boolean = false;
     private config: BonkEnvConfig;
     private static instanceCount: number = 0;
 
@@ -72,42 +73,43 @@ export class BonkEnv {
      * @returns Promise that resolves when the environment is started
      */
     async start(): Promise<void> {
-        if (this.isRunning) {
+        if (this.isRunning || this.starting) {
             throw new Error(`Environment ${this.id} is already running`);
         }
-        
+
+        // Claim the starting state before the first await so a second
+        // overlapping start() call rejects here immediately instead of
+        // spawning its own worker pool and (in IPC mode) bridge that would
+        // fight the first call for this.pool/this.bridge/this.port, orphaning
+        // a bound IPC server and an unclosed worker pool (issue #267). The
+        // flag is cleared in `finally`, so a failed start can be retried.
+        this.starting = true;
+
         console.log(`[BonkEnv:${this.id}] Starting on port ${this.port}`);
-        
-        // Create worker pool
-        this.pool = new WorkerPool();
-        
-        // Initialize the worker pool with the configured number of envs,
-        // forwarding the per-env config over the global defaults so configured
-        // environment, reward, and engine-tuning values all reach the workers.
-        const useSharedMemory = this.config.useSharedMemory ?? getConfig().workerPool.useSharedMemory;
-        const override = this.config.config ?? {};
-        const envConfig = resolveEnvironmentConfig(override);
-        const engineSections = mergeEngineSections(override);
+
         try {
+            // Create worker pool
+            this.pool = new WorkerPool();
+
+            // Initialize the worker pool with the configured number of envs,
+            // forwarding the per-env config over the global defaults so configured
+            // environment, reward, and engine-tuning values all reach the workers.
+            const useSharedMemory = this.config.useSharedMemory ?? getConfig().workerPool.useSharedMemory;
+            const override = this.config.config ?? {};
+            const envConfig = resolveEnvironmentConfig(override);
+            const engineSections = mergeEngineSections(override);
             await this.pool.init(
                 this.config.numEnvs ?? 1,
                 { ...envConfig, ...engineSections },
                 useSharedMemory
             );
-        } catch (error) {
-            // init() can spawn workers before rejecting. Always release both
-            // the partially created pool and the port reserved in the constructor.
-            await this.stop();
-            throw error;
-        }
 
-        // When IPC server mode is requested (enableIpcServer), bind an
-        // IpcBridge to this.port so external clients can connect. start()
-        // does not resolve until the Router socket is actually bound, so
-        // isActive() can never report success before the advertised port is
-        // reachable. A bind failure (e.g. EADDRINUSE) rejects start() instead
-        // of silently completing (issue #223).
-        try {
+            // When IPC server mode is requested (enableIpcServer), bind an
+            // IpcBridge to this.port so external clients can connect. start()
+            // does not resolve until the Router socket is actually bound, so
+            // isActive() can never report success before the advertised port is
+            // reachable. A bind failure (e.g. EADDRINUSE) rejects start() instead
+            // of silently completing (issue #223).
             if (this.config.enableIpcServer === true) {
                 const bridge = new IpcBridge({ server: { port: this.port } });
                 this.bridge = bridge;
@@ -146,13 +148,18 @@ export class BonkEnv {
                 );
                 console.log(`[BonkEnv:${this.id}] IPC server bound to port ${this.port}`);
             }
+
+            this.isRunning = true;
+            console.log(`[BonkEnv:${this.id}] Started successfully`);
         } catch (error) {
+            // init() can spawn workers and, in IPC mode, bind the socket
+            // before rejecting. Always release the partially created pool and
+            // bridge and the port reserved in the constructor.
             await this.stop();
             throw error;
+        } finally {
+            this.starting = false;
         }
-        
-        this.isRunning = true;
-        console.log(`[BonkEnv:${this.id}] Started successfully`);
     }
 
     /**

--- a/src/env/bonk-env.ts
+++ b/src/env/bonk-env.ts
@@ -39,13 +39,18 @@ export class BonkEnv {
     public readonly id: string;
     
     /** Port number this environment is running on (if IPC server enabled) */
-    public readonly port: number;
+    public port: number;
     
     private pool: WorkerPool | null = null;
     private bridge: IpcBridge | null = null;
     private portManager: PortManager;
     private isRunning: boolean = false;
-    private starting: boolean = false;
+    // Non-null while a start() is in flight. Doubles as the "starting" state
+    // guard (a second start() rejects with "already starting") and lets stop()
+    // await the in-flight start instead of tearing the pool/port out from under
+    // it. Cleared in the wrapper's finally once the attempt settles, so a
+    // failed start can be retried (issue #267).
+    private startPromise: Promise<void> | null = null;
     private config: BonkEnvConfig;
     private static instanceCount: number = 0;
 
@@ -73,23 +78,65 @@ export class BonkEnv {
      * @returns Promise that resolves when the environment is started
      */
     async start(): Promise<void> {
-        if (this.isRunning || this.starting) {
+        if (this.isRunning) {
             throw new Error(`Environment ${this.id} is already running`);
         }
+        if (this.startPromise) {
+            throw new Error(`Environment ${this.id} is already starting`);
+        }
 
-        // Claim the starting state before the first await so a second
-        // overlapping start() call rejects here immediately instead of
-        // spawning its own worker pool and (in IPC mode) bridge that would
-        // fight the first call for this.pool/this.bridge/this.port, orphaning
-        // a bound IPC server and an unclosed worker pool (issue #267). The
-        // flag is cleared in `finally`, so a failed start can be retried.
-        this.starting = true;
+        // A failed prior start released the port reserved in the constructor
+        // (teardownFailedStart), so a retry must re-claim it before binding.
+        // If the port was handed to another env in the meantime, allocate a
+        // fresh one instead of binding a port the PortManager no longer
+        // considers ours (issue #267 review).
+        this.reservePortForStart();
 
+        // Assign startPromise before the first await so a second overlapping
+        // start() call rejects immediately instead of spawning its own worker
+        // pool and (in IPC mode) bridge that would fight this call for
+        // this.pool/this.bridge/this.port (issue #267).
+        const startPromise = this.performStart();
+        this.startPromise = startPromise;
+        try {
+            await startPromise;
+        } finally {
+            if (this.startPromise === startPromise) {
+                this.startPromise = null;
+            }
+        }
+    }
+
+    /**
+     * Re-claims the port allocated in the constructor. The reservation is
+     * released when a start attempt fails, so a retry must reserve it again
+     * before spawning anything; if the port was allocated to another env in
+     * the meantime, allocate a fresh port for this env.
+     */
+    private reservePortForStart(): void {
+        if (this.portManager.isAllocated(this.port)) {
+            return;
+        }
+        try {
+            this.portManager.reserve(this.port);
+        } catch {
+            this.port = this.portManager.allocate();
+        }
+    }
+
+    /**
+     * Body of a start() attempt. Runs with this.startPromise already set, so
+     * the failure path must NOT call the public stop() — stop() awaits the
+     * in-flight start() and would deadlock. Teardown goes through
+     * teardownFailedStart() instead.
+     */
+    private async performStart(): Promise<void> {
         console.log(`[BonkEnv:${this.id}] Starting on port ${this.port}`);
 
         try {
             // Create worker pool
-            this.pool = new WorkerPool();
+            const pool = new WorkerPool();
+            this.pool = pool;
 
             // Initialize the worker pool with the configured number of envs,
             // forwarding the per-env config over the global defaults so configured
@@ -98,7 +145,7 @@ export class BonkEnv {
             const override = this.config.config ?? {};
             const envConfig = resolveEnvironmentConfig(override);
             const engineSections = mergeEngineSections(override);
-            await this.pool.init(
+            await pool.init(
                 this.config.numEnvs ?? 1,
                 { ...envConfig, ...engineSections },
                 useSharedMemory
@@ -117,7 +164,7 @@ export class BonkEnv {
                 // its numEnvs/config/useSharedMemory instead of spawning a
                 // second set of default-config workers (no double workers,
                 // env config forwarded).
-                bridge.adoptPool(this.pool!, this.config.numEnvs ?? 1, { config: envConfig, useSharedMemory });
+                bridge.adoptPool(pool, this.config.numEnvs ?? 1, { config: envConfig, useSharedMemory });
                 // start() keeps the serve loop alive until close(); bind
                 // failures surface through bridge.ready, so await ready
                 // rather than the serve promise.
@@ -153,13 +200,39 @@ export class BonkEnv {
             console.log(`[BonkEnv:${this.id}] Started successfully`);
         } catch (error) {
             // init() can spawn workers and, in IPC mode, bind the socket
-            // before rejecting. Always release the partially created pool and
-            // bridge and the port reserved in the constructor.
-            await this.stop();
+            // before rejecting. Release everything this attempt created and
+            // the constructor's port reservation so a retry re-acquires it.
+            await this.teardownFailedStart();
             throw error;
-        } finally {
-            this.starting = false;
         }
+    }
+
+    /**
+     * Releases the pool, bridge, and port reservation a failed start attempt
+     * created. Runs while this.startPromise is still set, so it must not go
+     * through the public stop() (which awaits the in-flight start and would
+     * deadlock).
+     */
+    private async teardownFailedStart(): Promise<void> {
+        if (this.bridge) {
+            try {
+                await this.bridge.close();
+            } catch (error) {
+                console.error(`[BonkEnv:${this.id}] Error closing IPC bridge after failed start:`, error);
+            }
+            this.bridge = null;
+        }
+        if (this.pool) {
+            try {
+                await this.pool.close();
+            } catch (error) {
+                console.error(`[BonkEnv:${this.id}] Error closing worker pool after failed start:`, error);
+            }
+            this.pool = null;
+        }
+        this.isRunning = false;
+        this.portManager.release(this.port);
+        console.log(`[BonkEnv:${this.id}] Start failed; resources released`);
     }
 
     /**
@@ -167,6 +240,21 @@ export class BonkEnv {
      * @returns Promise that resolves when the environment is stopped
      */
     async stop(): Promise<void> {
+        // A start() may be in flight (worker spawn and IPC bind can take
+        // seconds). Tearing down now would close the pool being initialized,
+        // null it, and release the port underneath the in-flight start(),
+        // leaving isRunning=true with a dead pool. Wait for the in-flight
+        // start to settle first: on success we stop the now-running env, on
+        // failure the attempt already released its own resources (issue #267
+        // review).
+        if (this.startPromise) {
+            try {
+                await this.startPromise;
+            } catch {
+                // The in-flight start failed and already cleaned up after itself.
+            }
+        }
+
         if (!this.pool && !this.bridge) {
             // Releasing is idempotent and covers a start failure before a
             // worker pool was fully initialized.

--- a/src/env/bonk-env.ts
+++ b/src/env/bonk-env.ts
@@ -244,8 +244,10 @@ export class BonkEnv {
             this.pool = null;
         }
         this.isRunning = false;
-        this.portManager.release(this.port);
-        this.portReserved = false;
+        if (this.portReserved) {
+            this.portManager.release(this.port);
+            this.portReserved = false;
+        }
         console.log(`[BonkEnv:${this.id}] Start failed; resources released`);
     }
 
@@ -270,10 +272,14 @@ export class BonkEnv {
         }
 
         if (!this.pool && !this.bridge) {
-            // Releasing is idempotent and covers a start failure before a
-            // worker pool was fully initialized.
-            this.portManager.release(this.port);
-            this.portReserved = false;
+            // Release only while this env still holds the reservation. After a
+            // failed start the port was already released (and may have been
+            // re-allocated to another env); releasing unconditionally here
+            // would delete that other env's claim (issue #267 review).
+            if (this.portReserved) {
+                this.portManager.release(this.port);
+                this.portReserved = false;
+            }
             console.log(`[BonkEnv:${this.id}] Already stopped`);
             return;
         }
@@ -297,8 +303,10 @@ export class BonkEnv {
         } finally {
             this.pool = null;
             this.isRunning = false;
-            this.portManager.release(this.port);
-            this.portReserved = false;
+            if (this.portReserved) {
+                this.portManager.release(this.port);
+                this.portReserved = false;
+            }
             console.log(`[BonkEnv:${this.id}] Stopped`);
         }
     }

--- a/src/env/bonk-env.ts
+++ b/src/env/bonk-env.ts
@@ -45,6 +45,12 @@ export class BonkEnv {
     private bridge: IpcBridge | null = null;
     private portManager: PortManager;
     private isRunning: boolean = false;
+    // True while THIS env holds the reservation for this.port.
+    // PortManager.isAllocated() only tracks Set membership, not ownership:
+    // after a failed start releases the reservation, another env can be
+    // allocated the same port, so membership alone cannot decide whether a
+    // retry may reuse this.port (issue #267 review).
+    private portReserved: boolean = false;
     // Non-null while a start() is in flight. Doubles as the "starting" state
     // guard (a second start() rejects with "already starting") and lets stop()
     // await the in-flight start instead of tearing the pool/port out from under
@@ -70,6 +76,7 @@ export class BonkEnv {
             // Allocate a unique port
             this.port = this.portManager.allocate();
         }
+        this.portReserved = true;
     }
 
     /**
@@ -111,16 +118,22 @@ export class BonkEnv {
      * Re-claims the port allocated in the constructor. The reservation is
      * released when a start attempt fails, so a retry must reserve it again
      * before spawning anything; if the port was allocated to another env in
-     * the meantime, allocate a fresh port for this env.
+     * the meantime, allocate a fresh port for this env. The early return is
+     * keyed on this env's own portReserved flag — isAllocated() would see the
+     * other env's claim and wrongly keep a foreign port (issue #267 review).
      */
     private reservePortForStart(): void {
-        if (this.portManager.isAllocated(this.port)) {
+        if (this.portReserved) {
             return;
         }
         try {
             this.portManager.reserve(this.port);
+            this.portReserved = true;
         } catch {
+            // The port was handed to another env after we released it; take a
+            // fresh one instead of binding a port we no longer own.
             this.port = this.portManager.allocate();
+            this.portReserved = true;
         }
     }
 
@@ -232,6 +245,7 @@ export class BonkEnv {
         }
         this.isRunning = false;
         this.portManager.release(this.port);
+        this.portReserved = false;
         console.log(`[BonkEnv:${this.id}] Start failed; resources released`);
     }
 
@@ -259,6 +273,7 @@ export class BonkEnv {
             // Releasing is idempotent and covers a start failure before a
             // worker pool was fully initialized.
             this.portManager.release(this.port);
+            this.portReserved = false;
             console.log(`[BonkEnv:${this.id}] Already stopped`);
             return;
         }
@@ -283,6 +298,7 @@ export class BonkEnv {
             this.pool = null;
             this.isRunning = false;
             this.portManager.release(this.port);
+            this.portReserved = false;
             console.log(`[BonkEnv:${this.id}] Stopped`);
         }
     }

--- a/tests/integration/bonk-env-ipc-server.test.ts
+++ b/tests/integration/bonk-env-ipc-server.test.ts
@@ -413,7 +413,7 @@ describe('BonkEnv IPC server mode (issue #223)', () => {
     }
   });
 
-  it('overlapping start calls reject with "already running" and never leave a zombie IPC server (#267)', { timeout: 60000 }, async () => {
+  it('overlapping start calls reject with "already starting" and never leave a zombie IPC server (#267)', { timeout: 60000 }, async () => {
     const portManager = new PortManager({ startPort: IPC_SERVER_TEST_START + 450, endPort: IPC_SERVER_TEST_START + 499 });
     const env = new BonkEnv({
       numEnvs: 1,
@@ -427,10 +427,11 @@ describe('BonkEnv IPC server mode (issue #223)', () => {
     const rejected = results.filter((r) => r.status === 'rejected');
     expect(fulfilled).toHaveLength(1);
     expect(rejected).toHaveLength(1);
-    // The loser must fail the "already running" guard, not race the winner to
-    // bind the same port.
+    // The loser must fail the transient "starting" guard with a distinct
+    // message, not race the winner to bind the same port.
     expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(Error);
-    expect((rejected[0] as PromiseRejectedResult).reason.message).toContain('already running');
+    expect((rejected[0] as PromiseRejectedResult).reason.message).toContain('already starting');
+    expect((rejected[0] as PromiseRejectedResult).reason.message).not.toContain('already running');
     expect((rejected[0] as PromiseRejectedResult).reason.message).not.toContain('Address already in use');
 
     try {
@@ -443,5 +444,43 @@ describe('BonkEnv IPC server mode (issue #223)', () => {
     expect(env.isActive()).toBe(false);
     expect(portManager.isAllocated(env.port)).toBe(false);
     expect(await canConnectTcp(env.port)).toBe(false);
+  });
+
+  it('a failed start can be retried on the same env with the port re-reserved (#267)', { timeout: 60000 }, async () => {
+    const port = IPC_SERVER_TEST_START + 500;
+    const portManager = new PortManager({ startPort: port, endPort: port + 10 });
+    const blocker = await occupyPort(port);
+
+    let env: BonkEnv;
+    try {
+      env = new BonkEnv({
+        numEnvs: 1,
+        useSharedMemory: false,
+        portManager,
+        port,
+        enableIpcServer: true,
+      });
+
+      await expect(env.start()).rejects.toThrow();
+      expect(env.isActive()).toBe(false);
+      // The failed attempt released the constructor's port reservation.
+      expect(portManager.isAllocated(port)).toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
+
+    // Retry on the same env must re-reserve the port and bind it, instead of
+    // dying with EADDRINUSE because the reservation was lost.
+    await env.start();
+    try {
+      expect(env.isActive()).toBe(true);
+      expect(await canConnectTcp(port)).toBe(true);
+    } finally {
+      await env.stop();
+    }
+
+    expect(env.isActive()).toBe(false);
+    expect(portManager.isAllocated(port)).toBe(false);
+    expect(await canConnectTcp(port)).toBe(false);
   });
 });

--- a/tests/integration/bonk-env-ipc-server.test.ts
+++ b/tests/integration/bonk-env-ipc-server.test.ts
@@ -483,4 +483,46 @@ describe('BonkEnv IPC server mode (issue #223)', () => {
     expect(portManager.isAllocated(port)).toBe(false);
     expect(await canConnectTcp(port)).toBe(false);
   });
+
+  it('a retry after failed start re-allocates a fresh port when another env took the old one (#267)', { timeout: 60000 }, async () => {
+    const port = IPC_SERVER_TEST_START + 550;
+    const portManager = new PortManager({ startPort: port, endPort: port + 10 });
+    const blocker = await occupyPort(port);
+
+    let envA: BonkEnv;
+    try {
+      envA = new BonkEnv({
+        numEnvs: 1,
+        useSharedMemory: false,
+        portManager,
+        port,
+        enableIpcServer: true,
+      });
+
+      await expect(envA.start()).rejects.toThrow();
+      expect(envA.isActive()).toBe(false);
+      // The failed attempt released the reservation.
+      expect(portManager.isAllocated(port)).toBe(false);
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
+
+    // Another env constructed before the retry is allocated the released port.
+    const envB = new BonkEnv({ numEnvs: 1, useSharedMemory: false, portManager, enableIpcServer: true });
+    expect(envB.port).toBe(port);
+
+    // The retry must NOT bind envB's port: envA no longer owns it, so it has
+    // to re-allocate a fresh port instead of double-claiming a foreign one.
+    await envA.start();
+    try {
+      expect(envA.isActive()).toBe(true);
+      expect(envA.port).not.toBe(port);
+      expect(await canConnectTcp(envA.port)).toBe(true);
+      expect(await canConnectTcp(port)).toBe(false);
+    } finally {
+      await envA.stop();
+    }
+    expect(portManager.isAllocated(envA.port)).toBe(false);
+    await envB.stop();
+  });
 });

--- a/tests/integration/bonk-env-ipc-server.test.ts
+++ b/tests/integration/bonk-env-ipc-server.test.ts
@@ -412,4 +412,36 @@ describe('BonkEnv IPC server mode (issue #223)', () => {
       await env.stop();
     }
   });
+
+  it('overlapping start calls reject with "already running" and never leave a zombie IPC server (#267)', { timeout: 60000 }, async () => {
+    const portManager = new PortManager({ startPort: IPC_SERVER_TEST_START + 450, endPort: IPC_SERVER_TEST_START + 499 });
+    const env = new BonkEnv({
+      numEnvs: 1,
+      useSharedMemory: false,
+      portManager,
+      enableIpcServer: true,
+    });
+
+    const results = await Promise.allSettled([env.start(), env.start()]);
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    // The loser must fail the "already running" guard, not race the winner to
+    // bind the same port.
+    expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(Error);
+    expect((rejected[0] as PromiseRejectedResult).reason.message).toContain('already running');
+    expect((rejected[0] as PromiseRejectedResult).reason.message).not.toContain('Address already in use');
+
+    try {
+      expect(env.isActive()).toBe(true);
+      expect(await canConnectTcp(env.port)).toBe(true);
+    } finally {
+      await env.stop();
+    }
+
+    expect(env.isActive()).toBe(false);
+    expect(portManager.isAllocated(env.port)).toBe(false);
+    expect(await canConnectTcp(env.port)).toBe(false);
+  });
 });

--- a/tests/integration/env-lifecycle.test.ts
+++ b/tests/integration/env-lifecycle.test.ts
@@ -278,8 +278,11 @@ describe('BonkEnv lifecycle', () => {
       const rejected = results.filter((r) => r.status === 'rejected');
       expect(fulfilled).toHaveLength(1);
       expect(rejected).toHaveLength(1);
+      // The loser must fail the transient "starting" guard with a distinct
+      // message, not the "already running" one reserved for a fully started env.
       expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(Error);
-      expect((rejected[0] as PromiseRejectedResult).reason.message).toContain('already running');
+      expect((rejected[0] as PromiseRejectedResult).reason.message).toContain('already starting');
+      expect((rejected[0] as PromiseRejectedResult).reason.message).not.toContain('already running');
 
       expect(env.isActive()).toBe(true);
       const pool = env.getPool() as unknown as { workers: unknown[] };
@@ -287,6 +290,20 @@ describe('BonkEnv lifecycle', () => {
       expect(env.isActive()).toBe(false);
       expect(pm.isAllocated(env.port)).toBe(false);
       expect(pool.workers).toHaveLength(0);
+    });
+
+    it('stop() during an in-flight start() waits for it and leaves the env stopped (#267)', { timeout: 30000 }, async () => {
+      env = new BonkEnv({ numEnvs: 1, portManager: pm });
+      // start() assigns its in-flight promise synchronously before suspending,
+      // so stop() called right after always observes the starting state. It
+      // must await the start instead of tearing the pool/port out from under
+      // it, then stop the now-running env cleanly.
+      const startPromise = env.start();
+      const stopPromise = env.stop();
+      await expect(stopPromise).resolves.toBeUndefined();
+      await startPromise;
+      expect(env.isActive()).toBe(false);
+      expect(pm.isAllocated(env.port)).toBe(false);
     });
   });
 

--- a/tests/integration/env-lifecycle.test.ts
+++ b/tests/integration/env-lifecycle.test.ts
@@ -305,6 +305,24 @@ describe('BonkEnv lifecycle', () => {
       expect(env.isActive()).toBe(false);
       expect(pm.isAllocated(env.port)).toBe(false);
     });
+
+    it('stop() after a failed start does not release another env\u2019s reservation of the same port (#267)', { timeout: 30000 }, async () => {
+      env = new BonkEnv({ numEnvs: 0, portManager: pm });
+      await expect(env.start()).rejects.toThrow('Invalid environment count');
+      expect(pm.isAllocated(env.port)).toBe(false);
+
+      // Another env claims the released port before env is stopped. The
+      // subsequent stop() must NOT delete that env's reservation from the
+      // PortManager.
+      const other = new BonkEnv({ numEnvs: 1, port: env.port, portManager: pm });
+      try {
+        await env.stop();
+        expect(pm.isAllocated(other.port)).toBe(true);
+      } finally {
+        await other.stop();
+      }
+      expect(pm.isAllocated(other.port)).toBe(false);
+    });
   });
 
   describe('init validation (#227)', () => {

--- a/tests/integration/env-lifecycle.test.ts
+++ b/tests/integration/env-lifecycle.test.ts
@@ -270,6 +270,24 @@ describe('BonkEnv lifecycle', () => {
       await env.stop();
       expect(pm.isAllocated(port)).toBe(false);
     });
+
+    it('overlapping start calls reject instead of spawning a second worker pool (#267)', { timeout: 30000 }, async () => {
+      env = new BonkEnv({ numEnvs: 1, portManager: pm });
+      const results = await Promise.allSettled([env.start(), env.start()]);
+      const fulfilled = results.filter((r) => r.status === 'fulfilled');
+      const rejected = results.filter((r) => r.status === 'rejected');
+      expect(fulfilled).toHaveLength(1);
+      expect(rejected).toHaveLength(1);
+      expect((rejected[0] as PromiseRejectedResult).reason).toBeInstanceOf(Error);
+      expect((rejected[0] as PromiseRejectedResult).reason.message).toContain('already running');
+
+      expect(env.isActive()).toBe(true);
+      const pool = env.getPool() as unknown as { workers: unknown[] };
+      await env.stop();
+      expect(env.isActive()).toBe(false);
+      expect(pm.isAllocated(env.port)).toBe(false);
+      expect(pool.workers).toHaveLength(0);
+    });
   });
 
   describe('init validation (#227)', () => {


### PR DESCRIPTION
Closes #267