### PR TITLE
fix(#316): await IPC listener unbind on shutdown

### DIFF
--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -69,6 +69,8 @@ export class IpcBridge {
     private _hostUseSharedMemory: boolean | undefined = undefined;
     private _boundResolve: (() => void) | null = null;
     private _boundReject: ((reason?: any) => void) | null = null;
+    private boundEndpoint: string | null = null;
+    private closePromise: Promise<void> | null = null;
 
     // Current bind signal for this serve cycle. Replaced on every start()
     // (see rearmReady) so a restart after close() resolves/rejects a fresh
@@ -230,12 +232,22 @@ export class IpcBridge {
     private _wrappedSend: Function;
 
     async start() {
-        const addr = `tcp://${this.bindAddress}:${this.port}`;
-        // Re-arm `ready` on every serve cycle, not only when the socket is
-        // recreated: a failed bind rejects the current promise and nulls its
-        // handlers, so the next start() must install fresh ones or a
-        // successful retry bind could never resolve ready (issue #263).
+        // Re-arm `ready` before waiting for a prior close to finish. Callers
+        // can read the new readiness promise immediately after invoking
+        // start(), even while the previous socket is still unbinding.
         this.rearmReady();
+        if (this.closePromise) {
+            const previousClose = this.closePromise;
+            try {
+                await previousClose;
+            } finally {
+                if (this.closePromise === previousClose) {
+                    this.closePromise = null;
+                }
+            }
+        }
+
+        const addr = `tcp://${this.bindAddress}:${this.port}`;
         // A closed ZMQ socket is permanently destroyed and can never be
         // re-bound (bind() throws "Socket is closed"). Recreate the transport
         // so a later start() after close() binds a fresh ROUTER and serves
@@ -261,6 +273,11 @@ export class IpcBridge {
             }
             throw err;
         }
+        // libzmq resolves wildcard binds to a concrete endpoint (for example,
+        // tcp://0.0.0.0:<port>). Keep that resolved value because unbind()
+        // requires the endpoint returned by lastEndpoint, not the original
+        // tcp://*:<port> request.
+        this.boundEndpoint = this.sock.lastEndpoint ?? addr;
         console.log(`[IPC] Bound ZMQ Router socket to ${addr}`);
         this._closed = false;
         if (!this._hostPool) {
@@ -803,9 +820,12 @@ export class IpcBridge {
         return this._closed;
     }
 
-    async close() {
+    close(): Promise<void> {
+        if (this.closePromise) {
+            return this.closePromise;
+        }
         if (this._closed) {
-            return;
+            return Promise.resolve();
         }
         this._closed = true;
         if (this.sessionReapTimer) {
@@ -829,13 +849,45 @@ export class IpcBridge {
         }
         this.sessions.clear();
 
-        // Close the socket to break out of the for await loop
-        try {
-            this.sock.close();
-        } catch (e) {
-            // Ignore close errors
-        }
+        // libzmq closes its TCP listener asynchronously when the socket is
+        // destroyed. Unbind the endpoint explicitly and await that operation
+        // before closing the socket so callers do not release/reuse a port
+        // while the old listener is still alive (#316).
+        const endpoint = this.boundEndpoint;
+        this.boundEndpoint = null;
+        this.closePromise = (async () => {
+            let failure: { error: unknown } | null = null;
 
-        await Promise.all(pools.map(pool => pool.close()));
+            if (endpoint) {
+                try {
+                    await this.sock.unbind(endpoint);
+                } catch (error) {
+                    failure = { error };
+                }
+            }
+
+            // Close the socket to break out of the for await loop. Preserve
+            // the existing best-effort handling for socket close errors, but
+            // do not hide an unbind or worker-pool failure from the caller.
+            try {
+                this.sock.close();
+            } catch (error) {
+                // Ignore close errors.
+            }
+
+            try {
+                await Promise.all(pools.map(pool => pool.close()));
+            } catch (error) {
+                if (!failure) {
+                    failure = { error };
+                }
+            }
+
+            if (failure) {
+                throw failure.error;
+            }
+        })();
+
+        return this.closePromise;
     }
 }

--- a/tests/integration/bonk-env-ipc-server.test.ts
+++ b/tests/integration/bonk-env-ipc-server.test.ts
@@ -133,6 +133,43 @@ describe('BonkEnv IPC server mode (issue #223)', () => {
     expect(portManager.isAllocated(env.port)).toBe(false);
   });
 
+  it('waits for the IPC listener to unbind before releasing the port (#316)', { timeout: 60000 }, async () => {
+    const port = IPC_SERVER_TEST_START + 600;
+    const portManager = new PortManager({ startPort: port, endPort: port + 10 });
+    const env = new BonkEnv({
+      numEnvs: 1,
+      useSharedMemory: false,
+      portManager,
+      port,
+      enableIpcServer: true,
+    });
+
+    try {
+      await env.start();
+      await env.stop();
+
+      expect(await canConnectTcp(port)).toBe(false);
+
+      const replacement = new BonkEnv({
+        numEnvs: 1,
+        useSharedMemory: false,
+        portManager,
+        port,
+        enableIpcServer: true,
+      });
+      try {
+        await replacement.start();
+        expect(await canConnectTcp(port)).toBe(true);
+      } finally {
+        await replacement.stop();
+      }
+
+      expect(portManager.isAllocated(port)).toBe(false);
+    } finally {
+      await env.stop();
+    }
+  });
+
   it('does not bind a port when IPC server mode is not requested', { timeout: 60000 }, async () => {
     const portManager = new PortManager({ startPort: IPC_SERVER_TEST_START + 100, endPort: IPC_SERVER_TEST_START + 149 });
     const env = new BonkEnv({

--- a/tests/unit/ipc-bridge-constructor.test.ts
+++ b/tests/unit/ipc-bridge-constructor.test.ts
@@ -11,8 +11,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => {
-  const sock: { bind: () => Promise<void>; close: () => void; send: () => Promise<void>; [Symbol.asyncIterator]?: any } = {
+  const sock: { bind: () => Promise<void>; unbind: () => Promise<void>; close: () => void; send: () => Promise<void>; [Symbol.asyncIterator]?: any } = {
     bind: async () => {},
+    unbind: async () => {},
     close: () => {},
     send: async () => {},
   };
@@ -78,6 +79,7 @@ let currentBridge: any = null;
 
 const mockSock = mocks.sock;
 let bindSpy: ReturnType<typeof vi.spyOn>;
+let unbindSpy: ReturnType<typeof vi.spyOn>;
 let closeSpy: ReturnType<typeof vi.spyOn>;
 let sendSpy: ReturnType<typeof vi.spyOn>;
 
@@ -108,6 +110,7 @@ beforeEach(() => {
   mocks.gpReport.mockClear();
   mocks.setLatestWorkerTelemetry.mockClear();
   bindSpy = vi.spyOn(mockSock, 'bind').mockResolvedValue(undefined);
+  unbindSpy = vi.spyOn(mockSock, 'unbind').mockResolvedValue(undefined);
   closeSpy = vi.spyOn(mockSock, 'close');
   sendSpy = vi.spyOn(mockSock, 'send').mockResolvedValue(undefined);
   delete mockSock[Symbol.asyncIterator];
@@ -115,6 +118,7 @@ beforeEach(() => {
 
 afterEach(() => {
   bindSpy.mockRestore();
+  unbindSpy.mockRestore();
   closeSpy.mockRestore();
   sendSpy.mockRestore();
   currentBridge = null;
@@ -337,6 +341,25 @@ describe('IpcBridge close() (lines 159-173)', () => {
   it('closes the socket (line 167)', async () => {
     const bridge = new IpcBridge({ server: { port: 12353 } });
     await bridge.close();
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it('awaits endpoint unbind before closing the socket (#316)', async () => {
+    const bridge = new IpcBridge({ server: { port: 12357 } });
+    const endpoint = 'tcp://127.0.0.1:12357';
+    (bridge as any).boundEndpoint = endpoint;
+
+    let releaseUnbind!: () => void;
+    unbindSpy.mockImplementationOnce(() => new Promise<void>(resolve => {
+      releaseUnbind = resolve;
+    }));
+
+    const closePromise = bridge.close();
+    expect(unbindSpy).toHaveBeenCalledWith(endpoint);
+    expect(closeSpy).not.toHaveBeenCalled();
+
+    releaseUnbind();
+    await closePromise;
     expect(closeSpy).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Problem

`IpcBridge.close()` returned before libzmq had released its TCP listener, so `BonkEnv.stop()` could report the port free while TCP connections still succeeded and an immediate re-bind failed with `EADDRINUSE`.

## Root Cause

`zmq.Socket.close()` is synchronous at the JavaScript API boundary, but libzmq completes TCP endpoint teardown asynchronously on its I/O thread. The shutdown path did not await endpoint unbinding.

## Changes

- Capture the endpoint actually resolved by ZeroMQ, including wildcard binds.
- Await `sock.unbind(endpoint)` before closing the Router socket and releasing the environment port.
- Make close single-flight and keep restart readiness correctly sequenced around an in-flight close.
- Add unit ordering coverage and an integration regression covering immediate TCP shutdown and same-port re-bind.

## Validation

- `npm test` (`96` files, `1708` passed, `19` skipped)
- `npm run typecheck`
- Focused IPC lifecycle tests (`71` passed)
- Direct wildcard endpoint unbind/re-bind probe

Closes #316