### PR TITLE
fix(#259): floor maxClientSessions cap to an integer

### DIFF
--- a/docs/typescript/src/ipc/ipc-bridge.md
+++ b/docs/typescript/src/ipc/ipc-bridge.md
@@ -158,8 +158,9 @@ been idle (no active request, no `init`/`reset`/`step`/`close`) for
 `CLIENT_SESSION_IDLE_TIMEOUT_MS` (5 minutes), detaching the client's identity
 so it must call `init` again; a session is never reaped while a request or its
 detached telemetry is still using its pool. `server.maxClientSessions`
-(default 32, clamped to a minimum of 1, falling back to the default when unset)
-caps the number of concurrent sessions; a new client `init` beyond the cap is
+(default 32, floored to an integer and clamped to a minimum of 1, falling back
+to the default when unset) caps the number of concurrent sessions; a new client
+`init` beyond the cap is
 rejected loudly with a clear error instead of silently evicting an existing
 session. Closed, rejected, and reaped identities keep failing loudly without
 retaining an unbounded identity registry: once any client has taken ownership

--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -88,13 +88,16 @@ export class IpcBridge {
         // missing/non-finite value (e.g. a partial mock config, or empty
         // string env overrides) falls back to the loader-provided default
         // instead of producing NaN or clamping to 1, and numeric strings from
-        // env-style configs are honored like real numbers.
+        // env-style configs are honored like real numbers. The cap is an
+        // integer count of concurrent sessions, so a fractional value is
+        // floored (1.5 → 1, 2.5 → 2) rather than silently relaxing the bound
+        // by Math.ceil (issue #259).
         const rawCap: unknown = config?.server?.maxClientSessions ?? getConfig().server.maxClientSessions;
         const parsedCap = typeof rawCap === 'string'
             ? (rawCap.trim() === '' ? NaN : Number(rawCap))
             : rawCap;
         this.maxClientSessions = Number.isFinite(parsedCap as number)
-            ? Math.max(1, parsedCap as number)
+            ? Math.floor(Math.max(1, parsedCap as number))
             : DEFAULT_MAX_CLIENT_SESSIONS;
         this.sock = new zmq.Router();
         this.localSession = {

--- a/tests/unit/ipc-bridge-constructor.test.ts
+++ b/tests/unit/ipc-bridge-constructor.test.ts
@@ -631,6 +631,33 @@ describe('IpcBridge per-client session cap (issue #193)', () => {
     expect((bridge as any).maxClientSessions).toBe(1);
   });
 
+  it('floors a fractional session cap so it cannot silently relax the bound (issue #259)', () => {
+    expect((new IpcBridge({ server: { port: 12375, maxClientSessions: 1.5 } } as any) as any).maxClientSessions).toBe(1);
+    expect((new IpcBridge({ server: { port: 12375, maxClientSessions: 2.5 } } as any) as any).maxClientSessions).toBe(2);
+    expect((new IpcBridge({ server: { port: 12375, maxClientSessions: '1.5' } } as any) as any).maxClientSessions).toBe(1);
+    expect((new IpcBridge({ server: { port: 12375, maxClientSessions: 0.5 } } as any) as any).maxClientSessions).toBe(1);
+  });
+
+  it('falls back to the default cap for non-number cap values instead of coercing them (issue #259)', () => {
+    for (const bad of [true, false, [5], {}, 'not-a-number']) {
+      const bridge = new IpcBridge({ server: { port: 12375, maxClientSessions: bad } } as any);
+      expect((bridge as any).maxClientSessions).toBe(32);
+    }
+  });
+
+  it('enforces a fractional cap as its floored integer: 1.5 admits one session, not two (issue #259)', async () => {
+    const bridge = new IpcBridge({ server: { port: 12379, maxClientSessions: 1.5 } } as any);
+    const handleRequest = (bridge as any).handleRequest.bind(bridge);
+
+    await handleRequest(Buffer.from('clientA'), JSON.stringify({ command: 'init', numEnvs: 1 }));
+    expect(lastResponse().status).toBe('ok');
+
+    await handleRequest(Buffer.from('clientB'), JSON.stringify({ command: 'init', numEnvs: 1 }));
+    const rejected = lastResponse();
+    expect(rejected.status).toBe('error');
+    expect(rejected.error).toContain('Too many active client sessions (max 1)');
+  });
+
   it('falls back to the default session cap when the cap is omitted', () => {
     // The getConfig mock normally reports 32; override it for both constructor
     // reads (port, then cap) with a cap-less config so the only path to a

--- a/tests/unit/ipc-bridge-constructor.test.ts
+++ b/tests/unit/ipc-bridge-constructor.test.ts
@@ -639,7 +639,7 @@ describe('IpcBridge per-client session cap (issue #193)', () => {
   });
 
   it('falls back to the default cap for non-number cap values instead of coercing them (issue #259)', () => {
-    for (const bad of [true, false, [5], {}, 'not-a-number']) {
+    for (const bad of [true, false, [5], {}, 'not-a-number', NaN, Infinity, '1e999']) {
       const bridge = new IpcBridge({ server: { port: 12375, maxClientSessions: bad } } as any);
       expect((bridge as any).maxClientSessions).toBe(32);
     }


### PR DESCRIPTION
Closes #259