### PR TITLE
fix(#320): convert exported map bounds to world units

### DIFF
--- a/src/core/environment.ts
+++ b/src/core/environment.ts
@@ -702,8 +702,12 @@ export class BonkEnvironment {
 
         // Re-apply explicit map bounds last — body re-adds above recomputed
         // dynamic bounds and would otherwise clobber the override every reset.
+        // MapDef physics.bounds are map pixels, while setMapBounds consumes
+        // internal world metres; convert with the engine's resolved scale so
+        // custom physics.scale values preserve the observation's map-pixel unit.
         if (this.mapBounds && typeof (this.physics as any).setMapBounds === 'function') {
-            this.physics.setMapBounds(this.mapBounds.width, this.mapBounds.height);
+            const scale = this.physics.getScale();
+            this.physics.setMapBounds(this.mapBounds.width / scale, this.mapBounds.height / scale);
         }
 
         // Re-apply the map's OOB death-circle center — like mapBounds it is a

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -1014,6 +1014,7 @@ export class PhysicsEngine {
 
   /**
    * Set explicit map bounds from the map's physics.bounds.
+   * Inputs are world metres; map-pixel callers must convert through getScale().
    * Overrides dynamically calculated arena bounds.
    */
   setMapBounds(widthMetres: number, heightMetres: number): void {
@@ -1029,6 +1030,11 @@ export class PhysicsEngine {
     this._arenaBoundsCache.halfWidth = this.arenaHalfWidth * this.scale;
     this._arenaBoundsCache.halfHeight = this.arenaHalfHeight * this.scale;
     return this._arenaBoundsCache;
+  }
+
+  /** Resolved map-pixel to world-unit scale used by engine coordinate conversions. */
+  getScale(): number {
+    return this.scale;
   }
 
   /**

--- a/tests/integration/environment-edge-cases.test.ts
+++ b/tests/integration/environment-edge-cases.test.ts
@@ -78,20 +78,20 @@ describe('BonkEnvironment edge cases', () => {
       expect(result.info.capZones[0].type).toBe(2);
     });
 
-    it('physics.bounds survives the constructor-internal reset and episode resets', async () => {
+    it('physics.bounds stays in map-pixel observation units across resets', async () => {
       const mapData: MapDef = makeMap({});
       (mapData as any).physics = { bounds: { width: 60, height: 40 } };
 
       env = new BonkEnvironment({ mapData, numOpponents: 0, maxTicks: 10 });
       const obs = env.reset();
-      expect(obs.arenaHalfWidth).toBe(30 * 30);  // width/2 (30m) × SCALE(30)
-      expect(obs.arenaHalfHeight).toBe(20 * 30);
+      expect(obs.arenaHalfWidth).toBe(30);  // width/2 in map pixels
+      expect(obs.arenaHalfHeight).toBe(20);
 
       for (let i = 0; i < 5; i++) env.step(0);
 
       const obs2 = env.reset();
-      expect(obs2.arenaHalfWidth).toBe(30 * 30);
-      expect(obs2.arenaHalfHeight).toBe(20 * 30);
+      expect(obs2.arenaHalfWidth).toBe(30);
+      expect(obs2.arenaHalfHeight).toBe(20);
     });
 
     it('capZones empty array when no capZones in map', async () => {
@@ -936,8 +936,8 @@ describe('BonkEnvironment edge cases', () => {
 
         expect(world).not.toBe(previousWorld);
         expect(observation.tick).toBe(0);
-        expect(observation.arenaHalfWidth).toBe(30 * 30);
-        expect(observation.arenaHalfHeight).toBe(20 * 30);
+        expect(observation.arenaHalfWidth).toBe(30);
+        expect(observation.arenaHalfHeight).toBe(20);
         expect(physics.getBodyMap().size).toBe(mapData.bodies.length);
         expect(physics.capZoneSensors).toHaveLength(1);
         expect(physics.ppm).toBe(18);

--- a/tests/integration/physics-config-consumed.test.ts
+++ b/tests/integration/physics-config-consumed.test.ts
@@ -26,6 +26,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { BonkEnvironment } from '../../src/core/environment';
 import { PhysicsEngine } from '../../src/core/physics-engine';
 import { BonkEnv } from '../../src/env/bonk-env';
+import { normalizeMap } from '../../src/core/map-adapter';
 import type { MapDef } from '../../src/core/physics-engine';
 
 /** Deterministic static-wall arena (x ±515 / y ±300 map px, no floor). */
@@ -38,6 +39,18 @@ const TEST_MAP: MapDef = {
     bodies: [
         { name: 'left', type: 'rect', x: -500, y: 0, width: 30, height: 600, static: true },
         { name: 'right', type: 'rect', x: 500, y: 0, width: 30, height: 600, static: true },
+    ],
+};
+
+const EXPORTED_BOUNDS_MAP = {
+    metadata: { name: 'exported-bounds-test' },
+    physics: { ppm: 12, boundsWidth: 1000, boundsHeight: 800 },
+    spawns: [
+        { x: -100, y: -50, blue: true },
+        { x: 100, y: -50, red: true },
+    ],
+    bodies: [
+        { bodyIndex: 0, fixtureIndex: 0, name: 'floor', type: 'rect', x: 0, y: 200, width: 900, height: 20, static: true },
     ],
 };
 
@@ -153,6 +166,51 @@ describe('physics/arena/player config is consumed by the engine (#217)', () => {
         const def = arenaBounds({});
         expect(def.w - m0.w).toBeCloseTo(5 * 30, 6);
         expect(def.h - m0.h).toBeCloseTo(5 * 30, 6);
+    });
+
+    it('converts exported map-pixel bounds once before reporting observations (#320)', () => {
+        const map = normalizeMap(EXPORTED_BOUNDS_MAP);
+        expect(map.physics?.bounds).toEqual({ width: 1000, height: 800 });
+
+        const env = new BonkEnvironment({
+            numOpponents: 0,
+            seed: 1,
+            maxTicks: 10,
+            mapData: EXPORTED_BOUNDS_MAP as any,
+        });
+        try {
+            // The constructor performs an initial reset, exercising the same
+            // path as the first step before an explicit caller reset.
+            const firstStep = env.step(0).observation;
+            expect(firstStep.arenaHalfWidth).toBeCloseTo(500, 6);
+            expect(firstStep.arenaHalfHeight).toBeCloseTo(400, 6);
+
+            const fast = env.getObservationFast();
+            expect(fast[13]).toBeCloseTo(500, 6);
+            expect(fast[14]).toBeCloseTo(400, 6);
+
+            const reset = env.reset(1);
+            expect(reset.arenaHalfWidth).toBeCloseTo(500, 6);
+            expect(reset.arenaHalfHeight).toBeCloseTo(400, 6);
+        } finally {
+            env.close();
+        }
+    });
+
+    it('keeps exported map-pixel bounds stable when physics.scale changes (#320)', () => {
+        const env = new BonkEnvironment({
+            numOpponents: 0,
+            seed: 1,
+            mapData: EXPORTED_BOUNDS_MAP as any,
+            physics: { scale: 60 },
+        });
+        try {
+            const observation = env.reset(1);
+            expect(observation.arenaHalfWidth).toBeCloseTo(500, 6);
+            expect(observation.arenaHalfHeight).toBeCloseTo(400, 6);
+        } finally {
+            env.close();
+        }
     });
 
     it('arena.defaultHalfWidth/Height set the fallback bounds for bodyless maps', () => {

--- a/tests/integration/worker-pool-transport-parity.test.ts
+++ b/tests/integration/worker-pool-transport-parity.test.ts
@@ -26,6 +26,18 @@ const OBS_FLOAT_FIELDS = [
 
 const OPP_FLOAT_FIELDS = ['x', 'y', 'velX', 'velY'];
 
+const EXPORTED_BOUNDS_MAP = {
+  metadata: { name: 'exported-bounds-transport-test' },
+  physics: { ppm: 12, boundsWidth: 1000, boundsHeight: 800 },
+  spawns: [
+    { x: -100, y: -50, blue: true },
+    { x: 100, y: -50, red: true },
+  ],
+  bodies: [
+    { bodyIndex: 0, fixtureIndex: 0, name: 'floor', type: 'rect', x: 0, y: 200, width: 900, height: 20, static: true },
+  ],
+};
+
 function assertObservationEqual(a: any, b: any): void {
   for (const field of OBS_FLOAT_FIELDS) {
     expect(a[field]).toBe(b[field]);
@@ -110,5 +122,36 @@ describe('transport precision parity (issue #236)', () => {
       shared.result.info.terminal_observation,
       message.result.info.terminal_observation,
     );
+  });
+
+  it('reports exported map-pixel bounds correctly in both transports (#320)', async () => {
+    if (!WorkerPool.isSupported()) return;
+
+    const run = async (useSharedMemory: boolean) => {
+      const pool = new WorkerPool(1);
+      try {
+        await pool.init(1, {
+          mapData: EXPORTED_BOUNDS_MAP,
+          numOpponents: 0,
+          maxTicks: 10,
+          seed: 1,
+        }, useSharedMemory);
+        const resetObservation = (await pool.reset([1]))[0];
+        const stepObservation = (await pool.step([0]))[0].observation;
+        return { resetObservation, stepObservation };
+      } finally {
+        await pool.close();
+      }
+    };
+
+    const shared = await run(true);
+    const message = await run(false);
+
+    for (const observation of [shared.resetObservation, shared.stepObservation, message.resetObservation, message.stepObservation]) {
+      expect(observation.arenaHalfWidth).toBeCloseTo(500, 5);
+      expect(observation.arenaHalfHeight).toBeCloseTo(400, 5);
+    }
+    assertObservationEqual(shared.resetObservation, message.resetObservation);
+    assertObservationEqual(shared.stepObservation, message.stepObservation);
   });
 });

--- a/tests/unit/map-adapter.test.ts
+++ b/tests/unit/map-adapter.test.ts
@@ -141,5 +141,17 @@ describe('normalizeMap', () => {
             expect((out.bodies[0] as any).collides.g1).toBe(true);
             expect(out.spawnPoints.team_blue).toEqual({ x: 0, y: 0 });
         });
+
+        it('preserves exported bounds in map-pixel units for downstream conversion (#320)', () => {
+            const out = normalizeMap({
+                physics: { ppm: 12, boundsWidth: 730, boundsHeight: 500 },
+                bodies: [
+                    { bodyIndex: 0, name: 'floor', type: 'rect', x: 0, y: 200, width: 900, height: 20, static: true },
+                ],
+                spawns: [{ x: -100, y: -50, blue: true }, { x: 100, y: -50, red: true }],
+            } as any);
+
+            expect(out.physics?.bounds).toEqual({ width: 730, height: 500 });
+        });
     });
 });


### PR DESCRIPTION
## Problem
Exported `physics.boundsWidth`/`boundsHeight` values are map pixels, but observations reported arena half-bounds 30x too large because they were passed directly to the world-unit `PhysicsEngine.setMapBounds()` API.

## Root Cause
`normalizeMap()` correctly forwards native bounds in map-pixel coordinates, while `setMapBounds()` stores world metres and `getArenaBounds()` converts those values back to map pixels. The environment was missing the map-pixel to world-unit conversion when reapplying bounds after each reset.

## Changes
- Added a resolved `PhysicsEngine` scale accessor while preserving the existing world-unit `setMapBounds()` API.
- Convert normalized map-pixel bounds by the resolved scale in `BonkEnvironment.reset()`.
- Added regression coverage for exported bounds, direct map bounds across resets, custom physics scale, fast observations, and message-passing/shared-memory parity.

## Validation
- `npm test`
- `npm run typecheck`
- Focused map, bounds, environment, physics, and worker integration suites

Closes #320