### PR TITLE
fix(#318): normalize exported polygon vertices

### DIFF
--- a/src/core/map-adapter.ts
+++ b/src/core/map-adapter.ts
@@ -160,16 +160,25 @@ function isInternalMapDef(raw: any): raw is MapDef {
 
 /** Convert a flat body into a MapBodyDef, preserving facade metadata. */
 function toBodyDef(body: FlatBody, index: number): any {
+    const x = body.x ?? 0;
+    const y = body.y ?? 0;
+    // The exporter's flat polygon view stores vertices in map/world pixels
+    // (`bx + cx + v`), while MapBodyDef vertices are body-local for Box2D and
+    // the normalized renderer/cap-zone consumers. Convert only polygons here;
+    // rects and circles already express their extent around x/y.
+    const vertices = body.type === 'polygon' && body.vertices
+        ? body.vertices.map(v => ({ x: v.x - x, y: v.y - y }))
+        : body.vertices;
     return {
         name: body.name ?? body.bodyType ?? `body_${index}`,
         type: (body.type === 'rect' || body.type === 'circle'
             || body.type === 'polygon') ? body.type : 'rect',
-        x: body.x ?? 0,
-        y: body.y ?? 0,
+        x,
+        y,
         width: body.width,
         height: body.height,
         radius: body.radius,
-        vertices: body.vertices,
+        vertices,
         static: body.static ?? body.bodyType === 'static',
         density: body.density,
         restitution: body.restitution,
@@ -463,8 +472,21 @@ export function normalizeMap(raw: unknown): MapDef {
             let bx0 = b.x, bx1 = b.x, by0 = b.y, by1 = b.y;
             if (b.type === 'circle' && b.radius) { bx0 = b.x - b.radius; bx1 = b.x + b.radius; by0 = b.y - b.radius; by1 = b.y + b.radius; }
             else if (b.type === 'rect' && b.width && b.height) { bx0 = b.x - b.width / 2; bx1 = b.x + b.width / 2; by0 = b.y - b.height / 2; by1 = b.y + b.height / 2; }
-            else if (b.vertices && b.vertices.length) {
-                for (const v of b.vertices) { if (v.x < bx0) bx0 = v.x; if (v.x > bx1) bx1 = v.x; if (v.y < by0) by0 = v.y; if (v.y > by1) by1 = v.y; }
+            else if (b.type === 'polygon' && b.vertices && b.vertices.length) {
+                // Polygon vertices in the normalized MapDef are body-local.
+                // Apply the body transform before folding them into the map
+                // bounds; the exporter input was absolute before toBodyDef()
+                // converted it to this local frame.
+                const angle = b.angle ?? 0;
+                const cosA = Math.cos(angle);
+                const sinA = Math.sin(angle);
+                bx0 = Infinity; bx1 = -Infinity; by0 = Infinity; by1 = -Infinity;
+                for (const v of b.vertices) {
+                    const wx = b.x + v.x * cosA - v.y * sinA;
+                    const wy = b.y + v.x * sinA + v.y * cosA;
+                    if (wx < bx0) bx0 = wx; if (wx > bx1) bx1 = wx;
+                    if (wy < by0) by0 = wy; if (wy > by1) by1 = wy;
+                }
             }
             if (bx0 < minX) minX = bx0; if (bx1 > maxX) maxX = bx1;
             if (by0 < minY) minY = by0; if (by1 > maxY) maxY = by1;

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -188,7 +188,7 @@ export interface MapBodyDef {
   width?: number;    // For rect
   height?: number;   // For rect
   radius?: number;   // For circle
-  vertices?: { x: number; y: number }[]; // For polygon
+  vertices?: { x: number; y: number }[]; // Body-local map-px vertices for polygons
   /** Omitted static defaults to a dynamic body. */
   static?: boolean;
   density?: number;

--- a/tests/integration/map-body-types.test.ts
+++ b/tests/integration/map-body-types.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { PhysicsEngine, MapBodyDef, SCALE } from '../../src/core/physics-engine';
+import { normalizeMap } from '../../src/core/map-adapter';
 import { safeDestroy } from '../utils/test-helpers';
 
 describe('MapBodyTypes', () => {
@@ -139,6 +140,43 @@ describe('MapBodyTypes', () => {
   });
 
   describe('polygon bodies', () => {
+    it('rebuilds an exported polygon at its authored non-origin position (#318)', () => {
+      const authoredVertices = [
+        { x: 300, y: 150 },
+        { x: 350, y: 200 },
+        { x: 300, y: 250 },
+      ];
+      const map = normalizeMap({
+        bodies: [{
+          bodyIndex: 0,
+          name: 'exported-triangle',
+          type: 'polygon',
+          x: 300,
+          y: 200,
+          angle: 0,
+          vertices: authoredVertices,
+          static: true,
+        }],
+        spawns: [{ x: 0, y: 0, blue: true, red: true }],
+      } as any);
+
+      engine = new PhysicsEngine();
+      engine.addBody(map.bodies[0]);
+
+      const body = engine.getBodyMap().get('exported-triangle') as any;
+      const shape = body.GetShapeList();
+      const worldVertices = Array.from({ length: shape.m_vertexCount }, (_, i) => {
+        const point = body.GetWorldPoint(shape.m_vertices[i]);
+        return { x: point.x * SCALE, y: point.y * SCALE };
+      });
+
+      expect(worldVertices).toHaveLength(authoredVertices.length);
+      worldVertices.forEach((actual, i) => {
+        expect(actual.x).toBeCloseTo(authoredVertices[i].x, 4);
+        expect(actual.y).toBeCloseTo(authoredVertices[i].y, 4);
+      });
+    });
+
     it('triangle polygon (3 vertices) is added', () => {
       engine = new PhysicsEngine();
       const triangle: MapBodyDef = {

--- a/tests/unit/map-adapter.test.ts
+++ b/tests/unit/map-adapter.test.ts
@@ -141,5 +141,42 @@ describe('normalizeMap', () => {
             expect((out.bodies[0] as any).collides.g1).toBe(true);
             expect(out.spawnPoints.team_blue).toEqual({ x: 0, y: 0 });
         });
+
+        it('converts exported polygon vertices to body-local coordinates (#318)', () => {
+            const out = normalizeMap({
+                bodies: [
+                    {
+                        bodyIndex: 0,
+                        name: 'exported-triangle',
+                        type: 'polygon',
+                        x: 300,
+                        y: 200,
+                        angle: 0,
+                        vertices: [
+                            { x: 300, y: 150 },
+                            { x: 350, y: 200 },
+                            { x: 300, y: 250 },
+                        ],
+                        static: true,
+                    },
+                    { bodyIndex: 1, name: 'rect', type: 'rect', x: 25, y: 40, width: 20, height: 10, static: true },
+                    { bodyIndex: 2, name: 'circle', type: 'circle', x: -25, y: -40, radius: 8, static: true },
+                ],
+                spawns: [{ x: 0, y: 0, blue: true, red: true }],
+            } as any) as any;
+
+            expect(out.bodies[0].vertices).toEqual([
+                { x: 0, y: -50 },
+                { x: 50, y: 0 },
+                { x: 0, y: 50 },
+            ]);
+            expect(out.bodies[1]).toMatchObject({ x: 25, y: 40, width: 20, height: 10 });
+            expect(out.bodies[2]).toMatchObject({ x: -25, y: -40, radius: 8 });
+            // The center includes all three fixtures: polygon [300..350,
+            // 150..250], rect [15..35, 35..45], and circle [-33..-17,
+            // -48..-32]. Polygon bounds must be reconstructed from its body
+            // transform after normalization rather than from local vertices.
+            expect(out.physics.deathCenter).toEqual({ x: 158.5, y: 101 });
+        });
     });
 });


### PR DESCRIPTION
Closes #318\n\n## Problem\nExported flat polygon vertices are absolute map coordinates, but the physics engine treats MapBodyDef polygon vertices as body-local while also placing the body at x/y. Non-origin polygons were therefore displaced by their own position a second time.\n\n## Root cause\nmapexporter.js emits vertices as bx + cx + v, while normalizeMap forwarded those vertices unchanged into addBody().\n\n## Changes\n- Convert exporter polygon vertices to body-local coordinates during normalizeMap().\n- Reconstruct normalized polygon world bounds with the body transform for death-center calculation.\n- Document the MapBodyDef local-vertex contract.\n- Add adapter and Box2D world-vertex regressions for a non-origin polygon, while asserting rect/circle normalization remains unchanged.\n\n## Validation\n- npm run typecheck\n- npm test (96 files, 1708 passed, 19 skipped)\n- Focused map/geometry/cap-zone/sensor suites (112 tests, 19 skipped)\n- git diff --check