### PR TITLE
fix(test,docs): aiPlayerId spawn vs bundled WDB map + August 2026 batch tracker

### DIFF
--- a/docs/FIXES-2026-08.md
+++ b/docs/FIXES-2026-08.md
@@ -1,0 +1,83 @@
+# Fidelity & Remediation Batches — August 2026
+
+Records the coordinated pull-request batches merged into `main` that restored
+native Bonk.io physics/runtime fidelity and closed a set of reported defects.
+Each entry lists the merged PR(s), the issue they close, and the subsystem they
+touch. These batches are additive to the audit in
+[`OPEN_ISSUE_REMEDIATION.md`](OPEN_ISSUE_REMEDIATION.md), which covers the
+earlier `#27`-`#161` scope.
+
+## Validation Gate
+
+Every batch passed, on the fully-merged `main`:
+
+- `npm run typecheck`
+- `npm test` (vitest run — full suite)
+- `python -m pytest python/tests/test_bonk_vec_env.py python/tests/test_bonk_vec_env_unit.py`
+- e2e IPC bridge and worker-pool black-box suites
+
+## Batch 1 skill — Native joint & map fidelity (issues #275-#287)
+
+Base native physics P2 joint model with the exporter and adapter in sync.
+
+| Issue | Merged PR |
+|--:|---|
+| #287 | [#289](https://github.com/Varuu-0/bonk-rl-env/pull/289) — snapshot-ring stress test hands the worker's first commit before sampling |
+| #286 | [#291](https://github.com/Varuu-0/bonk-rl-env/pull/291) — `normalizeMap` drops `frequencyHz`/`dampingRatio` from exported distance joints |
+| #285 | [#297](https://github.com/Varuu-0/bonk-rl-env/pull/297) — exporter emits native gear-joint referents and ratio |
+| #284 | [#290](https://github.com/Varuu-0/bonk-rl-env/pull/290) — forward rv-joint `lowerAngle`/`upperAngle` through `normalizeMap` |
+| #283 | [#295](https://github.com/Varuu-0/bonk-rl-env/pull/295) — skip null `physicsJoints` entries in `normalizeMap` |
+| #282 | [#312](https://github.com/Varuu-0/bonk-rl-env/pull/312) — consume exported rv/d joint anchors as body-relative offsets |
+| #281 | [#298](https://github.com/Varuu-0/bonk-rl-env/pull/298) — correct lpj/lsj motor and translation-limit field mapping |
+| #280 | [#292](https://github.com/Varuu-0/bonk-rl-env/pull/292) — prismatic-joint axis derived from exported angle |
+| #273 | [#294](https://github.com/Varuu-0/bonk-rl-env/pull/294) — preserve `spawnPoints`/`capZones`/`joints` for MapDefs without a `bodies` array |
+
+Integration notes:
+
+- Conflict-free merges consolidated the joint regression coverage into
+  `tests/integration/physics-fidelity-p2.test.ts`.
+- #294 additionally restored loading of the bundled WDB default map (`maps/`
+  `bonk_WDB__No_Mapshake__716916.json`); the environment now spawns on the real
+  map (Blue Offense `(-100, 212.5)`, Red Offense `(100, 212.5)`) instead of
+  falling back to the embedded box, which required updating the pre-existing
+  spawn assertions in `tests/integration/env-ai-player-id.test.ts`.
+
+## Batch 2 — Environment & IPC lifecycle (issues #259-#270)
+
+| Issue | Merged PR |
+|--:|---|
+| #259 | [#311](https://github.com/Varuu-0/bonk-rl-env/pull/311) — floor `maxClientSessions` cap to an integer |
+| #262 | [#314](https://github.com/Varuu-0/bonk-rl-env/pull/314) — honor snake_case `num_opponents` in shared-memory WorkerPool layout |
+| #263 | [#308](https://github.com/Varuu-0/bonk-rl-env/pull/308) — recreate the ROUTER socket so IPC bridge restarts after `close()` |
+| #265 | [#306](https://github.com/Varuu-0/bonk-rl-env/pull/306) — re-register port on restart so it stays tracked |
+| #266 | [#305](https://github.com/Varuu-0/bonk-rl-env/pull/305) — reject non-positive `maxTicks` at construction |
+| #267 | [#304](https://github.com/Varuu-0/bonk-rl-env/pull/304) — `BonkEnv.start()` rejects overlapping calls (mixed-memory `portReserved`/`startPromise` lifecycle) |
+| #269 | [#303](https://github.com/Varuu-0/bonk-rl-env/pull/303) — validate `WorkerPool.numWorkers` and guard config auto-detect |
+| #270 | [#296](https://github.com/Varuu-0/bonk-rl-env/pull/296) — first-wins local/bypass session pin |
+
+Integration notes:
+
+- #306 retained the already-merged mixed-memory port lifecycle from #267
+  (`portReserved`, `reservePortForStart`, `startPromise`) while preserving #265's
+  restart/wraparound/exhaustion tests.
+- #270 (render `DetachedRenderSampler` sequence-wrap) and #296 are grouped here
+  as cross-cutting lifecycle fixes.
+
+## Batch 3 — Validation, physics guards, rendering, Python (issues #260-#278)
+
+| Issue | Merged PR |
+|--:|---|
+| #260 | [#310](https://github.com/Varuu-0/bonk-rl-env/pull/310) — coalesce frame-skip terminal hold into one episode boundary (Python vec-env) |
+| #261 | [#309](https://github.com/Varuu-0/bonk-rl-env/pull/309) — reject out-of-range encoded actions `[0, 63]` in both transports |
+| #271 | [#302](https://github.com/Varuu-0/bonk-rl-env/pull/302) — fail-safe OOB death for NaN disc positions |
+| #272 | [#293](https://github.com/Varuu-0/bonk-rl-env/pull/293) — key detached render-sampler stale-frame guard on seqlock sequence |
+| #276 | [#300](https://github.com/Varuu-0/bonk-rl-env/pull/300) — clamp fixture friction non-negative so `f_p` surfaces cannot NaN the disc |
+| #277 | [#299](https://github.com/Varuu-0/bonk-rl-env/pull/299) — size polygon-fixture cap-zone sensors from vertex bounds |
+| #278 | [#301](https://github.com/Varuu-0/bonk-rl-env/pull/301) — reject malformed action values across all transports |
+
+Integration notes:
+
+- #301 (`assertValidAction`) merged with #309's encoded-number range guard so
+  both malformed-shape and out-of-range actions fail loudly.
+- #271/#276 OOB and friction guards were combined into single guards with
+  merged comments.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Additional documents:
 | [DEOBFUSCATION_FIX_TRACKER.md](DEOBFUSCATION_FIX_TRACKER.md) | Simulator discrepancies and implementation status derived from verified findings |
 | [DEOBFUSCATION_ROADMAP.md](DEOBFUSCATION_ROADMAP.md) | Proof-first staged backlog for remaining `alpha2s.js` deobfuscation work |
 | [OPEN_ISSUE_REMEDIATION.md](OPEN_ISSUE_REMEDIATION.md) | Evidence-based disposition and PR progress for the full open-issue audit |
+| [FIXES-2026-08.md](FIXES-2026-08.md) | August 2026 fidelity batches: merged joint/model, lifecycle, validation, render, IPC, and Python vec-env fixes |
 | [RENDERER.md](RENDERER.md) | Simulation renderer rebuild (M1–M5): native-coordinate layers, zero-overhead detached transport, usage |
 
 ## Subdirectories

--- a/tests/integration/env-ai-player-id.test.ts
+++ b/tests/integration/env-ai-player-id.test.ts
@@ -17,13 +17,13 @@ describe('Environment aiPlayerId wiring (#221)', () => {
     env = new BonkEnvironment({ aiPlayerId: 1, numOpponents: 1, maxTicks: 100, randomOpponent: false });
     const obs = env.reset();
 
-    // Default_Box blue AI spawn is (-200, -100) and the red opponent spawn
-    // is (200, -100).
+    // The bundled WDB default map's Blue Offense AI spawn is (-100, 212.5)
+    // and the Red Offense opponent spawn is (100, 212.5).
     expect(obs.opponents).toHaveLength(1);
-    expect(obs.playerX).toBeCloseTo(-200, 6);
-    expect(obs.playerY).toBeCloseTo(-100, 6);
-    expect(obs.opponents[0].x).toBeCloseTo(200, 6);
-    expect(obs.opponents[0].y).toBeCloseTo(-100, 6);
+    expect(obs.playerX).toBeCloseTo(-100, 6);
+    expect(obs.playerY).toBeCloseTo(212.5, 6);
+    expect(obs.opponents[0].x).toBeCloseTo(100, 6);
+    expect(obs.opponents[0].y).toBeCloseTo(212.5, 6);
 
     // The observation's player fields must be the physics state of slot 1
     // (the configured AI slot), NOT the hardcoded slot 0. With the buggy


### PR DESCRIPTION
## Summary

Follow-up to the merged August-2026 fidelity batches: the joint/map-fidelity
change (`fix(#273)` #294) restored loading of the bundled WDB default map, so
the environment now spawns on the real map (Blue Offense `(-100, 212.5)`, Red
Offense `(100, 212.5)`) instead of falling back to the embedded box. This PR
updates the pre-existing `aiPlayerId` integration assertion to the real spawn
points and adds the batch tracker doc.

## Changes

- `tests/integration/env-ai-player-id.test.ts` — update the hardcoded spawn
  coordinates from the embedded `Default_Box` (`-200,-100` / `200,-100`) to the
  bundled WDB default map's real spawns, matching the restored-map behavior.
- `docs/FIXES-2026-08.md` — new tracker summarizing the merged joint/model
  fidelity, environment/IPC lifecycle, validation, render, and Python vec-env
  fixes with their issue → PR mappings.
- `docs/README.md` — link the new tracker.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Pre-flight Checklist

- [x] `npm run typecheck` passes
- [x] `npm test` passes (full vitest suite: 93 files / 1694 tests)
- [x] `python -m pytest python/tests/test_bonk_vec_env.py python/tests/test_bonk_vec_env_unit.py` passes (80 tests)
- [x] Change does not generate new lint or type errors
- [x] Unrelated untracked files were not committed