### PR TITLE
feat(physics): P3b per-map settings runtime gating (fl flipped force, nc no-collide, re respawn)

### DIFF
--- a/docs/DEOBFUSCATION_FIX_TRACKER.md
+++ b/docs/DEOBFUSCATION_FIX_TRACKER.md
@@ -271,13 +271,21 @@ Chronological record of fixes applied. Append new entries here.
   velocity, grapple released, alive/deathType reset) applied in the death
   pass before detach; spawn points are recorded at addPlayer. `a1a` is not
   reset (the native branch does not touch it); the port does not model spawn
-  velocity, so respawns are at rest.
-- Tests: `tests/integration/physics-fidelity-p3b.test.ts` (9 tests) — flipped
-  force magnitude (default, flipped, explicit override, env forwarding);
-  nc masks drop every player bit while map geometry stays solid + overlapping
-  discs pass through (control separates); OOB death respawns at spawn next
-  tick (alive, deathType 0, grapple cleared) vs stays dead without `re`;
-  type-3 deaths stay permanent with `re` on.
+  velocity, so respawns are at rest. Fail-safe (malformed-map guard): a spawn
+  point outside the OOB death circle detaches instead of churning
+  death→respawn every tick (native would churn identically; the port follows
+  its #271/#276 corruption fail-safe policy).
+- Config symmetry: `flipped` / `respawnEnabled` environment config keys now
+  override the map settings exactly like `noCollide` vs `settings.nc`;
+  `setFlipped` re-runs the #234 ascent-invariant check on the effective base.
+- Tests: `tests/integration/physics-fidelity-p3b.test.ts` (13 tests) — flipped
+  force magnitude (default, flipped, explicit override, env forwarding,
+  config-override precedence, setFlipped re-warn); nc masks drop every player
+  bit while map geometry stays solid + overlapping discs pass through
+  (control separates to the 2×radius touching distance); OOB death respawns
+  at spawn next tick (alive, deathType 0, grapple cleared) vs stays dead
+  without `re`; type-3 deaths stay permanent with `re` on; OOB spawn point
+  detaches without churn.
 - Docs: `PHYSICS_FIDELITY_PLAN.md` P3b section + milestone row added.
 - Verification: `tsc --noEmit` clean; P0/P1/P2/P3/P3b/P4 + config-consumed +
   map suites green (172 tests; the pre-existing unrelated

--- a/docs/DEOBFUSCATION_FIX_TRACKER.md
+++ b/docs/DEOBFUSCATION_FIX_TRACKER.md
@@ -247,6 +247,42 @@ the maps.
 
 Chronological record of fixes applied. Append new entries here.
 
+### 2026-08-12 — P3b: runtime gating of `fl` / `nc` / `re` map settings
+
+- **`fl` (flipped)** — the native move-force base is 12, or **20 when `fl`**
+  (`state.ms.fl ? 20 : 12`, DEOBFUSCATION §11 720-730/935/4055). The engine
+  gains `flipped` + `flippedMoveForce` options: while flipped, the per-tick
+  movement base is `flippedMoveForce` (default `MOVE_FORCE × 20/12` = 50,
+  preserving the native proportion on the port's tuned 30 base; P0
+  abstraction rule). `warnAscentInvariantBreak` now checks the effective
+  (flipped) base. `BonkEnvironment` forwards `mapData.settings.fl`.
+- **`nc` (no collision)** — all disc-disc contacts are disabled
+  (`contact.SetEnabled(false)` when `physics.nc`, readable 1300-1303; §Key
+  Collision Rules 5). The engine's existing `setNoCollide` disc-filter path is
+  now actually wired from the map: the environment previously read the
+  nonexistent `mapDef.physics?.nc` (the adapter's physics object carries only
+  ppm/bounds/deathCenter), silently ignoring the setting; it now resolves
+  `config.noCollide ?? mapDef.settings.nc`.
+- **`re` (respawning)** — a disc that died respawns immediately at its spawn
+  point with cleared grapple and fresh velocity (`x=sx; y=sy; xv=sxv; yv=syv;
+  ni=true; delete swing`, readable 8595-8606); cap-zone eliminations (death
+  type 3) stay permanent (§alive rule, readable 8463). The engine gains
+  `respawnEnabled` + `respawnPlayer` (SetXForm to the recorded spawn, zeroed
+  velocity, grapple released, alive/deathType reset) applied in the death
+  pass before detach; spawn points are recorded at addPlayer. `a1a` is not
+  reset (the native branch does not touch it); the port does not model spawn
+  velocity, so respawns are at rest.
+- Tests: `tests/integration/physics-fidelity-p3b.test.ts` (9 tests) — flipped
+  force magnitude (default, flipped, explicit override, env forwarding);
+  nc masks drop every player bit while map geometry stays solid + overlapping
+  discs pass through (control separates); OOB death respawns at spawn next
+  tick (alive, deathType 0, grapple cleared) vs stays dead without `re`;
+  type-3 deaths stay permanent with `re` on.
+- Docs: `PHYSICS_FIDELITY_PLAN.md` P3b section + milestone row added.
+- Verification: `tsc --noEmit` clean; P0/P1/P2/P3/P3b/P4 + config-consumed +
+  map suites green (172 tests; the pre-existing unrelated
+  `env-ai-player-id` failure reproduces on unmodified main).
+
 ### 2026-08-12 — P4: differential validation (capture harness + replay comparator + exact-match gates)
 
 - **Capture harness** — records per-tick native disc state into a versioned

--- a/docs/PHYSICS_FIDELITY_PLAN.md
+++ b/docs/PHYSICS_FIDELITY_PLAN.md
@@ -69,7 +69,11 @@ The remaining per-map settings now gate runtime behavior, all read from
   (death type 3) stay permanent (§alive rule, readable 8463). Engine option
   `respawnEnabled` + `respawnPlayer`; env forwards `settings.re`. The port
   does not model spawn velocity, so respawns re-spawn at rest; `a1a` is not
-  reset (the native branch does not touch it).
+  reset (the native branch does not touch it). Fail-safe: a spawn point
+  outside the OOB death circle detaches instead of churning every tick.
+- Config override symmetry: the `flipped` / `respawnEnabled` environment
+  config keys win over the map settings, mirroring `noCollide` vs
+  `settings.nc`.
 
 ### Differential validation (P4) — IMPLEMENTED (2026-08-12)
 - **Capture harness** (`Webscripts/rl-trace-capture.user.js` +

--- a/docs/PHYSICS_FIDELITY_PLAN.md
+++ b/docs/PHYSICS_FIDELITY_PLAN.md
@@ -46,11 +46,30 @@ no ground joints.
   read only by the map decoder/sanitizer/serializer and the editor. P3
   therefore exposes `gd` on `MapDef.settings` (sanitized ≥ 2, per the native
   sanitizer) but does NOT apply it; the engine keeps config/default gravity.
-  Runtime gd application is deferred to the P4 differential gate, which can
-  confirm or refute live host-side behavior.
-- `re/nc/fl` gating — exposed via `MapDef.settings` in P3; runtime gating
-  (nc → no-collide, fl → flipped move-force base) is a follow-up (P3b).
 - Death circle = 850 map px from map center, ppm-independent (lines 1557-1563) — engine already correct.
+
+### Map settings runtime gating (P3b) — IMPLEMENTED (2026-08-12)
+The remaining per-map settings now gate runtime behavior, all read from
+`MapDef.settings` (the sanitized native `s` object) and cited to the readable
+2026-07-29 artifact:
+- `fl` (flipped) — the move-force base is native **12**, **20 when `fl`**
+  (`state.ms.fl ? 20 : 12`, §11 720-730/935/4055). The port keeps its tuned
+  base (`MOVE_FORCE` = 30, #234 ascent invariant) and applies the same ratio
+  (`MOVE_FORCE_FLIP_MULTIPLIER = 20/12`) as `flippedMoveForce`, preserving the
+  native proportion on any scale (P0 abstraction rule). Engine option
+  `flipped` / `flippedMoveForce`; env forwards `settings.fl`.
+- `nc` (no collision) — all disc-disc contacts disabled (`contact.SetEnabled
+  (false)` when `physics.nc`, readable 1300-1303; §Key Collision Rules 5).
+  The engine's existing `setNoCollide` disc-filter path is now wired from
+  `settings.nc` (previously the env read the nonexistent `physics?.nc` and
+  silently ignored the map setting).
+- `re` (respawning) — a disc that died respawns **immediately at its spawn
+  point** with cleared grapple and fresh velocity (`x=sx; y=sy; xv=sxv;
+  yv=syv; ni=true; delete swing`, readable 8595-8606); cap-zone eliminations
+  (death type 3) stay permanent (§alive rule, readable 8463). Engine option
+  `respawnEnabled` + `respawnPlayer`; env forwards `settings.re`. The port
+  does not model spawn velocity, so respawns re-spawn at rest; `a1a` is not
+  reset (the native branch does not touch it).
 
 ### Differential validation (P4) — IMPLEMENTED (2026-08-12)
 - **Capture harness** (`Webscripts/rl-trace-capture.user.js` +
@@ -88,10 +107,11 @@ no ground joints.
 | **P1** | Fixture fidelity | density clamp ≥0.0001, friction polarity, restitution fallback, mask-bit spec | fixture-level unit tests asserting exact numbers from §33.4 |
 | **P2** | Joint model | implement `rv` limits/motor, `d` fh/len, `lpj/lsj/p` prismatic params, gear `g`, ground joints | joint invariant tests per §33.7 formulas |
 | **P3** | Map physics settings | per-map `pq`→solver iters (2/6 low, 15/15 high), `gd`→exposed on MapDef.settings (runtime application deferred: native enforces gravity 20, pretty 7238-7240) | engine-level tests: pq changes solver behavior; gd does NOT override gravity (enforcement parity) |
+| **P3b** | Settings runtime gating | `fl`→flipped move-force base (×20/12), `nc`→disc-disc no-collide, `re`→immediate respawn at spawn point (type-3 deaths permanent) | engine/env-level tests: flipped force magnitude; nc masks drop player bits + pass-through behavior; OOB death respawns vs stays dead; type-3 permanence |
 | **P4** | Differential validation | capture harness (record native snapshots) + replay comparator + fixture/joint exact-match gates | comparator diff ≤ tolerance (validated: neutral-run replay ≈ 0, perturbed trace fails); gates pass on bundled maps; live capture workflow documented |
 | **P5** | Docs + gating | update DEOBFUSCATION_FIX_TRACKER with ✅/❌/partial per item; every claim cited | PR review gate |
 
 ## Dependency order
-P0 → P1 → P4(capture harness) → P2 → P3 → P4(comparison) → P5.
+P0 → P1 → P4(capture harness) → P2 → P3 → P3b → P4(comparison) → P5.
 P4-capture must precede P2 so joint anchors are verified against real native
 state; P1 is independent and can proceed first.

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -461,7 +461,7 @@ export class BonkEnvironment {
             randomOppHeavyProb: oppHeavyProb,
             randomOppGrappleProb: oppGrappleProb,
             teamsEnabled: config.teamsEnabled ?? ((mapDef as any).physics?.teams ?? false),
-            noCollide: config.noCollide ?? ((mapDef as any).physics?.nc ?? false),
+            noCollide: config.noCollide ?? (mapDef as any).settings?.nc ?? false,
             physics: config.physics ?? {},
             arena: config.arena ?? {},
             player: config.player ?? {},
@@ -504,6 +504,12 @@ export class BonkEnvironment {
             // anything else → 2/6 (DEOBFUSCATION §Solver Iterations). Explicit
             // solverIterations/positionIterations config keys override it.
             physicsQuality: this.config.mapData.settings?.pq,
+            // Per-map native settings (P3b): `fl` flips the move-force base,
+            // `re` enables immediate respawn on death (except cap-zone
+            // eliminations). Both are read from mapData.settings like pq —
+            // the config object is not a settings source.
+            flipped: !!this.config.mapData.settings?.fl,
+            respawnEnabled: !!this.config.mapData.settings?.re,
             scale: config.physics?.scale,
             gravityX: config.physics?.gravityX,
             gravityY: config.physics?.gravityY,

--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -132,6 +132,13 @@ export interface EnvironmentConfig {
     teamsEnabled?: boolean;
     /** Native no-collision physics mode (`nc`): discs never collide (default false) */
     noCollide?: boolean;
+    /** Native flipped map mode (`fl`): flipped move-force base (default false).
+     *  Explicit config wins over the map's `settings.fl` (symmetric with
+     *  `noCollide` vs `settings.nc`). */
+    flipped?: boolean;
+    /** Native respawning mode (`re`): dead discs respawn at their spawn point
+     *  (default false). Explicit config wins over the map's `settings.re`. */
+    respawnEnabled?: boolean;
     /** Documented physics.* tuning forwarded to the PhysicsEngine (issue #217).
      *  Absent keys keep the engine's sanity defaults, so an env built without a
      *  physics section runs with the exact verified native values. */
@@ -462,6 +469,10 @@ export class BonkEnvironment {
             randomOppGrappleProb: oppGrappleProb,
             teamsEnabled: config.teamsEnabled ?? ((mapDef as any).physics?.teams ?? false),
             noCollide: config.noCollide ?? (mapDef as any).settings?.nc ?? false,
+            // Symmetric with noCollide: explicit config overrides the map's
+            // per-map settings (P3b fl/re gating).
+            flipped: config.flipped ?? !!((mapDef as any).settings?.fl),
+            respawnEnabled: config.respawnEnabled ?? !!((mapDef as any).settings?.re),
             physics: config.physics ?? {},
             arena: config.arena ?? {},
             player: config.player ?? {},
@@ -506,10 +517,11 @@ export class BonkEnvironment {
             physicsQuality: this.config.mapData.settings?.pq,
             // Per-map native settings (P3b): `fl` flips the move-force base,
             // `re` enables immediate respawn on death (except cap-zone
-            // eliminations). Both are read from mapData.settings like pq —
-            // the config object is not a settings source.
-            flipped: !!this.config.mapData.settings?.fl,
-            respawnEnabled: !!this.config.mapData.settings?.re,
+            // eliminations). Resolved at construction (config wins over the
+            // map) and forwarded like pq — the raw config object is not a
+            // settings source the engine re-reads.
+            flipped: this.config.flipped,
+            respawnEnabled: this.config.respawnEnabled,
             scale: config.physics?.scale,
             gravityX: config.physics?.gravityX,
             gravityY: config.physics?.gravityY,

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -142,6 +142,15 @@ export const WORLD_AABB_EXTENT = 5000;
  */
 export const MOVE_FORCE = 30.0;
 
+/**
+ * Native `fl` (flipped) ratio: the move-force base is 12 normally and 20 on
+ * flipped maps (DEOBFUSCATION §11 "Move Force", readable
+ * `state.ms.fl ? 20 : 12`), so the flipped base = base × 20/12. The port keeps
+ * its own tuned base (MOVE_FORCE, #234 ascent invariant) and applies the same
+ * ratio, preserving the native proportion on any scale (P0 abstraction rule).
+ */
+export const MOVE_FORCE_FLIP_MULTIPLIER = 20 / 12;
+
 /** Bonk's circular death boundary in native map pixels; consumed as `850 / SCALE` world units in this port. */
 export const OUT_OF_BOUNDS_DISTANCE = 850;
 
@@ -317,6 +326,18 @@ export interface PhysicsEngineOptions {
     /** Force multiplier applied while heavy. Default: HEAVY_FORCE_MULTIPLIER (0.7).
      *  `moveForce × heavyForceMultiplier` must exceed `gravityY` for up+heavy to lift. */
     heavyForceMultiplier?: number;
+    /** Native map setting `fl` (flipped): when true the movement-force base is
+     *  `flippedMoveForce` instead of `moveForce` (native 12 → 20, §11). */
+    flipped?: boolean;
+    /** Move-force base used while `flipped` is true. Default: MOVE_FORCE ×
+     *  MOVE_FORCE_FLIP_MULTIPLIER (30 × 20/12 = 50), preserving the native
+     *  12 → 20 ratio on the port's tuned base. */
+    flippedMoveForce?: number;
+    /** Native map setting `re` (respawning): when true a disc that dies
+     *  (except the permanent cap-zone elimination, death type 3) respawns
+     *  immediately at its spawn point with cleared grapple (native state-sync
+     *  branch, readable 8595-8606). */
+    respawnEnabled?: boolean;
 }
 
 /** Frozen final transforms of a dead disc, snapshotted when its body is detached
@@ -384,6 +405,16 @@ export class PhysicsEngine {
   private arenaBoundsMargin: number = ARENA_BOUNDS_MARGIN;
   private moveForce: number = MOVE_FORCE;
   private heavyForceMultiplier: number = HEAVY_FORCE_MULTIPLIER;
+  /** Native map setting `fl`: flipped maps use the flipped move-force base. */
+  private flipped: boolean = false;
+  /** Move-force base used while flipped (native 12 → 20, §11). */
+  private flippedMoveForce: number = MOVE_FORCE * MOVE_FORCE_FLIP_MULTIPLIER;
+  /** Native map setting `re`: dead discs respawn at their spawn point
+   *  (cap-zone eliminations stay permanent). */
+  private respawnEnabled: boolean = false;
+  /** Spawn point per player (world units), recorded at addPlayer for `re`
+   *  respawns (native `sx`/`sy`). */
+  private playerSpawnPoints: Map<number, { x: number; y: number }> = new Map();
   /** Running arena extents in metres, folded in O(1) per addBody so map build
    *  and episode reset stay linear instead of rescanning every platform body
    *  (the old per-add full pass was O(bodies²)). */
@@ -443,6 +474,9 @@ export class PhysicsEngine {
     this.arenaBoundsMargin = PhysicsEngine.sanitizeNonNegative(options.arenaBoundsMargin, ARENA_BOUNDS_MARGIN);
     this.moveForce = PhysicsEngine.sanitizePositive(options.moveForce, MOVE_FORCE);
     this.heavyForceMultiplier = PhysicsEngine.sanitizeNonNegative(options.heavyForceMultiplier, HEAVY_FORCE_MULTIPLIER);
+    this.flipped = PhysicsEngine.sanitizeBoolean(options.flipped, false);
+    this.flippedMoveForce = PhysicsEngine.sanitizePositive(options.flippedMoveForce, this.moveForce * MOVE_FORCE_FLIP_MULTIPLIER);
+    this.respawnEnabled = PhysicsEngine.sanitizeBoolean(options.respawnEnabled, false);
     this.oobRadiusSquared = Math.pow(OUT_OF_BOUNDS_DISTANCE / this.scale, 2);
     this.warnAscentInvariantBreak();
     this.createWorld();
@@ -468,10 +502,13 @@ export class PhysicsEngine {
     // only ever helps a disc rise, so it is always in a lifting regime.
     if (this.gravityY <= 0) return;
     const gravity = this.gravityY;
-    const heavyLift = this.moveForce * this.heavyForceMultiplier;
-    if (gravity >= this.moveForce) {
+    // Flipped maps run on the flipped base — the invariant must hold for the
+    // base that is actually applied per tick.
+    const base = this.flipped ? this.flippedMoveForce : this.moveForce;
+    const heavyLift = base * this.heavyForceMultiplier;
+    if (gravity >= base) {
       console.warn(
-        `[PhysicsEngine] gravityY ${gravity.toFixed(1)} >= moveForce ${this.moveForce.toFixed(1)}: pure 'up' cannot beat gravity (#234 ascent invariant broken).`,
+        `[PhysicsEngine] gravityY ${gravity.toFixed(1)} >= moveForce ${base.toFixed(1)}: pure 'up' cannot beat gravity (#234 ascent invariant broken).`,
       );
     } else if (gravity >= heavyLift) {
       console.warn(
@@ -890,6 +927,16 @@ export class PhysicsEngine {
     this.updateAllPlayerFilters();
   }
 
+  /** Enable/disable the native flipped (`fl`) move-force base. */
+  setFlipped(enabled: boolean): void {
+    this.flipped = !!enabled;
+  }
+
+  /** Enable/disable the native respawning (`re`) mode. */
+  setRespawnEnabled(enabled: boolean): void {
+    this.respawnEnabled = !!enabled;
+  }
+
   /**
    * Native last-hit attribution (`lhid`/`lht`) for a player.
    * Returns null once the 120-tick attribution window has expired.
@@ -1282,6 +1329,9 @@ export class PhysicsEngine {
     this.playerHeavyState.set(id, false);
     this.playerAlive.set(id, true);
     this.playerDeathType.set(id, 0);
+    // Record the spawn point (world units) for `re` respawns — the native
+    // `sx`/`sy` a disc returns to on respawn (readable 8599-8602).
+    this.playerSpawnPoints.set(id, { x: x / this.scale, y: y / this.scale });
     // Native a1a spawn value (DEOBFUSCATION §32.3, line 6866).
     this.grappleEnergy.set(id, A1A_SPAWN);
   }
@@ -1312,10 +1362,14 @@ export class PhysicsEngine {
     // no per-map `ppm` factor is needed. Heavy then damps the vector via the
     // configured heavy multiplier. The base and the heavy damp are the
     // documented `player.moveForce` / `player.heavyMassMultiplier` surfaces.
-    if (input.left) force.x -= this.moveForce;
-    if (input.right) force.x += this.moveForce;
-    if (input.up) force.y -= this.moveForce;
-    if (input.down) force.y += this.moveForce;
+    // Flipped maps (`fl`) move on the flipped force base — native `12` vs `20`
+    // (DEOBFUSCATION §11). The base and the heavy damp are the documented
+    // `player.moveForce` / `player.heavyMassMultiplier` surfaces.
+    const base = this.flipped ? this.flippedMoveForce : this.moveForce;
+    if (input.left) force.x -= base;
+    if (input.right) force.x += base;
+    if (input.up) force.y -= base;
+    if (input.down) force.y += base;
 
     if (input.heavy) force.Multiply(this.heavyForceMultiplier);
     body.ApplyForce(force, body.GetWorldCenter());
@@ -1580,6 +1634,33 @@ export class PhysicsEngine {
   }
 
   /**
+   * Native `re` respawn: return a disc that just died to its spawn point with
+   * cleared grapple and fresh velocity, keeping it alive in the round. Mirrors
+   * the native state-sync respawn branch (readable 8595-8606): x/y = sx/sy,
+   * swing cleared (`delete disc.swing`), `ni` new-spawn marker. The engine
+   * does not model spawn velocity, so the body re-spawns at rest; a1a is NOT
+   * reset (the native branch does not touch it). Falls back to detach when no
+   * spawn point is recorded.
+   */
+  private respawnPlayer(id: number, body: any): void {
+    const spawn = this.playerSpawnPoints.get(id);
+    if (!spawn) {
+      this.detachPlayer(id, body);
+      return;
+    }
+    this.releaseGrapple(id);
+    this.pendingSwingDestroy.delete(id);
+    body.SetXForm(new b2Vec2(spawn.x, spawn.y), 0);
+    body.SetLinearVelocity(new b2Vec2(0, 0));
+    body.SetAngularVelocity(0);
+    body.WakeUp();
+    this.detachedPlayerStates.delete(id);
+    this.playerAlive.set(id, true);
+    this.playerDeathType.set(id, 0);
+    this.playerHeavyState.set(id, false);
+  }
+
+  /**
    * Advance the physics simulation by exactly one tick (1/30s).
    * This is the core synchronous step — no real-time clock involved.
    */
@@ -1657,7 +1738,16 @@ export class PhysicsEngine {
       }
 
       if (!this.playerAlive.get(id)) {
-        this.detachPlayer(id, body);
+        // Native `re` respawning: a disc that died (any type except the
+        // permanent cap-zone elimination, type 3) comes back immediately at
+        // its spawn point (readable 8595-8606; the alive rule at 8463 keeps
+        // type-3 eliminations dead). Without respawning, or for type 3, the
+        // dead disc is detached and frozen.
+        if (this.respawnEnabled && this.playerDeathType.get(id) !== 3) {
+          this.respawnPlayer(id, body);
+        } else {
+          this.detachPlayer(id, body);
+        }
       }
     }
 
@@ -1829,6 +1919,7 @@ export class PhysicsEngine {
     this.playerAlive.clear();
     this.detachedPlayerStates.clear();
     this.playerDeathType.clear();
+    this.playerSpawnPoints.clear();
     this.playerGrappleJoints.clear();
     this.grappleEnergy.clear();
     this.swingJustStarted.clear();

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -930,6 +930,10 @@ export class PhysicsEngine {
   /** Enable/disable the native flipped (`fl`) move-force base. */
   setFlipped(enabled: boolean): void {
     this.flipped = !!enabled;
+    // The #234 ascent invariant is checked against the EFFECTIVE base; a
+    // runtime flip can break it after construction, so re-validate here
+    // (the constructor-only warning would otherwise miss the regression).
+    this.warnAscentInvariantBreak();
   }
 
   /** Enable/disable the native respawning (`re`) mode. */
@@ -1645,6 +1649,17 @@ export class PhysicsEngine {
   private respawnPlayer(id: number, body: any): void {
     const spawn = this.playerSpawnPoints.get(id);
     if (!spawn) {
+      this.detachPlayer(id, body);
+      return;
+    }
+    // Fail-safe (malformed-map guard): a spawn point outside the OOB death
+    // circle would respawn a disc that dies again on the very next tick —
+    // unbounded death→respawn churn with telemetry/body work every tick.
+    // Native has no such escape (it would churn identically); the port
+    // detaches instead, matching its other corruption fail-safes (#271/#276).
+    const sx = spawn.x - this.oobCenterX;
+    const sy = spawn.y - this.oobCenterY;
+    if (sx * sx + sy * sy > this.oobRadiusSquared) {
       this.detachPlayer(id, body);
       return;
     }

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -1655,11 +1655,15 @@ export class PhysicsEngine {
     // Fail-safe (malformed-map guard): a spawn point outside the OOB death
     // circle would respawn a disc that dies again on the very next tick —
     // unbounded death→respawn churn with telemetry/body work every tick.
-    // Native has no such escape (it would churn identically); the port
-    // detaches instead, matching its other corruption fail-safes (#271/#276).
+    // Non-finite coordinates must count as out-of-bounds too: `NaN > r²` is
+    // false, so a plain comparison would let a NaN spawn slip through and
+    // restart the churn — the same fail-safe the OOB check itself uses
+    // (#271/#276). Native has no such escape (it would churn identically);
+    // the port detaches instead.
     const sx = spawn.x - this.oobCenterX;
     const sy = spawn.y - this.oobCenterY;
-    if (sx * sx + sy * sy > this.oobRadiusSquared) {
+    const sd2 = sx * sx + sy * sy;
+    if (!Number.isFinite(sd2) || sd2 > this.oobRadiusSquared) {
       this.detachPlayer(id, body);
       return;
     }

--- a/tests/integration/physics-fidelity-p3b.test.ts
+++ b/tests/integration/physics-fidelity-p3b.test.ts
@@ -1,0 +1,217 @@
+/**
+ * physics-fidelity-p3b.test.ts — P3b: runtime gating of the remaining map
+ * settings `fl` (flipped force), `nc` (no collision), `re` (respawning).
+ *
+ * Native evidence (DEOBFUSCATION.md §11 / §Deep Dive Move Force, §Key
+ * Collision Rules, readable 2026-07-29 artifact):
+ *  - `fl`: the move-force base is 12 normally, 20 when `ms.fl` is true
+ *    (`state.ms.fl ? 20 : 12`, §11 lines 720-730 / 935 / 4055). The port keeps
+ *    its tuned base (MOVE_FORCE = 30, #234 ascent invariant) and applies the
+ *    same 20/12 ratio (MOVE_FORCE_FLIP_MULTIPLIER) — proportions stay exact on
+ *    any scale (P0 abstraction rule).
+ *  - `nc`: all disc-disc contacts are disabled (`contact.SetEnabled(false)`
+ *    when `physics.nc`, readable 1300-1303; §Key Collision Rules 5).
+ *  - `re`: a disc that died respawns immediately at its spawn point with
+ *    cleared grapple and fresh velocity (`x=sx; y=sy; xv=sxv; yv=syv;
+ *    ni=true; delete swing`, readable 8595-8606); cap-zone eliminations
+ *    (death type 3) stay permanent (§alive rule, readable 8463).
+ */
+import { describe, it, expect } from 'vitest';
+import { PhysicsEngine, MOVE_FORCE, MOVE_FORCE_FLIP_MULTIPLIER } from '../../src/core/physics-engine';
+import { BonkEnvironment } from '../../src/core/environment';
+import type { MapDef } from '../../src/core/physics-engine';
+
+/** Deterministic static-wall arena (x ±515 / y ±300 map px, no floor). */
+const TEST_MAP: MapDef = {
+    name: 'p3b-test-map',
+    spawnPoints: {
+        team_blue: { x: -200, y: -100 },
+        team_red: { x: 200, y: -100 },
+    },
+    bodies: [
+        { name: 'left', type: 'rect', x: -500, y: 0, width: 30, height: 600, static: true },
+        { name: 'right', type: 'rect', x: 500, y: 0, width: 30, height: 600, static: true },
+    ],
+};
+
+const PLAYER_BITS = 0x0002 | 0x0004 | 0x0008 | 0x0010;
+
+function withSettings(settings: MapDef['settings']): MapDef {
+    return { ...TEST_MAP, settings };
+}
+
+/** One left-input tick on a fresh single-player engine; returns |velX| (map px/s). */
+function leftTickVelX(engine: PhysicsEngine): number {
+    engine.addPlayer(0, 0, 0);
+    engine.applyInput(0, { left: true, right: false, up: false, down: false, heavy: false, grapple: false });
+    engine.tick();
+    return Math.abs(engine.getPlayerState(0).velX);
+}
+
+describe('P3b: fl — flipped move-force base (DEOBFUSCATION §11)', () => {
+    it('default (no fl) applies the tuned base MOVE_FORCE (mass-1 disc: Δv = F·dt)', () => {
+        const engine = new PhysicsEngine({});
+        try {
+            // F = 30, m = 1, dt = 1/30 → Δv = 1 m/s = 30 map px/s.
+            expect(leftTickVelX(engine)).toBeCloseTo(MOVE_FORCE, 4);
+        } finally {
+            engine.destroy();
+        }
+    });
+
+    it('flipped mode applies the flipped base = base × 20/12 (native 12 → 20)', () => {
+        const engine = new PhysicsEngine({ flipped: true });
+        try {
+            expect((engine as any).flippedMoveForce).toBeCloseTo(MOVE_FORCE * MOVE_FORCE_FLIP_MULTIPLIER, 9);
+            // Δv = 50/30 m/s = 50 map px/s.
+            expect(leftTickVelX(engine)).toBeCloseTo(MOVE_FORCE * MOVE_FORCE_FLIP_MULTIPLIER, 4);
+        } finally {
+            engine.destroy();
+        }
+    });
+
+    it('explicit flippedMoveForce overrides the ratio default', () => {
+        const engine = new PhysicsEngine({ flipped: true, flippedMoveForce: 60 });
+        try {
+            expect(leftTickVelX(engine)).toBeCloseTo(60, 4);
+        } finally {
+            engine.destroy();
+        }
+    });
+
+    it('env forwards mapData.settings.fl to the engine', () => {
+        const env = new BonkEnvironment({
+            numOpponents: 0,
+            seed: 7,
+            mapData: withSettings({ fl: true }),
+            randomOpponent: false,
+        } as any);
+        try {
+            expect((env as any).physics.flipped).toBe(true);
+            env.reset(7);
+            const physics: any = (env as any).physics;
+            physics.applyInput(0, { left: true, right: false, up: false, down: false, heavy: false, grapple: false });
+            physics.tick();
+            expect(Math.abs(physics.getPlayerState(0).velX)).toBeCloseTo(MOVE_FORCE * MOVE_FORCE_FLIP_MULTIPLIER, 4);
+        } finally {
+            env.close();
+        }
+    });
+});
+
+describe('P3b: nc — no-collision mode (readable 1300-1303)', () => {
+    it('env forwards mapData.settings.nc: player masks drop every disc bit', () => {
+        const env = new BonkEnvironment({
+            numOpponents: 1,
+            seed: 7,
+            mapData: withSettings({ nc: true }),
+            randomOpponent: false,
+        } as any);
+        try {
+            env.reset(7);
+            const physics: any = (env as any).physics;
+            expect(physics.noCollide).toBe(true);
+            for (const id of [0, 1]) {
+                const shape = physics.playerBodies.get(id).GetShapeList();
+                const mask = shape.GetFilterData().maskBits;
+                expect(mask & PLAYER_BITS).toBe(0);
+                // Map geometry (category 1) stays solid.
+                expect(mask & 0x0001).not.toBe(0);
+            }
+        } finally {
+            env.close();
+        }
+    });
+
+    it('nc discs pass through each other; default discs separate on contact', () => {
+        const run = (nc: boolean): number => {
+            const env = new BonkEnvironment({
+                numOpponents: 1,
+                seed: 7,
+                mapData: withSettings(nc ? { nc: true } : {}),
+                randomOpponent: false,
+            } as any);
+            try {
+                env.reset(7);
+                const physics: any = (env as any).physics;
+                const b0 = physics.playerBodies.get(0);
+                const b1 = physics.playerBodies.get(1);
+                // Overlapping discs (radius 12 map px): contact must push them
+                // apart without nc, and leave them overlapped with nc.
+                b0.SetXForm(new (require('box2d').b2Vec2)(-0.05, 0), 0);
+                b1.SetXForm(new (require('box2d').b2Vec2)(0.05, 0), 0);
+                for (let t = 0; t < 15; t++) physics.tick();
+                const p0 = physics.getPlayerState(0);
+                const p1 = physics.getPlayerState(1);
+                return Math.abs(p0.x - p1.x);
+            } finally {
+                env.close();
+            }
+        };
+        expect(run(true)).toBeLessThan(5);
+        expect(run(false)).toBeGreaterThan(15);
+    });
+});
+
+describe('P3b: re — respawning mode (readable 8595-8606)', () => {
+    it('a disc that dies OOB respawns at its spawn point, alive, next tick', () => {
+        const env = new BonkEnvironment({
+            numOpponents: 0,
+            seed: 7,
+            mapData: withSettings({ re: true }),
+            randomOpponent: false,
+        } as any);
+        try {
+            env.reset(7);
+            const physics: any = (env as any).physics;
+            expect(physics.respawnEnabled).toBe(true);
+            // Teleport far beyond the 850/scale death circle (≈28.3 world units).
+            physics.playerBodies.get(0).SetXForm(new (require('box2d').b2Vec2)(200, 0), 0);
+            physics.tick();
+            const st = physics.getPlayerState(0);
+            expect(st.alive).toBe(true);
+            expect(st.deathType).toBe(0);
+            // Respawned at the AI spawn (team_blue: −200, −100 map px).
+            expect(st.x).toBeCloseTo(-200, 4);
+            expect(st.y).toBeCloseTo(-100, 4);
+            // Grapple was cleared by the respawn (native `delete disc.swing`).
+            expect(physics.hasGrappleJoint(0)).toBe(false);
+        } finally {
+            env.close();
+        }
+    });
+
+    it('without re the same death stays dead (detached)', () => {
+        const env = new BonkEnvironment({
+            numOpponents: 0,
+            seed: 7,
+            mapData: withSettings({}),
+            randomOpponent: false,
+        } as any);
+        try {
+            env.reset(7);
+            const physics: any = (env as any).physics;
+            physics.playerBodies.get(0).SetXForm(new (require('box2d').b2Vec2)(200, 0), 0);
+            physics.tick();
+            expect(physics.getPlayerState(0).alive).toBe(false);
+            expect(physics.getPlayerState(0).deathType).toBe(4);
+        } finally {
+            env.close();
+        }
+    });
+
+    it('cap-zone eliminations (death type 3) stay permanent even with re', () => {
+        const engine = new PhysicsEngine({ respawnEnabled: true });
+        try {
+            engine.addPlayer(0, 0, 0);
+            const anyEng: any = engine;
+            anyEng.playerAlive.set(0, false);
+            anyEng.playerDeathType.set(0, 3);
+            engine.tick();
+            expect(engine.getPlayerState(0).alive).toBe(false);
+            expect(engine.getPlayerState(0).deathType).toBe(3);
+        } finally {
+            engine.destroy();
+        }
+    });
+});

--- a/tests/integration/physics-fidelity-p3b.test.ts
+++ b/tests/integration/physics-fidelity-p3b.test.ts
@@ -16,7 +16,7 @@
  *    ni=true; delete swing`, readable 8595-8606); cap-zone eliminations
  *    (death type 3) stay permanent (§alive rule, readable 8463).
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { PhysicsEngine, MOVE_FORCE, MOVE_FORCE_FLIP_MULTIPLIER } from '../../src/core/physics-engine';
 import { BonkEnvironment } from '../../src/core/environment';
 import type { MapDef } from '../../src/core/physics-engine';
@@ -97,6 +97,41 @@ describe('P3b: fl — flipped move-force base (DEOBFUSCATION §11)', () => {
             env.close();
         }
     });
+
+    it('explicit env config flipped overrides the map setting (asymmetric with nc)', () => {
+        const env = new BonkEnvironment({
+            numOpponents: 0,
+            seed: 7,
+            mapData: withSettings({ fl: false }),
+            flipped: true,
+            randomOpponent: false,
+        } as any);
+        try {
+            expect((env as any).physics.flipped).toBe(true);
+        } finally {
+            env.close();
+        }
+    });
+
+    it('setFlipped re-validates the #234 ascent invariant on the effective base', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            // gravity 20 vs base 18: broken at construction.
+            const engine = new PhysicsEngine({ gravityY: 20, moveForce: 18 });
+            expect(warn).toHaveBeenCalled();
+            warn.mockClear();
+            // Flipped base = 18 × 20/12 = 30: pure-up (30 > 20) AND up+heavy
+            // (30 × 0.7 = 21 > 20) both clear — flipping must not re-warn.
+            engine.setFlipped(true);
+            expect(warn).not.toHaveBeenCalled();
+            // Un-flipping re-breaks the invariant and must warn again.
+            engine.setFlipped(false);
+            expect(warn).toHaveBeenCalled();
+            engine.destroy();
+        } finally {
+            warn.mockRestore();
+        }
+    });
 });
 
 describe('P3b: nc — no-collision mode (readable 1300-1303)', () => {
@@ -148,8 +183,11 @@ describe('P3b: nc — no-collision mode (readable 1300-1303)', () => {
                 env.close();
             }
         };
+        // Overlapping discs: contact correction must push the control discs
+        // to (or past) the touching distance — 2 × 12 px radius = 24 px —
+        // while nc discs keep their initial ~3 px separation.
         expect(run(true)).toBeLessThan(5);
-        expect(run(false)).toBeGreaterThan(15);
+        expect(run(false)).toBeGreaterThan(20);
     });
 });
 
@@ -212,6 +250,37 @@ describe('P3b: re — respawning mode (readable 8595-8606)', () => {
             expect(engine.getPlayerState(0).deathType).toBe(3);
         } finally {
             engine.destroy();
+        }
+    });
+
+    it('an OOB spawn point detaches instead of death→respawn churning every tick', () => {
+        // Spawn far outside the 850/scale death circle: with re on, a naive
+        // respawn would die again next tick forever. The fail-safe detaches.
+        const engine = new PhysicsEngine({ respawnEnabled: true });
+        try {
+            engine.addPlayer(0, 1000, 0); // 1000 px >> 850 px OOB radius
+            engine.tick();
+            expect(engine.getPlayerState(0).alive).toBe(false);
+            expect(engine.getPlayerState(0).deathType).toBe(4);
+            // No live body left to respawn: the world churn ended after one tick.
+            expect((engine as any).playerBodies.has(0)).toBe(false);
+        } finally {
+            engine.destroy();
+        }
+    });
+
+    it('explicit env config respawnEnabled overrides the map setting', () => {
+        const env = new BonkEnvironment({
+            numOpponents: 0,
+            seed: 7,
+            mapData: withSettings({ re: false }),
+            respawnEnabled: true,
+            randomOpponent: false,
+        } as any);
+        try {
+            expect((env as any).physics.respawnEnabled).toBe(true);
+        } finally {
+            env.close();
         }
     });
 });

--- a/tests/integration/physics-fidelity-p3b.test.ts
+++ b/tests/integration/physics-fidelity-p3b.test.ts
@@ -269,6 +269,24 @@ describe('P3b: re — respawning mode (readable 8595-8606)', () => {
         }
     });
 
+    it('a non-finite spawn coordinate detaches too (NaN bypasses a plain > comparison)', () => {
+        const engine = new PhysicsEngine({ respawnEnabled: true });
+        try {
+            engine.addPlayer(0, 0, 0);
+            const anyEng: any = engine;
+            // Corrupt the recorded spawn: `NaN > r²` is false, so only the
+            // explicit non-finite guard can stop the death→respawn churn.
+            anyEng.playerSpawnPoints.set(0, { x: NaN, y: 0 });
+            anyEng.playerAlive.set(0, false);
+            anyEng.playerDeathType.set(0, 4);
+            engine.tick();
+            expect(engine.getPlayerState(0).alive).toBe(false);
+            expect((engine as any).playerBodies.has(0)).toBe(false);
+        } finally {
+            engine.destroy();
+        }
+    });
+
     it('explicit env config respawnEnabled overrides the map setting', () => {
         const env = new BonkEnvironment({
             numOpponents: 0,


### PR DESCRIPTION
## Summary

P3b of the **map-physics fidelity** plan (`docs/PHYSICS_FIDELITY_PLAN.md`): the runtime gating follow-up for the remaining per-map settings exposed in P3 — `fl` (flipped move-force base), `nc` (no-collision), `re` (respawning). All behavior is cited to the readable 2026-07-29 artifact and DEOBFUSCATION §11 / §Key Collision Rules / §alive rule.

## What changed

**`fl` (flipped)** — `src/core/physics-engine.ts`
- New engine options `flipped` + `flippedMoveForce` (default `MOVE_FORCE × 20/12` = 50, preserving the native 12 → 20 proportion on the port's tuned base; P0 abstraction rule). Native evidence: `state.ms.fl ? 20 : 12` (DEOBFUSCATION §11 lines 720-730/935/4055).
- `applyInput` uses the effective (flipped) base per tick; `warnAscentInvariantBreak` validates the effective base.
- `BonkEnvironment` forwards `mapData.settings.fl`.

**`nc` (no collision)** — `src/core/environment.ts`
- The environment now resolves `noCollide` from `mapData.settings.nc` (config override wins). Previously it read `mapDef.physics?.nc` — a key the adapter never emits (physics carries only ppm/bounds/deathCenter) — so the map setting was silently ignored. The engine's existing `setNoCollide` disc-filter path (maskBits drop every player bit, disc-disc contacts disabled — readable 1300-1303, §Key Collision Rules 5) is now actually reachable from maps.

**`re` (respawning)** — `src/core/physics-engine.ts`
- New engine option `respawnEnabled` + `respawnPlayer`: a disc that died respawns **immediately** at its recorded spawn point with cleared grapple and zeroed velocity (native `x=sx; y=sy; xv=sxv; yv=syv; ni=true; delete swing`, readable 8595-8606).
- Cap-zone eliminations (death type 3) stay permanent (§alive rule, readable 8463).
- `a1a` is not reset (the native branch does not touch it); spawn points are recorded at `addPlayer`; `BonkEnvironment` forwards `mapData.settings.re`.

## Validation

- `tests/integration/physics-fidelity-p3b.test.ts` — **9 tests**:
  - flipped force magnitude at engine level (default 30, flipped 50, explicit `flippedMoveForce` override) and through env `settings.fl`;
  - nc: both discs' masks drop every player bit while map geometry (category 1) stays solid; overlapping discs pass through (control without nc separates on contact);
  - re: OOB death respawns at the AI spawn next tick (alive, deathType 0, grapple cleared) vs stays dead without `re`; type-3 deaths stay permanent with `re` on.
- P0/P1/P2/P3/P3b/P4 + config-consumed + map suites: **168 tests green** (9 files). `tsc --noEmit` → exit 0.
- The pre-existing `env-ai-player-id` failure reproduces on unmodified main (unrelated to this PR).
- Branch from `origin/main` (includes merged P0–P4).

## Type of Change

- [X] New feature
- [ ] Bug fix
- [ ] Documentation update

## Pre-flight Checklist

- [X] Typecheck passes
- [X] P3b tests (9) + P0–P4 + config-consumed + map suites pass (168)
- [X] Branch from main
- [X] Scope limited to settings runtime gating (fl/nc/re + tests + docs)