### PR TITLE
fix(#319): scale explicit map bounds for observations

### DIFF
--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -703,7 +703,13 @@ export class BonkEnvironment {
         // Re-apply explicit map bounds last — body re-adds above recomputed
         // dynamic bounds and would otherwise clobber the override every reset.
         if (this.mapBounds && typeof (this.physics as any).setMapBounds === 'function') {
-            this.physics.setMapBounds(this.mapBounds.width, this.mapBounds.height);
+            // MapDef physics bounds are authored in map pixels, while the
+            // engine's setMapBounds API stores world-unit dimensions.
+            const scale = this.physics.getScale();
+            this.physics.setMapBounds(
+                this.mapBounds.width / scale,
+                this.mapBounds.height / scale,
+            );
         }
 
         // Re-apply the map's OOB death-circle center — like mapBounds it is a

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -1014,7 +1014,9 @@ export class PhysicsEngine {
 
   /**
    * Set explicit map bounds from the map's physics.bounds.
-   * Overrides dynamically calculated arena bounds.
+   * The engine API consumes world-unit (metre) dimensions and overrides
+   * dynamically calculated arena bounds. Map-pixel callers should convert
+   * through getScale() before calling this method.
    */
   setMapBounds(widthMetres: number, heightMetres: number): void {
     this.arenaHalfWidth = widthMetres / 2;
@@ -1029,6 +1031,11 @@ export class PhysicsEngine {
     this._arenaBoundsCache.halfWidth = this.arenaHalfWidth * this.scale;
     this._arenaBoundsCache.halfHeight = this.arenaHalfHeight * this.scale;
     return this._arenaBoundsCache;
+  }
+
+  /** Pixels-per-world-unit conversion used for exported map coordinates. */
+  getScale(): number {
+    return this.scale;
   }
 
   /**

--- a/tests/integration/environment-edge-cases.test.ts
+++ b/tests/integration/environment-edge-cases.test.ts
@@ -78,20 +78,59 @@ describe('BonkEnvironment edge cases', () => {
       expect(result.info.capZones[0].type).toBe(2);
     });
 
-    it('physics.bounds survives the constructor-internal reset and episode resets', async () => {
+    it('reports map-pixel physics.bounds after reset and step', async () => {
       const mapData: MapDef = makeMap({});
-      (mapData as any).physics = { bounds: { width: 60, height: 40 } };
+      (mapData as any).physics = { bounds: { width: 730, height: 500 } };
 
       env = new BonkEnvironment({ mapData, numOpponents: 0, maxTicks: 10 });
       const obs = env.reset();
-      expect(obs.arenaHalfWidth).toBe(30 * 30);  // width/2 (30m) × SCALE(30)
-      expect(obs.arenaHalfHeight).toBe(20 * 30);
+      expect(obs.arenaHalfWidth).toBeCloseTo(365, 10);
+      expect(obs.arenaHalfHeight).toBeCloseTo(250, 10);
 
-      for (let i = 0; i < 5; i++) env.step(0);
+      const stepped = env.step(0).observation;
+      expect(stepped.arenaHalfWidth).toBeCloseTo(365, 10);
+      expect(stepped.arenaHalfHeight).toBeCloseTo(250, 10);
 
       const obs2 = env.reset();
-      expect(obs2.arenaHalfWidth).toBe(30 * 30);
-      expect(obs2.arenaHalfHeight).toBe(20 * 30);
+      expect(obs2.arenaHalfWidth).toBeCloseTo(365, 10);
+      expect(obs2.arenaHalfHeight).toBeCloseTo(250, 10);
+    });
+
+    it('reports exported boundsWidth/boundsHeight in map pixels', async () => {
+      const exportedMap = {
+        metadata: { name: 'exported-explicit-bounds' },
+        spawns: [
+          { x: 0, y: 0, blue: true },
+          { x: 100, y: 0, red: true },
+        ],
+        bodies: [],
+        physics: { boundsWidth: 730, boundsHeight: 500 },
+      };
+
+      env = new BonkEnvironment({ mapData: exportedMap as any, numOpponents: 0, maxTicks: 10 });
+      const resetObservation = env.reset();
+      expect(resetObservation.arenaHalfWidth).toBeCloseTo(365, 10);
+      expect(resetObservation.arenaHalfHeight).toBeCloseTo(250, 10);
+
+      const stepObservation = env.step(0).observation;
+      expect(stepObservation.arenaHalfWidth).toBeCloseTo(365, 10);
+      expect(stepObservation.arenaHalfHeight).toBeCloseTo(250, 10);
+    });
+
+    it('uses the configured engine scale for map-pixel physics.bounds', async () => {
+      const mapData: MapDef = makeMap({
+        physics: { bounds: { width: 730, height: 500 } },
+      });
+
+      env = new BonkEnvironment({
+        mapData,
+        physics: { scale: 60 },
+        numOpponents: 0,
+        maxTicks: 10,
+      });
+      const observation = env.reset();
+      expect(observation.arenaHalfWidth).toBeCloseTo(365, 10);
+      expect(observation.arenaHalfHeight).toBeCloseTo(250, 10);
     });
 
     it('capZones empty array when no capZones in map', async () => {
@@ -936,8 +975,8 @@ describe('BonkEnvironment edge cases', () => {
 
         expect(world).not.toBe(previousWorld);
         expect(observation.tick).toBe(0);
-        expect(observation.arenaHalfWidth).toBe(30 * 30);
-        expect(observation.arenaHalfHeight).toBe(20 * 30);
+        expect(observation.arenaHalfWidth).toBeCloseTo(30, 10);
+        expect(observation.arenaHalfHeight).toBeCloseTo(20, 10);
         expect(physics.getBodyMap().size).toBe(mapData.bodies.length);
         expect(physics.capZoneSensors).toHaveLength(1);
         expect(physics.ppm).toBe(18);

--- a/tests/integration/worker-pool-transport-parity.test.ts
+++ b/tests/integration/worker-pool-transport-parity.test.ts
@@ -26,6 +26,16 @@ const OBS_FLOAT_FIELDS = [
 
 const OPP_FLOAT_FIELDS = ['x', 'y', 'velX', 'velY'];
 
+const EXPORTED_MAP_WITH_BOUNDS = {
+  metadata: { name: 'exported-explicit-bounds' },
+  spawns: [
+    { x: 0, y: 0, blue: true },
+    { x: 100, y: 0, red: true },
+  ],
+  bodies: [],
+  physics: { boundsWidth: 730, boundsHeight: 500 },
+};
+
 function assertObservationEqual(a: any, b: any): void {
   for (const field of OBS_FLOAT_FIELDS) {
     expect(a[field]).toBe(b[field]);
@@ -43,6 +53,36 @@ function assertObservationEqual(a: any, b: any): void {
 }
 
 describe('transport precision parity (issue #236)', () => {
+  it('reports exported map-pixel bounds in both transports (issue #319)', { timeout: 30000 }, async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    const run = async (useSharedMemory: boolean) => {
+      const pool = new WorkerPool(1);
+      try {
+        await pool.init(1, {
+          mapData: EXPORTED_MAP_WITH_BOUNDS,
+          numOpponents: 0,
+          randomOpponent: false,
+          maxTicks: 10,
+          seed: 42,
+        }, useSharedMemory);
+        const resetObs = (await pool.reset([42]))[0];
+        const stepObs = (await pool.step([0]))[0].observation;
+        return { resetObs, stepObs };
+      } finally {
+        await pool.close();
+      }
+    };
+
+    for (const useSharedMemory of [true, false]) {
+      const { resetObs, stepObs } = await run(useSharedMemory);
+      for (const observation of [resetObs, stepObs]) {
+        expect(observation.arenaHalfWidth).toBeCloseTo(365, 5);
+        expect(observation.arenaHalfHeight).toBeCloseTo(250, 5);
+      }
+    }
+  });
+
   it('returns bit-identical reset/step observations and rewards in both transports', async () => {
     if (!WorkerPool.isSupported()) return;
 


### PR DESCRIPTION
## Problem
`MapDef.physics.bounds` and exported `physics.boundsWidth`/`boundsHeight` are authored in map pixels, but explicit bounds were forwarded to `PhysicsEngine.setMapBounds()` as world-unit dimensions. Observations therefore reported arena half-bounds 30x too large.

## Root Cause
`setMapBounds()` intentionally preserves its existing world-unit API for direct engine callers, while `getArenaBounds()` converts stored world-unit extents back to map pixels. The environment was missing the map-pixel-to-world conversion when applying map-level bounds.

## Changes
- Convert map-defined explicit bounds using the engine's resolved scale before calling `setMapBounds()`.
- Add a public scale accessor without changing direct `setMapBounds()` semantics.
- Add regression coverage for internal MapDef bounds, exported bounds fields, custom scale, reset/step observations, and both worker transports.

## Validation
- `npm test` (`96` files, `1709` passed, `19` skipped)
- `npm run typecheck`
- Targeted bounds/map/transport tests passed
- No `build` script is defined in `package.json`

Closes #319