### PR TITLE
fix(#262): honor snake_case num_opponents in shared-memory WorkerPool layout

### DIFF
--- a/src/core/worker-pool.ts
+++ b/src/core/worker-pool.ts
@@ -221,8 +221,13 @@ export class WorkerPool {
         // opponent count (mirroring BonkEnvironment's normalization) so every
         // opponent's state fits in the per-env record. All writers and
         // readers (this pool, the workers, the SharedMemoryManager) derive
-        // the same layout from the same config object.
-        const numOpponents = SharedMemoryManager.normalizeNumOpponents(config?.numOpponents);
+        // the same layout from the same config object. The documented
+        // snake_case num_opponents alias resolves here exactly as it does in
+        // BonkEnvironment, so a snake_case-only config sizes the SAB record
+        // for every spawned opponent instead of the default 1 (#262).
+        const numOpponents = SharedMemoryManager.normalizeNumOpponents(
+            config?.numOpponents ?? (config as any)?.num_opponents,
+        );
         this._obsNumOpponents = numOpponents;
         this._obsFloatsPerEnv = 16 + 6 * Math.max(0, numOpponents - 1);
 

--- a/src/core/worker.ts
+++ b/src/core/worker.ts
@@ -159,7 +159,14 @@ parentPort.on('message', (msg) => {
             globalOffset = msg.startId || 0;
             // Size the shared-memory observation buffer and manager for the
             // configured opponent count so all opponents are transported.
-            _obsNumOpponents = SharedMemoryManager.normalizeNumOpponents(config.numOpponents);
+            // The documented snake_case num_opponents alias resolves here
+            // exactly as it does in BonkEnvironment, so a snake_case-only
+            // config sizes the buffer for every spawned opponent instead of
+            // the default 1, which would overflow the SAB record on the
+            // first non-terminal step (#262).
+            _obsNumOpponents = SharedMemoryManager.normalizeNumOpponents(
+                config.numOpponents ?? (config as any)?.num_opponents,
+            );
             _obsBuffer = new Float32Array(16 + 6 * Math.max(0, _obsNumOpponents - 1));
             envs = [];
             for (let i = 0; i < numEnvsParam; i++) {

--- a/tests/integration/worker-pool-opponents-parity.test.ts
+++ b/tests/integration/worker-pool-opponents-parity.test.ts
@@ -146,3 +146,64 @@ describe('SAB multi-opponent parity (issue #210)', () => {
     expect(env.getObservationFast()[15]).toBe(1);
   });
 });
+
+describe('snake_case num_opponents alias parity (issue #262)', () => {
+  it('resolves the documented num_opponents alias in both transports', async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    const run = async (useSharedMemory: boolean) => {
+      const pool = new WorkerPool(1);
+      try {
+        // Only the snake_case spelling, as documented for the Python client:
+        // the SAB layout must be sized from it or the worker crashes on the
+        // first non-terminal step and the pool enters the failed state.
+        await pool.init(1, { maxTicks: 300, num_opponents: 3, seed: 42 }, useSharedMemory);
+        const resetObs = (await pool.reset([42]))[0];
+        expect(resetObs.opponents.length).toBe(3);
+
+        const stepLens: number[] = [];
+        for (let i = 0; i < 5; i++) {
+          stepLens.push((await pool.step([2]))[0].observation.opponents.length);
+        }
+        expect((pool as any).state).toBe('ready');
+        return { resetObs, stepLens, pool };
+      } catch (e) {
+        await pool.close();
+        throw e;
+      }
+    };
+
+    const shared = await run(true);
+    const message = await run(false);
+
+    expect(shared.resetObs.opponents.length).toBe(3);
+    expect(message.resetObs.opponents.length).toBe(3);
+    expect(shared.stepLens).toEqual([3, 3, 3, 3, 3]);
+    expect(message.stepLens).toEqual([3, 3, 3, 3, 3]);
+
+    // Same seed -> same trajectories in both transports for the alias too.
+    for (let i = 0; i < 3; i++) {
+      const a = shared.resetObs.opponents[i];
+      const b = message.resetObs.opponents[i];
+      expect(a.x).toBeCloseTo(b.x, 2);
+      expect(a.y).toBeCloseTo(b.y, 2);
+      expect(a.alive).toBe(b.alive);
+    }
+
+    await shared.pool.close();
+    await message.pool.close();
+  });
+
+  it('normalizes snake_case num_opponents: 0 to zero opponents, not the default 1', async () => {
+    if (!WorkerPool.isSupported()) return;
+    const pool = new WorkerPool(1);
+    try {
+      await pool.init(1, { maxTicks: 300, num_opponents: 0, seed: 42 }, true);
+      const resetObs = (await pool.reset([42]))[0];
+      expect(resetObs.opponents.length).toBe(0);
+      expect((pool as any).state).toBe('ready');
+    } finally {
+      await pool.close();
+    }
+  });
+});

--- a/tests/integration/worker-pool-opponents-parity.test.ts
+++ b/tests/integration/worker-pool-opponents-parity.test.ts
@@ -194,16 +194,75 @@ describe('snake_case num_opponents alias parity (issue #262)', () => {
     await message.pool.close();
   });
 
+  it('prefers camelCase numOpponents over the snake_case alias when both are supplied', async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    const run = async (useSharedMemory: boolean) => {
+      const pool = new WorkerPool(1);
+      try {
+        // Both spellings supplied: the camelCase key must win, mirroring
+        // BonkEnvironment's `numOpponents ?? num_opponents ?? 1` resolution
+        // (src/core/environment.ts). A reordering of that chain in either
+        // site would silently diverge from the environment without this test.
+        await pool.init(1, { maxTicks: 300, numOpponents: 5, num_opponents: 3, seed: 42 }, useSharedMemory);
+        const resetObs = (await pool.reset([42]))[0];
+        expect(resetObs.opponents.length).toBe(5);
+
+        const stepLens: number[] = [];
+        for (let i = 0; i < 5; i++) {
+          stepLens.push((await pool.step([2]))[0].observation.opponents.length);
+        }
+        expect((pool as any).state).toBe('ready');
+        return { resetObs, stepLens, pool };
+      } catch (e) {
+        await pool.close();
+        throw e;
+      }
+    };
+
+    const shared = await run(true);
+    const message = await run(false);
+
+    expect(shared.resetObs.opponents.length).toBe(5);
+    expect(message.resetObs.opponents.length).toBe(5);
+    expect(shared.stepLens).toEqual([5, 5, 5, 5, 5]);
+    expect(message.stepLens).toEqual([5, 5, 5, 5, 5]);
+
+    await shared.pool.close();
+    await message.pool.close();
+  });
+
   it('normalizes snake_case num_opponents: 0 to zero opponents, not the default 1', async () => {
     if (!WorkerPool.isSupported()) return;
-    const pool = new WorkerPool(1);
-    try {
-      await pool.init(1, { maxTicks: 300, num_opponents: 0, seed: 42 }, true);
-      const resetObs = (await pool.reset([42]))[0];
-      expect(resetObs.opponents.length).toBe(0);
-      expect((pool as any).state).toBe('ready');
-    } finally {
-      await pool.close();
-    }
+
+    const run = async (useSharedMemory: boolean) => {
+      const pool = new WorkerPool(1);
+      try {
+        await pool.init(1, { maxTicks: 300, num_opponents: 0, seed: 42 }, useSharedMemory);
+        const resetObs = (await pool.reset([42]))[0];
+        expect(resetObs.opponents.length).toBe(0);
+
+        // A step after the empty reset pins the 16-float empty layout write
+        // path (no opponent blocks written) on both transports.
+        const stepObs = (await pool.step([2]))[0].observation;
+        expect(stepObs.opponents.length).toBe(0);
+        expect((pool as any).state).toBe('ready');
+        return { resetObs, stepObs, pool };
+      } catch (e) {
+        await pool.close();
+        throw e;
+      }
+    };
+
+    const shared = await run(true);
+    const message = await run(false);
+
+    expect(shared.resetObs.opponents.length).toBe(0);
+    expect(message.resetObs.opponents.length).toBe(0);
+    expect(shared.stepObs.opponents.length).toBe(0);
+    expect(message.stepObs.opponents.length).toBe(0);
+
+    await shared.pool.close();
+    await message.pool.close();
   });
 });


### PR DESCRIPTION
Closes #262.

## Summary

\WorkerPool.init()\ and the worker sized the shared-memory observation layout from the camelCase \
umOpponents\ key only, while \BonkEnvironment\ also honors the documented snake_case \
um_opponents\ alias. A snake_case-only config (\{ num_opponents: 3 }\) spawned N opponents but laid out a 16-float SAB record for 1: reset silently dropped opponents 2..N, and the first non-terminal step crashed the worker with \RangeError: offset is out of bounds\ in \SharedMemoryManager.writeObservation()\, permanently failing the pool.

## Changes

- \src/core/worker-pool.ts\ — \initInternal\ resolves \config?.numOpponents ?? config.num_opponents\ before \
ormalizeNumOpponents()\, mirroring \BonkEnvironment\ (\src/core/environment.ts:350\).
- \src/core/worker.ts\ — \init\ resolves the same alias when sizing \_obsNumOpponents\/\_obsBuffer\.
- \	ests/integration/worker-pool-opponents-parity.test.ts\ — new regression block: snake_case \
um_opponents: 3\ returns 3 opponents in reset and 5 steps in both transports (pool stays \eady\), and \
um_opponents: 0\ normalizes to 0 opponents.

## Verification

- \
pm run typecheck\ — passes.
- \
px vitest run tests/integration/worker-pool-opponents-parity.test.ts\ — 7/7 passed (2 new).
- \
pm test\ — 1559 passed / 19 skipped; the single failure (\snapshot-ring-stress.test.ts\ torn-read stress, timing-sensitive) passes in isolation and is unrelated to this change.