### PR TITLE
fix(#261): reject out-of-range encoded actions in both transports

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -52,6 +52,13 @@ const SYNC_STATUS_OFFSET = 1;
 // remain a representable uint32. The range is enforced for BOTH transports so
 // the two cannot drift (#226).
 const MAX_SUPPORTED_RESET_SEED = 0xFFFFFFFE;
+
+// Encoded actions are six binary flags packed into one integer, so the valid
+// space is [0, 63] (mirrors the Python client's Discrete(64)). The range is
+// enforced for BOTH transports: a value outside it carries bits that
+// `decodeAction()` never reads, so it would silently execute a different
+// action than the caller requested (#261).
+const MAX_ENCODED_ACTION = 63;
 const WORKER_IDLE = 0;
 const WORKER_COMPLETE = 1;
 const WORKER_ERROR = -1;
@@ -897,14 +904,22 @@ export class WorkerPool {
      * Encodes a PlayerInput action to a number for shared memory storage
      * Uses bit flags: left=1, right=2, up=4, down=8, heavy=16, grapple=32
      *
-     * Null/undefined, arrays, empty objects, non-boolean field values, and
+* Null/undefined, arrays, empty objects, non-boolean field values, and
      * non-finite numbers (NaN, ±Infinity) throw a labeled error instead of
      * being silently encoded as a different (usually no-op) action, so
-     * callers can tell a bad request apart from a pool failure (#278).
+     * callers can tell a bad request apart from a pool failure (#278). An
+     * encoded number outside [0, 63] is likewise rejected: `decodeAction()`
+     * reads only the low six bits, so such a value would silently run a
+     * different action (#261).
      */
     private encodeAction(action: PlayerInput | number): number {
         assertValidAction(action);
         if (typeof action === 'number') {
+            if (!Number.isInteger(action) || action < 0 || action > MAX_ENCODED_ACTION) {
+                throw new Error(
+                    `Invalid action: expected an encoded action in [0, ${MAX_ENCODED_ACTION}], got ${action}`,
+                );
+            }
             return action; // Already encoded
         }
         let encoded = 0;

--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -54,11 +54,14 @@ const SYNC_STATUS_OFFSET = 1;
 const MAX_SUPPORTED_RESET_SEED = 0xFFFFFFFE;
 
 // Encoded actions are six binary flags packed into one integer, so the valid
-// space is [0, 63] (mirrors the Python client's Discrete(64)). The range is
-// enforced for BOTH transports: a value outside it carries bits that
-// `decodeAction()` never reads, so it would silently execute a different
-// action than the caller requested (#261).
-const MAX_ENCODED_ACTION = 63;
+// space is [0, 63] (mirrors the Python client's Discrete(64)). The bound is
+// derived from the six-bit flag layout in encodeAction()/decodeAction(), not
+// hardcoded, so the two transports' action-space contract cannot silently
+// diverge from the bit flags if a flag is ever added. Values outside the
+// range are rejected in BOTH transports: they carry bits `decodeAction()`
+// never reads, so they would silently execute a different action than the
+// caller requested (#261).
+const MAX_ENCODED_ACTION = (1 << 6) - 1;
 const WORKER_IDLE = 0;
 const WORKER_COMPLETE = 1;
 const WORKER_ERROR = -1;

--- a/tests/e2e/ipc-bridge-e2e.test.ts
+++ b/tests/e2e/ipc-bridge-e2e.test.ts
@@ -187,9 +187,10 @@ describe('IpcBridge black-box E2E', () => {
       }
     });
 
-    it('out-of-range actions handled gracefully', async () => {
+    it('out-of-range actions return an error', async () => {
       const result = await sendCommand({ command: 'step', actions: [100, -1, 255] });
-      expect(result.status).toBe('ok');
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('Invalid action: expected an encoded action in [0, 63], got 100');
     });
   });
 

--- a/tests/e2e/worker-pool-blackbox.test.ts
+++ b/tests/e2e/worker-pool-blackbox.test.ts
@@ -149,12 +149,11 @@ describe('WorkerPool black-box', () => {
       }
     });
 
-    it('out-of-range actions handled gracefully', async () => {
-      const results = await pool.step([100, -1, 255]);
-      expect(results).toHaveLength(3);
-      for (const r of results) {
-        expect(Number.isFinite(r.reward)).toBe(true);
-      }
+    it('out-of-range actions are rejected', async () => {
+      await expect(pool.step([100, -1, 255])).rejects.toThrow(
+        'Invalid action: expected an encoded action in [0, 63], got 100',
+      );
+      await expect(pool.step([0, 0, 0])).resolves.toHaveLength(3);
     });
 
     it('multiple sequential steps produce consistent results', async () => {

--- a/tests/integration/worker-pool-action-range-validation.test.ts
+++ b/tests/integration/worker-pool-action-range-validation.test.ts
@@ -1,0 +1,55 @@
+/**
+ * worker-pool-action-range-validation.test.ts — Regression coverage for issue #261
+ *
+ * Encoded actions outside the documented Discrete(64) space [0, 63] must be
+ * rejected as a per-request input error in BOTH transports. Previously
+ * `encodeAction()` passed any number through unchanged and `decodeAction()`
+ * read only bits 0–5, so 64 executed the no-op action 0, 100 executed
+ * up+grapple (100 & 63 = 36), and 255 executed every flag — the identical
+ * request silently ran a different action than the caller asked for, with no
+ * error in either transport.
+ */
+import { describe, it, expect } from 'vitest';
+import { WorkerPool } from '../../src/core/worker-pool';
+
+describe('WorkerPool action range validation (issue #261)', () => {
+  const runRejectionSequence = async (useSharedMemory: boolean) => {
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(2, {}, useSharedMemory);
+      const baseline = (await pool.reset([1, 2]))[0].tick;
+
+      // Values outside [0, 63] carry bits decodeAction() never reads and
+      // would be silently re-interpreted as a different action. Every
+      // rejection must carry the offending value in both transports and
+      // must leave the pool ready.
+      const invalidActions = [-1, 64, 100, 255];
+      for (const action of invalidActions) {
+        await expect(pool.step([action, 0])).rejects.toThrow(
+          `Invalid action: expected an encoded action in [0, 63], got ${action}`,
+        );
+        expect((pool as any).state).toBe('ready');
+      }
+
+      // Boundary values [0, 63] remain valid in both transports. Rejections
+      // happened before any worker state was touched: this step advances
+      // every environment exactly one tick from baseline.
+      const results = await pool.step([0, 63]);
+      expect(results).toHaveLength(2);
+      for (const res of results) {
+        expect(res.observation.tick).toBe(baseline + 1);
+      }
+    } finally {
+      await pool.close();
+    }
+  };
+
+  it('shared-memory mode: out-of-range action values are rejected and the pool recovers', async () => {
+    if (!WorkerPool.isSupported()) return;
+    await runRejectionSequence(true);
+  });
+
+  it('message-passing mode: out-of-range action values are rejected and the pool recovers', async () => {
+    await runRejectionSequence(false);
+  });
+});

--- a/tests/integration/worker-pool-action-range-validation.test.ts
+++ b/tests/integration/worker-pool-action-range-validation.test.ts
@@ -7,7 +7,8 @@
  * read only bits 0–5, so 64 executed the no-op action 0, 100 executed
  * up+grapple (100 & 63 = 36), and 255 executed every flag — the identical
  * request silently ran a different action than the caller asked for, with no
- * error in either transport.
+ * error in either transport. Non-integer numbers were likewise silently
+ * truncated by `decodeAction()`'s bitwise ops (3.5 → 3).
  */
 import { describe, it, expect } from 'vitest';
 import { WorkerPool } from '../../src/core/worker-pool';
@@ -19,11 +20,11 @@ describe('WorkerPool action range validation (issue #261)', () => {
       await pool.init(2, {}, useSharedMemory);
       const baseline = (await pool.reset([1, 2]))[0].tick;
 
-      // Values outside [0, 63] carry bits decodeAction() never reads and
-      // would be silently re-interpreted as a different action. Every
-      // rejection must carry the offending value in both transports and
-      // must leave the pool ready.
-      const invalidActions = [-1, 64, 100, 255];
+      // Values outside [0, 63] carry bits decodeAction() never reads (and
+      // non-integers get truncated by its bitwise ops) and would be silently
+      // re-interpreted as a different action. Every rejection must carry the
+      // offending value in both transports and must leave the pool ready.
+      const invalidActions = [-1, 3.5, 64, 100, 255];
       for (const action of invalidActions) {
         await expect(pool.step([action, 0])).rejects.toThrow(
           `Invalid action: expected an encoded action in [0, 63], got ${action}`,


### PR DESCRIPTION
Closes #261