### PR TITLE
fix(#263): recreate the ROUTER socket so IpcBridge restarts after close()

### DIFF
--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -63,16 +63,41 @@ export class IpcBridge {
     private _boundResolve: (() => void) | null = null;
     private _boundReject: ((reason?: any) => void) | null = null;
 
-    /**
-     * Resolves once the ZMQ Router socket is bound and accepting connections,
-     * and rejects if the bind fails. Embedders that drive the serve loop
-     * without awaiting start() (which only exits on close()) can await this
-     * to know when the advertised port is actually reachable.
-     */
-    readonly ready: Promise<void> = new Promise<void>((resolve, reject) => {
+    // Current bind signal for this serve cycle. Replaced on every start()
+    // (see rearmReady) so a restart after close() resolves/rejects a fresh
+    // promise instead of the stale, already-resolved first-bind one (#263).
+    private _ready: Promise<void> = new Promise<void>((resolve, reject) => {
         this._boundResolve = resolve;
         this._boundReject = reject;
     });
+
+    /**
+     * Resolves once the current serve cycle's ZMQ Router socket is bound and
+     * accepting connections, and rejects if the bind fails. Embedders that
+     * drive the serve loop without awaiting start() (which only exits on
+     * close()) can await this to know when the advertised port is actually
+     * reachable. Re-armed per start(), so awaiting it after a close() +
+     * start() restart reflects the new bind (issue #263).
+     */
+    get ready(): Promise<void> {
+        return this._ready;
+    }
+
+    /**
+     * Replace the one-shot `ready` signal with a fresh promise for the next
+     * serve cycle. A ZMQ bind can only settle a promise once, so a restart
+     * after close() must observe a new promise (issue #263). The rejection is
+     * swallowed for the same reason as in the constructor: consumers such as
+     * src/server.ts never await ready, so a bind failure must not surface as
+     * an unhandled rejection.
+     */
+    private rearmReady(): void {
+        this._ready = new Promise<void>((resolve, reject) => {
+            this._boundResolve = resolve;
+            this._boundReject = reject;
+        });
+        this._ready.catch(() => {});
+    }
     // Single-flight guard covering the entire post-step telemetry unit
     // (snapshot fetch through report). Prevents overlapping snapshot fetches
     // or duplicate reports when a second boundary step arrives during the
@@ -112,7 +137,7 @@ export class IpcBridge {
         // bind fails, both start() and ready reject; mark ready's rejection
         // as handled so it cannot surface as an unhandled-rejection crash for
         // consumers (such as src/server.ts) that never await ready.
-        this.ready.catch(() => {});
+        this._ready.catch(() => {});
     }
 
     private markBound(): void {
@@ -196,6 +221,16 @@ export class IpcBridge {
 
     async start() {
         const addr = `tcp://${this.bindAddress}:${this.port}`;
+        // A closed ZMQ socket is permanently destroyed and can never be
+        // re-bound (bind() throws "Socket is closed"). Recreate the transport
+        // so a later start() after close() binds a fresh ROUTER and serves
+        // again (issue #263): re-wrap the send function on the new socket and
+        // re-arm `ready` so `await bridge.ready` reflects the new bind.
+        if (this.sock.closed) {
+            this.sock = new zmq.Router();
+            this._wrappedSend = wrap(TelemetryIndices.ZMQ_SEND, this.sock.send.bind(this.sock));
+            this.rearmReady();
+        }
         try {
             await this.sock.bind(addr);
         } catch (err) {

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -240,11 +240,13 @@ export class IpcBridge {
             await this.sock.bind(addr);
         } catch (err) {
             this.markBindFailed(err);
-            // The recreated socket was never bound, and _closed is still true
-            // (it is only reset after a successful bind), so a later close()
-            // would early-return and leak the open handle. Close it so a
-            // failed restart is fully clean and a retry recreates from scratch.
-            if (recreated && this._closed) {
+            // A socket recreated here is always a restart-after-close() (the
+            // original socket was destroyed by close(), which also left
+            // _closed true until a successful bind). Its bind never succeeded,
+            // so a later close() would early-return and leak the open handle;
+            // close it here so a failed restart is fully clean and a retry
+            // recreates from scratch.
+            if (recreated) {
                 this.sock.close();
             }
             throw err;

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -221,20 +221,32 @@ export class IpcBridge {
 
     async start() {
         const addr = `tcp://${this.bindAddress}:${this.port}`;
+        // Re-arm `ready` on every serve cycle, not only when the socket is
+        // recreated: a failed bind rejects the current promise and nulls its
+        // handlers, so the next start() must install fresh ones or a
+        // successful retry bind could never resolve ready (issue #263).
+        this.rearmReady();
         // A closed ZMQ socket is permanently destroyed and can never be
         // re-bound (bind() throws "Socket is closed"). Recreate the transport
         // so a later start() after close() binds a fresh ROUTER and serves
-        // again (issue #263): re-wrap the send function on the new socket and
-        // re-arm `ready` so `await bridge.ready` reflects the new bind.
+        // again (issue #263): re-wrap the send function on the new socket.
+        let recreated = false;
         if (this.sock.closed) {
             this.sock = new zmq.Router();
             this._wrappedSend = wrap(TelemetryIndices.ZMQ_SEND, this.sock.send.bind(this.sock));
-            this.rearmReady();
+            recreated = true;
         }
         try {
             await this.sock.bind(addr);
         } catch (err) {
             this.markBindFailed(err);
+            // The recreated socket was never bound, and _closed is still true
+            // (it is only reset after a successful bind), so a later close()
+            // would early-return and leak the open handle. Close it so a
+            // failed restart is fully clean and a retry recreates from scratch.
+            if (recreated && this._closed) {
+                this.sock.close();
+            }
             throw err;
         }
         console.log(`[IPC] Bound ZMQ Router socket to ${addr}`);

--- a/tests/integration/ipc-bridge-restart.test.ts
+++ b/tests/integration/ipc-bridge-restart.test.ts
@@ -152,7 +152,10 @@ describe('IpcBridge can be restarted after close() (issue #263)', () => {
       expect(bridge.isClosed()).toBe(true);
       await serve3;
     } finally {
-      await new Promise<void>(resolve => blocker.close(() => resolve()));
+      // The success path already closed the listener above; only close here
+      // if an assertion failed while it was still listening, so a redundant
+      // close (which rejects with ERR_SERVER_NOT_RUNNING) is a true no-op.
+      if (blocker.listening) await new Promise<void>(resolve => blocker.close(() => resolve()));
     }
   }, 60000);
 });

--- a/tests/integration/ipc-bridge-restart.test.ts
+++ b/tests/integration/ipc-bridge-restart.test.ts
@@ -8,9 +8,11 @@
  * (libzmq sockets can never be re-bound after close()). This test proves the
  * documented lifecycle end to end: start → DEALER round-trip → close → start
  * the SAME instance again → a fresh DEALER round-trip succeeds, with
- * `bridge.ready` re-armed to reflect the new bind.
+ * `bridge.ready` re-armed to reflect the new bind — and that a restart whose
+ * bind fails once still recovers on retry (ready resolves for the live bind).
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as net from 'net';
 import * as zmq from 'zeromq';
 import { IpcBridge } from '../../src/ipc/ipc-bridge';
 import { PortManager } from '../../src/utils/port-manager';
@@ -60,10 +62,34 @@ describe('IpcBridge can be restarted after close() (issue #263)', () => {
     }
   }
 
+  /**
+   * Wait until the bridge's port is bindable again. The closed listener
+   * releases it synchronously, but poll with a throwaway ROUTER so the
+   * follow-up bind cannot flake on OS timing.
+   */
+  async function waitForPortFree(): Promise<void> {
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const probe = new zmq.Router();
+      try {
+        await probe.bind(`tcp://127.0.0.1:${port}`);
+        probe.close();
+        return;
+      } catch {
+        probe.close();
+        await new Promise(r => setTimeout(r, 50));
+      }
+    }
+    throw new Error(`port ${port} did not become free`);
+  }
+
   it('start → close → start serves fresh DEALER round-trips on the same instance', async () => {
-    // First serve cycle.
+    // First serve cycle. start() only exits on close(), so never await it
+    // directly; keep the promise referenced and surface bind failures via
+    // bridge.ready (an unhandled serve rejection would crash the worker).
     const readyBeforeFirstStart = bridge.ready;
     const serve1 = bridge.start();
+    serve1.catch(() => {});
     await bridge.ready;
     expect(bridge.isClosed()).toBe(false);
     await roundTrip(1);
@@ -76,6 +102,7 @@ describe('IpcBridge can be restarted after close() (issue #263)', () => {
 
     // Restart the same instance (the documented "later start() + restart").
     const serve2 = bridge.start();
+    serve2.catch(() => {});
     // `ready` must be re-armed for the new serve cycle: awaiting it below
     // reflects the re-bound socket, not the already-resolved first bind.
     expect(bridge.ready).not.toBe(readyBeforeFirstStart);
@@ -87,5 +114,39 @@ describe('IpcBridge can be restarted after close() (issue #263)', () => {
     await bridge.close();
     expect(bridge.isClosed()).toBe(true);
     await serve2;
+  }, 60000);
+
+  it('recovers when a restart bind fails once: ready rejects, then resolves on retry', async () => {
+    // First serve cycle + full shutdown so the socket is destroyed.
+    const serve1 = bridge.start();
+    serve1.catch(() => {});
+    await bridge.ready;
+    await bridge.close();
+    await serve1;
+
+    // Occupy the port so the restart's bind deterministically fails once.
+    const blocker = net.createServer();
+    await new Promise<void>((resolve, reject) => {
+      blocker.once('error', reject);
+      blocker.listen(port, '127.0.0.1', resolve);
+    });
+
+    const serve2 = bridge.start();
+    serve2.catch(() => {}); // the bind failure surfaces via bridge.ready
+    await expect(bridge.ready).rejects.toThrow();
+    expect(bridge.isClosed()).toBe(true);
+
+    // Release the port; the retry must re-arm ready and bind fresh.
+    await new Promise<void>(resolve => blocker.close(() => resolve()));
+    await waitForPortFree();
+
+    const serve3 = bridge.start();
+    serve3.catch(() => {});
+    await expect(bridge.ready).resolves.toBeUndefined();
+    expect(bridge.isClosed()).toBe(false);
+
+    await bridge.close();
+    expect(bridge.isClosed()).toBe(true);
+    await serve3;
   }, 60000);
 });

--- a/tests/integration/ipc-bridge-restart.test.ts
+++ b/tests/integration/ipc-bridge-restart.test.ts
@@ -1,0 +1,91 @@
+/**
+ * ipc-bridge-restart.test.ts — regression coverage for issue #263
+ *
+ * IpcBridge.close() permanently destroys the ZMQ ROUTER socket, but both the
+ * code and the docs treat a later start() on the same instance as a
+ * supported restart ("a later `start()` restarts clean"). Previously that
+ * restart deterministically failed with the opaque `Socket is closed`
+ * (libzmq sockets can never be re-bound after close()). This test proves the
+ * documented lifecycle end to end: start → DEALER round-trip → close → start
+ * the SAME instance again → a fresh DEALER round-trip succeeds, with
+ * `bridge.ready` re-armed to reflect the new bind.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as zmq from 'zeromq';
+import { IpcBridge } from '../../src/ipc/ipc-bridge';
+import { PortManager } from '../../src/utils/port-manager';
+
+describe('IpcBridge can be restarted after close() (issue #263)', () => {
+  let bridge: IpcBridge;
+  let portManager: PortManager;
+  let port: number;
+
+  beforeAll(async () => {
+    portManager = new PortManager({ startPort: 15800, endPort: 15899 });
+    port = portManager.allocate();
+    bridge = new IpcBridge({ server: { port } } as any);
+  }, 30000);
+
+  afterAll(async () => {
+    try { await bridge.close(); } catch { /* ignore */ }
+    portManager.release(port);
+  }, 10000);
+
+  /**
+   * Connect a fresh DEALER client (as the Python client does) to the
+   * bridge's port and complete an `init` → `reset` round-trip. The reset
+   * observation length proves the response came from a live pool served by
+   * the currently-bound ROUTER socket.
+   */
+  async function roundTrip(numEnvs: number): Promise<void> {
+    const client = new zmq.Dealer();
+    try {
+      await client.connect(`tcp://127.0.0.1:${port}`);
+      await new Promise(r => setTimeout(r, 100));
+
+      const sendCommand = async (cmd: object): Promise<any> => {
+        await client.send(JSON.stringify(cmd));
+        const [response] = await client.receive();
+        return JSON.parse(response.toString());
+      };
+
+      const init = await sendCommand({ command: 'init', numEnvs, useSharedMemory: false });
+      expect(init.status).toBe('ok');
+
+      const reset = await sendCommand({ command: 'reset', seeds: Array.from({ length: numEnvs }, (_, i) => i + 1) });
+      expect(reset.status).toBe('ok');
+      expect(reset.data.observation).toHaveLength(numEnvs);
+    } finally {
+      client.close();
+    }
+  }
+
+  it('start → close → start serves fresh DEALER round-trips on the same instance', async () => {
+    // First serve cycle.
+    const readyBeforeFirstStart = bridge.ready;
+    const serve1 = bridge.start();
+    await bridge.ready;
+    expect(bridge.isClosed()).toBe(false);
+    await roundTrip(1);
+
+    // Full shutdown: the socket is destroyed here, so a restart must
+    // recreate it from scratch.
+    await bridge.close();
+    expect(bridge.isClosed()).toBe(true);
+    await serve1; // the first serve loop exits once the socket is closed
+
+    // Restart the same instance (the documented "later start() + restart").
+    const serve2 = bridge.start();
+    // `ready` must be re-armed for the new serve cycle: awaiting it below
+    // reflects the re-bound socket, not the already-resolved first bind.
+    expect(bridge.ready).not.toBe(readyBeforeFirstStart);
+    await bridge.ready;
+    expect(bridge.isClosed()).toBe(false);
+    await roundTrip(1);
+
+    // Second cycle must shut down the same way.
+    await bridge.close();
+    expect(bridge.isClosed()).toBe(true);
+    await serve2;
+  }, 60000);
+});

--- a/tests/integration/ipc-bridge-restart.test.ts
+++ b/tests/integration/ipc-bridge-restart.test.ts
@@ -125,28 +125,34 @@ describe('IpcBridge can be restarted after close() (issue #263)', () => {
     await serve1;
 
     // Occupy the port so the restart's bind deterministically fails once.
+    // The listener is closed in `finally` so a failed assertion can never
+    // leave the port bound for the rest of the suite.
     const blocker = net.createServer();
-    await new Promise<void>((resolve, reject) => {
-      blocker.once('error', reject);
-      blocker.listen(port, '127.0.0.1', resolve);
-    });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        blocker.once('error', reject);
+        blocker.listen(port, '127.0.0.1', resolve);
+      });
 
-    const serve2 = bridge.start();
-    serve2.catch(() => {}); // the bind failure surfaces via bridge.ready
-    await expect(bridge.ready).rejects.toThrow();
-    expect(bridge.isClosed()).toBe(true);
+      const serve2 = bridge.start();
+      serve2.catch(() => {}); // the bind failure surfaces via bridge.ready
+      await expect(bridge.ready).rejects.toThrow();
+      expect(bridge.isClosed()).toBe(true);
 
-    // Release the port; the retry must re-arm ready and bind fresh.
-    await new Promise<void>(resolve => blocker.close(() => resolve()));
-    await waitForPortFree();
+      // Release the port; the retry must re-arm ready and bind fresh.
+      await new Promise<void>(resolve => blocker.close(() => resolve()));
+      await waitForPortFree();
 
-    const serve3 = bridge.start();
-    serve3.catch(() => {});
-    await expect(bridge.ready).resolves.toBeUndefined();
-    expect(bridge.isClosed()).toBe(false);
+      const serve3 = bridge.start();
+      serve3.catch(() => {});
+      await expect(bridge.ready).resolves.toBeUndefined();
+      expect(bridge.isClosed()).toBe(false);
 
-    await bridge.close();
-    expect(bridge.isClosed()).toBe(true);
-    await serve3;
+      await bridge.close();
+      expect(bridge.isClosed()).toBe(true);
+      await serve3;
+    } finally {
+      await new Promise<void>(resolve => blocker.close(() => resolve()));
+    }
   }, 60000);
 });


### PR DESCRIPTION
Closes #263