### PR TITLE
fix(#282): consume exported rv/d joint anchors as body-relative offsets

### DIFF
--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -1022,14 +1022,17 @@ export class PhysicsEngine {
     }
 
     const cd = def.collideConnected ?? false;
-    // §33.8 anchor coordinates: only finite numbers are honored — anything
-    // else (null/undefined, NaN, non-numeric strings) degrades to 0 so no
-    // joint branch can emit a NaN anchor. A bare `?? 0` does not coerce NaN
-    // (`NaN ?? 0` is still NaN), so the d-branch anchors must go through the
-    // same finite check as the rv pivot guard. Returns the value in world
-    // units (map px / this.scale).
-    const anchorCoord = (v: unknown): number =>
-      (typeof v === 'number' && Number.isFinite(v) ? v : 0) / this.scale;
+    // §33.8 anchor parity: an anchor is honored only when BOTH coordinates are
+    // finite numbers — anything else (null/undefined, NaN, non-numeric strings)
+    // degrades the WHOLE anchor to (0,0), matching the rv branch's whole-anchor
+    // pivot guard. Per-coordinate coercion would pin e.g. `{x: 5, y: null}` at
+    // (5/SCALE, 0) in the d branch while the rv pivot degrades fully to (0,0).
+    // A bare `?? 0` does not coerce NaN (`NaN ?? 0` is still NaN). Returns the
+    // pair in world units (map px / this.scale).
+    const anchorPair = (a?: { x: number; y: number }): [number, number] =>
+      a && Number.isFinite(a.x) && Number.isFinite(a.y)
+        ? [a.x / this.scale, a.y / this.scale]
+        : [0, 0];
     const makeAnchorA = (a?: { x: number; y: number }) =>
       a && Number.isFinite(a.x) && Number.isFinite(a.y)
         ? new b2Vec2(a.x / this.scale, a.y / this.scale)
@@ -1041,21 +1044,24 @@ export class PhysicsEngine {
       const jd = new b2DistanceJointDef();
       if (isGround) {
         // Ground anchors use native map-px coords (ab += [365/ppm, 250/ppm]).
+        const [abx, aby] = anchorPair(def.anchorB);
         jd.Initialize(
           bodyA,
           bodyB,
           makeAnchorA(def.anchorA),
-          new b2Vec2(anchorCoord(def.anchorB?.x), anchorCoord(def.anchorB?.y)),
+          new b2Vec2(abx, aby),
         );
       } else {
         // §33.8 d: aa/ab are body-relative local anchors, set directly in the
         // connected bodies' frames (Initialize would subtract each body's
         // position, pinning the joint ~one body-position away on any
         // non-origin body).
+        const [ax, ay] = anchorPair(def.anchorA);
+        const [bx, by] = anchorPair(def.anchorB);
         jd.body1 = bodyA;
         jd.body2 = bodyB;
-        jd.localAnchor1.Set(anchorCoord(def.anchorA?.x), anchorCoord(def.anchorA?.y));
-        jd.localAnchor2.Set(anchorCoord(def.anchorB?.x), anchorCoord(def.anchorB?.y));
+        jd.localAnchor1.Set(ax, ay);
+        jd.localAnchor2.Set(bx, by);
         if (!(typeof def.length === 'number' && Number.isFinite(def.length))) {
           // No authored length: replicate Initialize's default — the distance
           // between the anchor world points in the bodies' frames.
@@ -1084,11 +1090,11 @@ export class PhysicsEngine {
       // anchor: when `aa` is absent the exporter emits `anchorA: null`, and
       // makeAnchorA then falls back to a WORLD position (bodyA.GetPosition()).
       // Adding it again would produce p + R·p instead of p. Truthy-but-invalid
-      // anchors (e.g. `{}`, `{x: null}`, `{x: NaN}`, string coordinates) must
-      // degrade to the same origin — makeAnchorA would compute a.x / scale =
-      // NaN, while the d branch's anchorCoord coerces the same input to 0.
-      // The un-authored fallback pins the pivot at the body origin (local
-      // anchor (0,0)).
+      // and partially-valid anchors (e.g. `{}`, `{x: null}`, `{x: NaN}`, string
+      // coordinates, `{x: 5, y: null}`) must degrade the whole anchor to the
+      // body origin — makeAnchorA would compute a.x / scale = NaN, while the d
+      // branch's anchorPair applies the same whole-anchor finite check. The
+      // un-authored fallback pins the pivot at the body origin (local (0,0)).
       if (def.anchorA && Number.isFinite(def.anchorA.x) && Number.isFinite(def.anchorA.y)) {
         pivot.Add(bodyA.GetWorldVector(makeAnchorA(def.anchorA)));
       }

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -1022,8 +1022,18 @@ export class PhysicsEngine {
     }
 
     const cd = def.collideConnected ?? false;
+    // §33.8 anchor coordinates: only finite numbers are honored — anything
+    // else (null/undefined, NaN, non-numeric strings) degrades to 0 so no
+    // joint branch can emit a NaN anchor. A bare `?? 0` does not coerce NaN
+    // (`NaN ?? 0` is still NaN), so the d-branch anchors must go through the
+    // same finite check as the rv pivot guard. Returns the value in world
+    // units (map px / this.scale).
+    const anchorCoord = (v: unknown): number =>
+      (typeof v === 'number' && Number.isFinite(v) ? v : 0) / this.scale;
     const makeAnchorA = (a?: { x: number; y: number }) =>
-      a ? new b2Vec2(a.x / this.scale, a.y / this.scale) : (bodyA.GetPosition().Copy());
+      a && Number.isFinite(a.x) && Number.isFinite(a.y)
+        ? new b2Vec2(a.x / this.scale, a.y / this.scale)
+        : (bodyA.GetPosition().Copy());
 
     const type = def.type;
     let created: any = null;
@@ -1035,7 +1045,7 @@ export class PhysicsEngine {
           bodyA,
           bodyB,
           makeAnchorA(def.anchorA),
-          new b2Vec2((def.anchorB?.x ?? 0) / this.scale, (def.anchorB?.y ?? 0) / this.scale),
+          new b2Vec2(anchorCoord(def.anchorB?.x), anchorCoord(def.anchorB?.y)),
         );
       } else {
         // §33.8 d: aa/ab are body-relative local anchors, set directly in the
@@ -1044,8 +1054,8 @@ export class PhysicsEngine {
         // non-origin body).
         jd.body1 = bodyA;
         jd.body2 = bodyB;
-        jd.localAnchor1.Set((def.anchorA?.x ?? 0) / this.scale, (def.anchorA?.y ?? 0) / this.scale);
-        jd.localAnchor2.Set((def.anchorB?.x ?? 0) / this.scale, (def.anchorB?.y ?? 0) / this.scale);
+        jd.localAnchor1.Set(anchorCoord(def.anchorA?.x), anchorCoord(def.anchorA?.y));
+        jd.localAnchor2.Set(anchorCoord(def.anchorB?.x), anchorCoord(def.anchorB?.y));
         if (!(typeof def.length === 'number' && Number.isFinite(def.length))) {
           // No authored length: replicate Initialize's default — the distance
           // between the anchor world points in the bodies' frames.
@@ -1074,10 +1084,11 @@ export class PhysicsEngine {
       // anchor: when `aa` is absent the exporter emits `anchorA: null`, and
       // makeAnchorA then falls back to a WORLD position (bodyA.GetPosition()).
       // Adding it again would produce p + R·p instead of p. Truthy-but-invalid
-      // anchors (e.g. `{}`, `{x: null}`) must degrade to the same origin —
-      // makeAnchorA would compute a.x / scale = NaN, while the d-joint branch
-      // coerces the same input to 0 via `?.x ?? 0`. The un-authored fallback
-      // pins the pivot at the body origin (local anchor (0,0)).
+      // anchors (e.g. `{}`, `{x: null}`, `{x: NaN}`, string coordinates) must
+      // degrade to the same origin — makeAnchorA would compute a.x / scale =
+      // NaN, while the d branch's anchorCoord coerces the same input to 0.
+      // The un-authored fallback pins the pivot at the body origin (local
+      // anchor (0,0)).
       if (def.anchorA && Number.isFinite(def.anchorA.x) && Number.isFinite(def.anchorA.y)) {
         pivot.Add(bodyA.GetWorldVector(makeAnchorA(def.anchorA)));
       }

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -1070,12 +1070,17 @@ export class PhysicsEngine {
       // so the joint's local anchor on bodyA lands exactly at aa/SCALE
       // (GetPosition returns an internal reference — operate on a copy).
       const pivot = bodyA.GetPosition().Copy();
-      // Only add the body-relative offset when the map authored an anchor:
-      // when `aa` is absent the exporter emits `anchorA: null`, and
+      // Only add the body-relative offset when the map authored a valid
+      // anchor: when `aa` is absent the exporter emits `anchorA: null`, and
       // makeAnchorA then falls back to a WORLD position (bodyA.GetPosition()).
-      // Adding it again would produce p + R·p instead of p. The un-authored
-      // fallback pins the pivot at the body origin (local anchor (0,0)).
-      if (def.anchorA) pivot.Add(bodyA.GetWorldVector(makeAnchorA(def.anchorA)));
+      // Adding it again would produce p + R·p instead of p. Truthy-but-invalid
+      // anchors (e.g. `{}`, `{x: null}`) must degrade to the same origin —
+      // makeAnchorA would compute a.x / scale = NaN, while the d-joint branch
+      // coerces the same input to 0 via `?.x ?? 0`. The un-authored fallback
+      // pins the pivot at the body origin (local anchor (0,0)).
+      if (def.anchorA && Number.isFinite(def.anchorA.x) && Number.isFinite(def.anchorA.y)) {
+        pivot.Add(bodyA.GetWorldVector(makeAnchorA(def.anchorA)));
+      }
       jd.Initialize(bodyA, bodyB, pivot);
       jd.collideConnected = cd;
       jd.enableLimit = !!def.enableLimit;

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -1024,19 +1024,36 @@ export class PhysicsEngine {
     const cd = def.collideConnected ?? false;
     const makeAnchorA = (a?: { x: number; y: number }) =>
       a ? new b2Vec2(a.x / this.scale, a.y / this.scale) : (bodyA.GetPosition().Copy());
-    const makeAnchorB = (a?: { x: number; y: number }, b?: any) =>
-      a ? new b2Vec2(a.x / this.scale, a.y / this.scale) : (b.GetPosition().Copy());
 
     const type = def.type;
     let created: any = null;
     if (type === 'distance' || type === 'd') {
       const jd = new b2DistanceJointDef();
-      // Ground anchors use native map-px coords (ab += [365/ppm, 250/ppm]).
-      const a = makeAnchorA(def.anchorA);
-      const b = isGround
-        ? new b2Vec2((def.anchorB?.x ?? 0) / this.scale, (def.anchorB?.y ?? 0) / this.scale)
-        : makeAnchorB(def.anchorB, bodyB);
-      jd.Initialize(bodyA, bodyB, a, b);
+      if (isGround) {
+        // Ground anchors use native map-px coords (ab += [365/ppm, 250/ppm]).
+        jd.Initialize(
+          bodyA,
+          bodyB,
+          makeAnchorA(def.anchorA),
+          new b2Vec2((def.anchorB?.x ?? 0) / this.scale, (def.anchorB?.y ?? 0) / this.scale),
+        );
+      } else {
+        // §33.8 d: aa/ab are body-relative local anchors, set directly in the
+        // connected bodies' frames (Initialize would subtract each body's
+        // position, pinning the joint ~one body-position away on any
+        // non-origin body).
+        jd.body1 = bodyA;
+        jd.body2 = bodyB;
+        jd.localAnchor1.Set((def.anchorA?.x ?? 0) / this.scale, (def.anchorA?.y ?? 0) / this.scale);
+        jd.localAnchor2.Set((def.anchorB?.x ?? 0) / this.scale, (def.anchorB?.y ?? 0) / this.scale);
+        if (!(typeof def.length === 'number' && Number.isFinite(def.length))) {
+          // No authored length: replicate Initialize's default — the distance
+          // between the anchor world points in the bodies' frames.
+          const wa = bodyA.GetWorldPoint(jd.localAnchor1);
+          const wb = bodyB.GetWorldPoint(jd.localAnchor2);
+          jd.length = Math.sqrt((wb.x - wa.x) * (wb.x - wa.x) + (wb.y - wa.y) * (wb.y - wa.y));
+        }
+      }
       // apply an explicit authored length after Initialize (Initialize sets
       // length from the anchor distance) (§33.7 d: len→0.01-floor).
       if (typeof def.length === 'number' && Number.isFinite(def.length)) {
@@ -1048,7 +1065,13 @@ export class PhysicsEngine {
       created = this.world.CreateJoint(jd);
     } else if (type === 'rv' || type === 'revolute') {
       const jd = new b2RevoluteJointDef();
-      jd.Initialize(bodyA, bodyB, makeAnchorA(def.anchorA));
+      // §33.8 rv: aa is a body-relative offset; the pivot's world position is
+      // bodyA.p + R·(aa/ppm). Initialize converts it back via GetLocalPoint,
+      // so the joint's local anchor on bodyA lands exactly at aa/SCALE
+      // (GetPosition returns an internal reference — operate on a copy).
+      const pivot = bodyA.GetPosition().Copy();
+      pivot.Add(bodyA.GetWorldVector(makeAnchorA(def.anchorA)));
+      jd.Initialize(bodyA, bodyB, pivot);
       jd.collideConnected = cd;
       jd.enableLimit = !!def.enableLimit;
       // Adapter forwards the exporter's lower/upperLimit (which map to the

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -1070,7 +1070,12 @@ export class PhysicsEngine {
       // so the joint's local anchor on bodyA lands exactly at aa/SCALE
       // (GetPosition returns an internal reference — operate on a copy).
       const pivot = bodyA.GetPosition().Copy();
-      pivot.Add(bodyA.GetWorldVector(makeAnchorA(def.anchorA)));
+      // Only add the body-relative offset when the map authored an anchor:
+      // when `aa` is absent the exporter emits `anchorA: null`, and
+      // makeAnchorA then falls back to a WORLD position (bodyA.GetPosition()).
+      // Adding it again would produce p + R·p instead of p. The un-authored
+      // fallback pins the pivot at the body origin (local anchor (0,0)).
+      if (def.anchorA) pivot.Add(bodyA.GetWorldVector(makeAnchorA(def.anchorA)));
       jd.Initialize(bodyA, bodyB, pivot);
       jd.collideConnected = cd;
       jd.enableLimit = !!def.enableLimit;

--- a/tests/integration/physics-fidelity-p2.test.ts
+++ b/tests/integration/physics-fidelity-p2.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { PhysicsEngine } from '../../src/core/physics-engine';
+import { PhysicsEngine, SCALE } from '../../src/core/physics-engine';
 import { normalizeMap } from '../../src/core/map-adapter';
 
 /**
@@ -50,6 +50,53 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
       e.addJoint({ type: 'd', name: 'j1', bodyA: 'plat_0', bodyB: 'cart_0', anchorA: { x: 0, y: 100 }, anchorB: { x: 0, y: 140 }, frequencyHz: 4, dampingRatio: 0.5, length: 50, collideConnected: false }, bm);
     });
     expect(warnings.filter(w => /unknown joint type/.test(w))).toHaveLength(0);
+  });
+
+  it('rv/d anchors are body-relative offsets on a non-origin body, not world coordinates (#282)', () => {
+    const e = makeEngine();
+    // bodyA sits 100 map px right of the world origin; the authored anchors
+    // are body-relative offsets, exactly as the exporter stores them (§33.8).
+    e.addBody({ name: 'bodyA', type: 'rect', x: 100, y: 0, width: 40, height: 10, static: true, density: 0 } as any);
+    e.addBody({ name: 'bodyB', type: 'rect', x: 200, y: 0, width: 20, height: 20, static: false, density: 1 } as any);
+    const bm = e.getBodyMap() as Map<string, any>;
+    const bodyA = bm.get('bodyA') as any;
+
+    e.addJoint({ type: 'rv', name: 'j_rv', bodyA: 'bodyA', bodyB: 'bodyB', anchorA: { x: 0, y: 50 }, enableLimit: false }, bm);
+    e.addJoint({ type: 'd', name: 'j_d', bodyA: 'bodyA', bodyB: 'bodyB', anchorA: { x: 0, y: 50 }, anchorB: { x: 0, y: -50 }, length: 60 }, bm);
+    // No authored length: the joint must still build (§33.7 d length default
+    // = distance between the anchor world points in the bodies' frames).
+    e.addJoint({ type: 'd', name: 'j_d_nolen', bodyA: 'bodyA', bodyB: 'bodyB', anchorA: { x: 0, y: 50 }, anchorB: { x: 0, y: -50 } }, bm);
+
+    const rv = (e as any).createdJoints.get('j_rv');
+    const d = (e as any).createdJoints.get('j_d');
+    const dNolen = (e as any).createdJoints.get('j_d_nolen');
+    expect(rv).toBeTruthy();
+    expect(d).toBeTruthy();
+    expect(dNolen).toBeTruthy();
+
+    // The local anchor on bodyA must be exactly anchorA / SCALE — NOT
+    // anchorA / SCALE − bodyA.position, which the old world-point
+    // interpretation would pin at x = −100/30 here.
+    expect(rv.m_localAnchor1.x).toBeCloseTo(0, 5);
+    expect(rv.m_localAnchor1.y).toBeCloseTo(50 / SCALE, 5);
+    // §33.8 d: aa/ab are local anchors in the connected bodies' frames.
+    expect(d.m_localAnchor1.x).toBeCloseTo(0, 5);
+    expect(d.m_localAnchor1.y).toBeCloseTo(50 / SCALE, 5);
+    expect(d.m_localAnchor2.x).toBeCloseTo(0, 5);
+    expect(d.m_localAnchor2.y).toBeCloseTo(-50 / SCALE, 5);
+    // Authored length survives; without a length the anchor distance is used.
+    expect(d.m_length).toBeCloseTo(60 / SCALE, 5);
+    expect(dNolen.m_length).toBeCloseTo(Math.sqrt(100 * 100 + 100 * 100) / SCALE, 5);
+
+    // The rv pivot's world position is bodyA.p + R·(aa/SCALE) = (100/30, 50/30);
+    // stepping keeps the anchor attached to the body at that point.
+    expect(bodyA.GetWorldPoint(rv.m_localAnchor1).x).toBeCloseTo(100 / SCALE, 5);
+    expect(bodyA.GetWorldPoint(rv.m_localAnchor1).y).toBeCloseTo(50 / SCALE, 5);
+    for (let i = 0; i < 30; i++) e.tick();
+    expect(bodyA.GetWorldPoint(rv.m_localAnchor1).x).toBeCloseTo(100 / SCALE, 5);
+    expect(bodyA.GetWorldPoint(rv.m_localAnchor1).y).toBeCloseTo(50 / SCALE, 5);
+    expect(bodyA.GetWorldPoint(d.m_localAnchor1).x).toBeCloseTo(100 / SCALE, 5);
+    expect(bodyA.GetWorldPoint(d.m_localAnchor1).y).toBeCloseTo(50 / SCALE, 5);
   });
 
   it('constructs a prismatic (lpj) joint with limits, motor, and axis', () => {

--- a/tests/integration/physics-fidelity-p2.test.ts
+++ b/tests/integration/physics-fidelity-p2.test.ts
@@ -52,11 +52,15 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
     expect(warnings.filter(w => /unknown joint type/.test(w))).toHaveLength(0);
   });
 
-  it('rv/d anchors are body-relative offsets on a non-origin body, not world coordinates (#282)', () => {
-    const e = makeEngine();
-    // bodyA sits 100 map px right of the world origin; the authored anchors
-    // are body-relative offsets, exactly as the exporter stores them (§33.8).
-    e.addBody({ name: 'bodyA', type: 'rect', x: 100, y: 0, width: 40, height: 10, static: true, density: 0 } as any);
+  it('rv/d anchors are body-relative offsets that track a rotating body, not world coordinates (#282)', () => {
+    // No gravity: the two dynamic bodies move only from their authored
+    // velocities, so the pivot assertions below are exact.
+    const e = new PhysicsEngine({ gravityY: 0 });
+    // bodyA starts 100 map px right of the world origin and is dynamic with
+    // linear + angular velocity, so its pose changes every tick. A static
+    // body could never expose a detached pivot — drive a moving, rotating
+    // body to prove the world pivot really tracks it (§33.8).
+    e.addBody({ name: 'bodyA', type: 'rect', x: 100, y: 0, width: 40, height: 10, static: false, density: 1, linearVelocity: { x: 0.5, y: 0 }, angularVelocity: 0.5 } as any);
     e.addBody({ name: 'bodyB', type: 'rect', x: 200, y: 0, width: 20, height: 20, static: false, density: 1 } as any);
     const bm = e.getBodyMap() as Map<string, any>;
     const bodyA = bm.get('bodyA') as any;
@@ -88,15 +92,68 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
     expect(d.m_length).toBeCloseTo(60 / SCALE, 5);
     expect(dNolen.m_length).toBeCloseTo(Math.sqrt(100 * 100 + 100 * 100) / SCALE, 5);
 
-    // The rv pivot's world position is bodyA.p + R·(aa/SCALE) = (100/30, 50/30);
-    // stepping keeps the anchor attached to the body at that point.
-    expect(bodyA.GetWorldPoint(rv.m_localAnchor1).x).toBeCloseTo(100 / SCALE, 5);
-    expect(bodyA.GetWorldPoint(rv.m_localAnchor1).y).toBeCloseTo(50 / SCALE, 5);
+    // Step the world: bodyA must actually move and rotate — otherwise the
+    // post-tick pivot assertions below would be vacuous.
     for (let i = 0; i < 30; i++) e.tick();
-    expect(bodyA.GetWorldPoint(rv.m_localAnchor1).x).toBeCloseTo(100 / SCALE, 5);
-    expect(bodyA.GetWorldPoint(rv.m_localAnchor1).y).toBeCloseTo(50 / SCALE, 5);
-    expect(bodyA.GetWorldPoint(d.m_localAnchor1).x).toBeCloseTo(100 / SCALE, 5);
-    expect(bodyA.GetWorldPoint(d.m_localAnchor1).y).toBeCloseTo(50 / SCALE, 5);
+    expect(bodyA.GetAngle()).not.toBeCloseTo(0, 2);
+    const pos = bodyA.GetPosition();
+    expect(pos.x).not.toBeCloseTo(100 / SCALE, 5);
+
+    // The world pivot tracks the rotating body: it stays the authored
+    // body-relative offset transformed by the CURRENT pose — never a fixed
+    // world point (the joint's local anchor is invariant, and its world
+    // position is exactly pos + R·(aa/SCALE) recomputed from the live pose).
+    expect(rv.m_localAnchor1.x).toBeCloseTo(0, 5);
+    expect(rv.m_localAnchor1.y).toBeCloseTo(50 / SCALE, 5);
+    const angle = bodyA.GetAngle();
+    const pivot = bodyA.GetWorldPoint(rv.m_localAnchor1);
+    expect(pivot.x).toBeCloseTo(pos.x + (0 * Math.cos(angle) - (50 / SCALE) * Math.sin(angle)), 5);
+    expect(pivot.y).toBeCloseTo(pos.y + (0 * Math.sin(angle) + (50 / SCALE) * Math.cos(angle)), 5);
+    // The distance-joint anchor stays attached to the same body-frame point.
+    const dPivot = bodyA.GetWorldPoint(d.m_localAnchor1);
+    expect(dPivot.x).toBeCloseTo(pivot.x, 5);
+    expect(dPivot.y).toBeCloseTo(pivot.y, 5);
+  });
+
+  it('rv/d joints without authored anchors pin the pivot at the body origin, not p + R·p (#282)', () => {
+    // The exporter emits anchorA/anchorB: null for joints whose game
+    // definition has no aa/ab (Webscripts/mapexporter.js:560), so this is the
+    // path real maps take. bodyA sits off the world origin — the reported
+    // regression (pivot = p + R·p) is invisible at the origin and would
+    // misplace the pivot by the full body position here.
+    const e = new PhysicsEngine({ gravityY: 0 });
+    e.addBody({ name: 'bodyA', type: 'rect', x: 100, y: 0, width: 40, height: 10, static: false, density: 1, angularVelocity: 0.5 } as any);
+    e.addBody({ name: 'bodyB', type: 'rect', x: 200, y: 0, width: 20, height: 20, static: false, density: 1 } as any);
+    const bm = e.getBodyMap() as Map<string, any>;
+    const bodyA = bm.get('bodyA') as any;
+
+    e.addJoint({ type: 'rv', name: 'j_rv', bodyA: 'bodyA', bodyB: 'bodyB', enableLimit: false }, bm);
+    // No anchors and no length: the d joint constrains the two body origins
+    // to their initial separation (the default length), so nothing yanks.
+    e.addJoint({ type: 'd', name: 'j_d', bodyA: 'bodyA', bodyB: 'bodyB' }, bm);
+
+    const rv = (e as any).createdJoints.get('j_rv');
+    const d = (e as any).createdJoints.get('j_d');
+    expect(rv).toBeTruthy();
+    expect(d).toBeTruthy();
+
+    // No authored anchor → local anchor (0,0): the pivot is the body origin.
+    // The double-add regression would leave rv.m_localAnchor1 at (100/30, 0).
+    expect(rv.m_localAnchor1.x).toBeCloseTo(0, 5);
+    expect(rv.m_localAnchor1.y).toBeCloseTo(0, 5);
+    expect(d.m_localAnchor1.x).toBeCloseTo(0, 5);
+    expect(d.m_localAnchor1.y).toBeCloseTo(0, 5);
+    expect(d.m_localAnchor2.x).toBeCloseTo(0, 5);
+    expect(d.m_localAnchor2.y).toBeCloseTo(0, 5);
+
+    // And it stays pinned to the body frame while the body rotates.
+    for (let i = 0; i < 30; i++) e.tick();
+    expect(bodyA.GetAngle()).not.toBeCloseTo(0, 2);
+    expect(rv.m_localAnchor1.x).toBeCloseTo(0, 5);
+    expect(rv.m_localAnchor1.y).toBeCloseTo(0, 5);
+    const pos = bodyA.GetPosition();
+    expect(bodyA.GetWorldPoint(rv.m_localAnchor1).x).toBeCloseTo(pos.x, 5);
+    expect(bodyA.GetWorldPoint(rv.m_localAnchor1).y).toBeCloseTo(pos.y, 5);
   });
 
   it('constructs a prismatic (lpj) joint with limits, motor, and axis', () => {

--- a/tests/integration/physics-fidelity-p2.test.ts
+++ b/tests/integration/physics-fidelity-p2.test.ts
@@ -158,10 +158,12 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
 
   it('malformed truthy anchors degrade to the body origin, never a NaN pivot (#282)', () => {
     // The map adapter passes anchorA through verbatim (map-adapter.ts:318), so
-    // hand-authored maps can carry truthy-but-invalid anchors (`{}`, `{x: null}`).
-    // makeAnchorA would compute a.x / scale = NaN for these; the rv pivot must
-    // fall back to the body origin exactly like the d-joint branch does via
-    // `?.x ?? 0` — no NaN coordinates may reach the joint def.
+    // hand-authored maps can carry truthy-but-invalid anchors (`{}`, `{x: null}`,
+    // `{x: NaN}`, string coordinates). makeAnchorA would compute a.x / scale =
+    // NaN for these; both the rv pivot guard and the d branch's anchorCoord
+    // sanitizer must degrade them to the body origin — no NaN coordinates may
+    // reach the joint def. (`NaN ?? 0` stays NaN, so a bare `?? 0` would not
+    // be enough for the d branch.)
     const e = new PhysicsEngine({ gravityY: 0 });
     e.addBody({ name: 'bodyA', type: 'rect', x: 100, y: 0, width: 40, height: 10, static: false, density: 1, angularVelocity: 0.5 } as any);
     e.addBody({ name: 'bodyB', type: 'rect', x: 200, y: 0, width: 20, height: 20, static: false, density: 1 } as any);
@@ -172,19 +174,23 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
       ['j_empty', {}],
       ['j_nullx', { x: null, y: 0 }],
       ['j_nully', { x: 0, y: null }],
+      ['j_nanx', { x: NaN, y: 0 }],
+      ['j_nany', { x: 0, y: NaN }],
+      ['j_strx', { x: 'abc', y: 0 }],
+      ['j_stry', { x: 0, y: 'abc' }],
     ] as [string, any][]) {
       e.addJoint({ type: 'rv', name, bodyA: 'bodyA', bodyB: 'bodyB', anchorA: anchor, enableLimit: false }, bm);
       e.addJoint({ type: 'd', name: name + '_d', bodyA: 'bodyA', bodyB: 'bodyB', anchorA: anchor, anchorB: anchor }, bm);
     }
 
-    for (const name of ['j_empty', 'j_nullx', 'j_nully']) {
+    for (const name of ['j_empty', 'j_nullx', 'j_nully', 'j_nanx', 'j_nany', 'j_strx', 'j_stry']) {
       const rv = (e as any).createdJoints.get(name);
       const d = (e as any).createdJoints.get(name + '_d');
       expect(rv).toBeTruthy();
       expect(d).toBeTruthy();
       // Both branches degrade the malformed anchor to the body origin: the rv
       // pivot lands at local (0,0) instead of NaN, and the d joint pins its
-      // local anchors at (0,0) (the `?.x ?? 0` coerce path).
+      // local anchors at (0,0) via the shared anchorCoord finite check.
       for (const a of [rv.m_localAnchor1, d.m_localAnchor1, d.m_localAnchor2]) {
         expect(Number.isFinite(a.x)).toBe(true);
         expect(Number.isFinite(a.y)).toBe(true);

--- a/tests/integration/physics-fidelity-p2.test.ts
+++ b/tests/integration/physics-fidelity-p2.test.ts
@@ -156,6 +156,59 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
     expect(bodyA.GetWorldPoint(rv.m_localAnchor1).y).toBeCloseTo(pos.y, 5);
   });
 
+  it('malformed truthy anchors degrade to the body origin, never a NaN pivot (#282)', () => {
+    // The map adapter passes anchorA through verbatim (map-adapter.ts:318), so
+    // hand-authored maps can carry truthy-but-invalid anchors (`{}`, `{x: null}`).
+    // makeAnchorA would compute a.x / scale = NaN for these; the rv pivot must
+    // fall back to the body origin exactly like the d-joint branch does via
+    // `?.x ?? 0` — no NaN coordinates may reach the joint def.
+    const e = new PhysicsEngine({ gravityY: 0 });
+    e.addBody({ name: 'bodyA', type: 'rect', x: 100, y: 0, width: 40, height: 10, static: false, density: 1, angularVelocity: 0.5 } as any);
+    e.addBody({ name: 'bodyB', type: 'rect', x: 200, y: 0, width: 20, height: 20, static: false, density: 1 } as any);
+    const bm = e.getBodyMap() as Map<string, any>;
+    const bodyA = bm.get('bodyA') as any;
+
+    for (const [name, anchor] of [
+      ['j_empty', {}],
+      ['j_nullx', { x: null, y: 0 }],
+      ['j_nully', { x: 0, y: null }],
+    ] as [string, any][]) {
+      e.addJoint({ type: 'rv', name, bodyA: 'bodyA', bodyB: 'bodyB', anchorA: anchor, enableLimit: false }, bm);
+      e.addJoint({ type: 'd', name: name + '_d', bodyA: 'bodyA', bodyB: 'bodyB', anchorA: anchor, anchorB: anchor }, bm);
+    }
+
+    for (const name of ['j_empty', 'j_nullx', 'j_nully']) {
+      const rv = (e as any).createdJoints.get(name);
+      const d = (e as any).createdJoints.get(name + '_d');
+      expect(rv).toBeTruthy();
+      expect(d).toBeTruthy();
+      // Both branches degrade the malformed anchor to the body origin: the rv
+      // pivot lands at local (0,0) instead of NaN, and the d joint pins its
+      // local anchors at (0,0) (the `?.x ?? 0` coerce path).
+      for (const a of [rv.m_localAnchor1, d.m_localAnchor1, d.m_localAnchor2]) {
+        expect(Number.isFinite(a.x)).toBe(true);
+        expect(Number.isFinite(a.y)).toBe(true);
+        expect(a.x).toBeCloseTo(0, 5);
+        expect(a.y).toBeCloseTo(0, 5);
+      }
+      expect(Number.isFinite(d.m_length)).toBe(true);
+      expect(d.m_length).toBeCloseTo(100 / SCALE, 5);
+    }
+
+    // And the rv pivot stays finite and origin-pinned while the body rotates.
+    for (let i = 0; i < 30; i++) e.tick();
+    const rv = (e as any).createdJoints.get('j_empty');
+    expect(bodyA.GetAngle()).not.toBeCloseTo(0, 2);
+    expect(Number.isFinite(rv.m_localAnchor1.x)).toBe(true);
+    expect(Number.isFinite(rv.m_localAnchor1.y)).toBe(true);
+    expect(rv.m_localAnchor1.x).toBeCloseTo(0, 5);
+    expect(rv.m_localAnchor1.y).toBeCloseTo(0, 5);
+    const pos = bodyA.GetPosition();
+    expect(Number.isFinite(bodyA.GetWorldPoint(rv.m_localAnchor1).x)).toBe(true);
+    expect(bodyA.GetWorldPoint(rv.m_localAnchor1).x).toBeCloseTo(pos.x, 5);
+    expect(bodyA.GetWorldPoint(rv.m_localAnchor1).y).toBeCloseTo(pos.y, 5);
+  });
+
   it('constructs a prismatic (lpj) joint with limits, motor, and axis', () => {
     const e = makeEngine();
     const bm = makeBodyMap(e);

--- a/tests/integration/physics-fidelity-p2.test.ts
+++ b/tests/integration/physics-fidelity-p2.test.ts
@@ -159,11 +159,12 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
   it('malformed truthy anchors degrade to the body origin, never a NaN pivot (#282)', () => {
     // The map adapter passes anchorA through verbatim (map-adapter.ts:318), so
     // hand-authored maps can carry truthy-but-invalid anchors (`{}`, `{x: null}`,
-    // `{x: NaN}`, string coordinates). makeAnchorA would compute a.x / scale =
-    // NaN for these; both the rv pivot guard and the d branch's anchorCoord
-    // sanitizer must degrade them to the body origin — no NaN coordinates may
-    // reach the joint def. (`NaN ?? 0` stays NaN, so a bare `?? 0` would not
-    // be enough for the d branch.)
+    // `{x: NaN}`, string coordinates) and partially-valid anchors (`{x: 5, y: null}`).
+    // makeAnchorA would compute a.x / scale = NaN for these; both the rv pivot
+    // guard and the d branch must degrade the WHOLE anchor to the body origin —
+    // no NaN coordinates may reach the joint def, and no coordinate may survive
+    // a partially-valid anchor (`NaN ?? 0` stays NaN, so a bare `?? 0` would
+    // not be enough for the d branch).
     const e = new PhysicsEngine({ gravityY: 0 });
     e.addBody({ name: 'bodyA', type: 'rect', x: 100, y: 0, width: 40, height: 10, static: false, density: 1, angularVelocity: 0.5 } as any);
     e.addBody({ name: 'bodyB', type: 'rect', x: 200, y: 0, width: 20, height: 20, static: false, density: 1 } as any);
@@ -178,19 +179,21 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
       ['j_nany', { x: 0, y: NaN }],
       ['j_strx', { x: 'abc', y: 0 }],
       ['j_stry', { x: 0, y: 'abc' }],
+      ['j_partialx', { x: 5, y: null }],
+      ['j_partialy', { x: null, y: 5 }],
     ] as [string, any][]) {
       e.addJoint({ type: 'rv', name, bodyA: 'bodyA', bodyB: 'bodyB', anchorA: anchor, enableLimit: false }, bm);
       e.addJoint({ type: 'd', name: name + '_d', bodyA: 'bodyA', bodyB: 'bodyB', anchorA: anchor, anchorB: anchor }, bm);
     }
 
-    for (const name of ['j_empty', 'j_nullx', 'j_nully', 'j_nanx', 'j_nany', 'j_strx', 'j_stry']) {
+    for (const name of ['j_empty', 'j_nullx', 'j_nully', 'j_nanx', 'j_nany', 'j_strx', 'j_stry', 'j_partialx', 'j_partialy']) {
       const rv = (e as any).createdJoints.get(name);
       const d = (e as any).createdJoints.get(name + '_d');
       expect(rv).toBeTruthy();
       expect(d).toBeTruthy();
-      // Both branches degrade the malformed anchor to the body origin: the rv
-      // pivot lands at local (0,0) instead of NaN, and the d joint pins its
-      // local anchors at (0,0) via the shared anchorCoord finite check.
+      // Both branches degrade the malformed or partially-valid anchor to the
+      // body origin: the rv pivot lands at local (0,0), and the d joint pins
+      // both local anchors at (0,0) via the same whole-anchor finite check.
       for (const a of [rv.m_localAnchor1, d.m_localAnchor1, d.m_localAnchor2]) {
         expect(Number.isFinite(a.x)).toBe(true);
         expect(Number.isFinite(a.y)).toBe(true);


### PR DESCRIPTION
Closes #282