### PR TITLE
fix(#313): scale exported distance joint lengths

### DIFF
--- a/src/core/differential/exact-match-gates.ts
+++ b/src/core/differential/exact-match-gates.ts
@@ -115,6 +115,7 @@ export function verifyJointGates(env: BonkEnvironment, trace: NativeTrace): Gate
   const mismatches: string[] = [];
   const physics: any = (env as any).physics;
   const scale: number = physics.scale;
+  const ppm: number = physics.ppm;
   const created: Map<string, any> = physics.createdJoints ?? new Map();
   const mapDef: any = normalizeMap(trace.map);
   const joints: any[] = mapDef.joints ?? [];
@@ -151,13 +152,14 @@ export function verifyJointGates(env: BonkEnvironment, trace: NativeTrace): Gate
         mismatches.push(`joint "${name}" rv maxMotorTorque mismatch`);
       }
     } else if (t === 'd' || t === 'distance') {
-      // The engine stores m_length in metres (authored map px / scale,
-      // physics-engine addJoint: `jd.length = def.length / this.scale`). Only
-      // compare when a length was authored — otherwise the engine replicates
+      // Exported d-joint lengths are native world units (map px / ppm); the
+      // engine stores m_length in its map-px / scale world. Only compare when
+      // a length was authored — otherwise the engine replicates
       // b2DistanceJointDef.Initialize's anchor-distance default and there is
       // no authored value to diff against.
       if (typeof j.length === 'number' && Number.isFinite(j.length)) {
-        if (Math.abs((built as any).m_length - j.length / scale) > 1e-9) {
+        const nativeLength = j.length === 0 ? 0.01 : j.length;
+        if (Math.abs((built as any).m_length - (nativeLength * ppm) / scale) > 1e-9) {
           mismatches.push(`joint "${name}" d length mismatch`);
         }
       }

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -60,6 +60,9 @@ export const GRAVITY_Y = 20;
 /** Default player circle radius in metres */
 export const DEFAULT_PPM = 12;
 
+/** Native minimum rest length for an exported distance joint (map px / ppm). */
+const NATIVE_DISTANCE_JOINT_MIN_LENGTH = 0.01;
+
 /**
  * Verified native player-disc fixture (DEOBFUSCATION §35.4 / §38.6, live
  * 2026-07-29 fixture, alpha2s.pretty.js 7397-7401; Node-verified index labels
@@ -1178,10 +1181,19 @@ export class PhysicsEngine {
           jd.length = Math.sqrt((wb.x - wa.x) * (wb.x - wa.x) + (wb.y - wa.y) * (wb.y - wa.y));
         }
       }
-      // apply an explicit authored length after Initialize (Initialize sets
-      // length from the anchor distance) (§33.7 d: len→0.01-floor).
+      // Apply an explicit authored length after Initialize. Exported d-joint
+      // lengths are native world units (map px / ppm), while this Box2D world
+      // uses map px / this.scale. Preserve the native zero-length floor while
+      // converting between those unit systems (§33.8 d: len→0.01-floor).
       if (typeof def.length === 'number' && Number.isFinite(def.length)) {
-        jd.length = def.length / this.scale;
+        const nativeLength = def.length === 0
+          ? NATIVE_DISTANCE_JOINT_MIN_LENGTH
+          : def.length;
+        jd.length = (nativeLength * this.ppm) / this.scale;
+      } else if (jd.length === 0) {
+        // The fallback anchor-distance path also needs the native floor when
+        // both normalized anchors coincide.
+        jd.length = (NATIVE_DISTANCE_JOINT_MIN_LENGTH * this.ppm) / this.scale;
       }
       jd.collideConnected = cd;
       jd.frequencyHz = def.frequencyHz ?? 0;

--- a/tests/integration/physics-fidelity-p2.test.ts
+++ b/tests/integration/physics-fidelity-p2.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { PhysicsEngine, SCALE } from '../../src/core/physics-engine';
+import { DEFAULT_PPM, PhysicsEngine, SCALE } from '../../src/core/physics-engine';
 import { normalizeMap } from '../../src/core/map-adapter';
 import { BonkEnvironment } from '../../src/core/environment';
 
@@ -89,8 +89,9 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
     expect(d.m_localAnchor1.y).toBeCloseTo(50 / SCALE, 5);
     expect(d.m_localAnchor2.x).toBeCloseTo(0, 5);
     expect(d.m_localAnchor2.y).toBeCloseTo(-50 / SCALE, 5);
-    // Authored length survives; without a length the anchor distance is used.
-    expect(d.m_length).toBeCloseTo(60 / SCALE, 5);
+    // Authored d lengths are native world units (map px / ppm); without a
+    // length the port uses the converted anchor distance.
+    expect(d.m_length).toBeCloseTo((60 * DEFAULT_PPM) / SCALE, 5);
     expect(dNolen.m_length).toBeCloseTo(Math.sqrt(100 * 100 + 100 * 100) / SCALE, 5);
 
     // Step the world: bodyA must actually move and rotate — otherwise the
@@ -315,9 +316,57 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
     expect(pr.m_localXAxis1.y).toBeCloseTo(1, 5);
     expect(pr.m_localXAxis1.x).toBeCloseTo(0, 5);
     expect(pr.m_refAngle).toBeCloseTo(0.3, 5);
-    // Distance: authored length applied after Initialize (px / scale).
+    // Distance: exported native-world length converted to the port world.
     const ds = (e as any).createdJoints.get('joint_2');
-    expect(ds.m_length).toBeCloseTo(50 / 30, 5);
+    expect(ds.m_length).toBeCloseTo((50 * DEFAULT_PPM) / SCALE, 5);
+  });
+
+  it('converts exported native distance length to map separation and preserves it (#313)', () => {
+    const e = new PhysicsEngine({ gravityY: 0 });
+    e.addBody({ name: 'anchor', type: 'circle', x: 0, y: 0, radius: 5, static: true } as any);
+    e.addBody({ name: 'weight', type: 'circle', x: 120, y: 0, radius: 5, static: false, density: 1 } as any);
+    const bm = e.getBodyMap() as Map<string, any>;
+
+    e.addJoint({
+      type: 'd',
+      name: 'exported-distance',
+      bodyA: 'anchor',
+      bodyB: 'weight',
+      anchorA: { x: 0, y: 0 },
+      anchorB: { x: 0, y: 0 },
+      length: 10, // 120 map px / ppm=12, as emitted by mapexporter.js
+    }, bm);
+
+    const joint = (e as any).createdJoints.get('exported-distance');
+    expect(joint.m_length).toBeCloseTo((10 * DEFAULT_PPM) / SCALE, 5);
+
+    for (let i = 0; i < 120; i++) e.tick();
+
+    const anchor = bm.get('anchor').GetPosition();
+    const weight = bm.get('weight').GetPosition();
+    const dx = (weight.x - anchor.x) * SCALE;
+    const dy = (weight.y - anchor.y) * SCALE;
+    expect(Math.sqrt(dx * dx + dy * dy)).toBeCloseTo(120, 3);
+  });
+
+  it('applies the native minimum to an explicitly zero distance length (#313)', () => {
+    const e = new PhysicsEngine({ gravityY: 0 });
+    e.addBody({ name: 'anchor', type: 'circle', x: 0, y: 0, radius: 5, static: true } as any);
+    e.addBody({ name: 'weight', type: 'circle', x: 120, y: 0, radius: 5, static: false, density: 1 } as any);
+    const bm = e.getBodyMap() as Map<string, any>;
+
+    e.addJoint({
+      type: 'd',
+      name: 'zero-distance',
+      bodyA: 'anchor',
+      bodyB: 'weight',
+      anchorA: { x: 0, y: 0 },
+      anchorB: { x: 0, y: 0 },
+      length: 0,
+    }, bm);
+
+    const joint = (e as any).createdJoints.get('zero-distance');
+    expect(joint.m_length).toBeCloseTo((0.01 * DEFAULT_PPM) / SCALE, 8);
   });
 
 it('normalizeMap forwards authored distance-joint frequencyHz/dampingRatio (#286)', () => {


### PR DESCRIPTION
## Problem
Exported `d` joint lengths (`l`) are native world units (`map px / ppm`), but `PhysicsEngine.addJoint()` treated them as map pixels and divided by `SCALE`, shortening rest lengths by `ppm` (12x at the default). The native `0.01` minimum was also lost for zero-length joints.

## Root Cause
The exporter forwards the normalized live `l` value unchanged through `normalizeMap()`, while the port's Box2D world uses `map px / SCALE`. The missing `ppm` conversion occurred in the distance-joint construction path.

## Changes
- Convert authored distance-joint lengths with `nativeLength * ppm / SCALE` in `PhysicsEngine.addJoint()`.
- Preserve the native `0.01` floor for explicit zero and coincident-anchor fallback lengths.
- Update the differential joint gate and add P2 regressions for exported `l=10` / 120 map px separation and the zero-length floor.

## Validation
- `npx vitest run tests/integration/physics-fidelity-p2.test.ts` (33 passed)
- `npx vitest run tests/integration/physics-fidelity-p4.test.ts` (8 passed)
- Affected physics/exporter suites (60 passed)
- `npm run typecheck`
- `npm test` (96 files passed, 1,708 passed, 19 skipped)

Closes #313