### PR TITLE
fix(#322): scale prismatic travel limits

### DIFF
--- a/src/core/differential/exact-match-gates.ts
+++ b/src/core/differential/exact-match-gates.ts
@@ -168,14 +168,15 @@ export function verifyJointGates(env: BonkEnvironment, trace: NativeTrace): Gate
     } else {
       // prismatic (lpj/lsj/p): translation limits + motor force, mirroring the
       // engine's #281 symmetric ±length fallback exactly — a positive authored
-      // length with no explicit translations becomes a symmetric limit.
+      // length with no explicit translations becomes a symmetric limit. The
+      // engine stores these authored map-pixel values in world units.
       const lenLimit = typeof j.length === 'number' && Number.isFinite(j.length) && j.length > 0;
       const lt = j.lowerTranslation !== undefined ? j.lowerTranslation : (lenLimit ? -j.length : 0);
       const ut = j.upperTranslation !== undefined ? j.upperTranslation : (lenLimit ? +j.length : 0);
-      if (Math.abs((built as any).m_lowerTranslation - lt) > 1e-9) {
+      if (Math.abs((built as any).m_lowerTranslation - lt / scale) > 1e-9) {
         mismatches.push(`joint "${name}" prismatic lowerTranslation mismatch`);
       }
-      if (Math.abs((built as any).m_upperTranslation - ut) > 1e-9) {
+      if (Math.abs((built as any).m_upperTranslation - ut / scale) > 1e-9) {
         mismatches.push(`joint "${name}" prismatic upperTranslation mismatch`);
       }
       if (Math.abs((built as any).m_maxMotorForce - (j.maxMotorForce ?? 0)) > 1e-9) {

--- a/src/core/physics-engine.ts
+++ b/src/core/physics-engine.ts
@@ -1249,8 +1249,12 @@ export class PhysicsEngine {
       // Negative/zero lengths keep the previous 0/0 range (an inverted range
       // would be degenerate), only positive lengths become a symmetric limit.
       const lenLimit = typeof def.length === 'number' && Number.isFinite(def.length) && def.length > 0;
-      jd.lowerTranslation = def.lowerTranslation !== undefined ? def.lowerTranslation : (lenLimit ? -def.length : 0);
-      jd.upperTranslation = def.upperTranslation !== undefined ? def.upperTranslation : (lenLimit ? +def.length : 0);
+      // Map definitions store prismatic travel in map pixels; Box2D reads
+      // translations in this engine's world units (map pixels / scale).
+      const lowerTranslation = def.lowerTranslation !== undefined ? def.lowerTranslation : (lenLimit ? -def.length : 0);
+      const upperTranslation = def.upperTranslation !== undefined ? def.upperTranslation : (lenLimit ? +def.length : 0);
+      jd.lowerTranslation = lowerTranslation / this.scale;
+      jd.upperTranslation = upperTranslation / this.scale;
       jd.enableMotor = !!def.enableMotor;
       jd.motorSpeed = def.motorSpeed ?? 0;
       jd.maxMotorForce = def.maxMotorForce ?? 0;

--- a/tests/integration/physics-fidelity-p2.test.ts
+++ b/tests/integration/physics-fidelity-p2.test.ts
@@ -228,6 +228,40 @@ describe('physics fidelity P2: joint model (DEOBFUSCATION §33.8)', () => {
     expect(warnings.filter(w => /unknown joint type/.test(w))).toHaveLength(0);
   });
 
+  it('scales authored map-pixel translation limits for lpj, lsj, and p joints (#322)', () => {
+    const e = makeEngine();
+    const cases = [
+      { type: 'lpj', lower: -50, upper: 50 },
+      { type: 'lsj', lower: -40, upper: 40 },
+      { type: 'p', lower: -25, upper: 75 },
+    ];
+
+    for (const { type, lower, upper } of cases) {
+      const suffix = type;
+      e.addBody({ name: `${suffix}_anchor`, type: 'rect', x: 0, y: 0, width: 40, height: 10, static: true } as any);
+      e.addBody({ name: `${suffix}_slider`, type: 'rect', x: 0, y: 0, width: 20, height: 20, static: false, density: 1 } as any);
+      const bm = e.getBodyMap() as Map<string, any>;
+
+      e.addJoint({
+        type,
+        name: `${suffix}_joint`,
+        bodyA: `${suffix}_anchor`,
+        bodyB: `${suffix}_slider`,
+        anchorA: { x: 0, y: 0 },
+        axis: { x: 1, y: 0 },
+        enableLimit: true,
+        lowerTranslation: lower,
+        upperTranslation: upper,
+      }, bm);
+
+      const joint: any = (e as any).createdJoints.get(`${suffix}_joint`);
+      expect(joint).toBeTruthy();
+      expect(joint.m_enableLimit).toBe(true);
+      expect(joint.m_lowerTranslation).toBeCloseTo(lower / SCALE, 5);
+      expect(joint.m_upperTranslation).toBeCloseTo(upper / SCALE, 5);
+    }
+  });
+
   it('supports a ground-anchored prismatic joint (bodyB=-1) without warning', () => {
     const e = makeEngine();
     const bm = makeBodyMap(e);
@@ -664,8 +698,8 @@ it('normalizeMap forwards authored distance-joint frequencyHz/dampingRatio (#286
     const j: any = (e as any).createdJoints.get('joint_0');
     expect(j).toBeTruthy();
     expect(j.m_enableLimit).toBe(true);
-    expect(j.m_lowerTranslation).toBeCloseTo(-50, 5);
-    expect(j.m_upperTranslation).toBeCloseTo(50, 5);
+    expect(j.m_lowerTranslation).toBeCloseTo(-50 / SCALE, 5);
+    expect(j.m_upperTranslation).toBeCloseTo(50 / SCALE, 5);
     expect(j.m_enableMotor).toBe(true);
     expect(j.m_motorSpeed).toBeCloseTo(3, 5);
     expect(j.m_maxMotorForce).toBeCloseTo(1000, 5);
@@ -735,8 +769,8 @@ it('normalizeMap forwards authored distance-joint frequencyHz/dampingRatio (#286
     const j: any = (e as any).createdJoints.get('joint_0');
     expect(j).toBeTruthy();
     expect(j.m_enableLimit).toBe(false);
-    expect(j.m_lowerTranslation).toBeCloseTo(-40, 5);
-    expect(j.m_upperTranslation).toBeCloseTo(40, 5);
+    expect(j.m_lowerTranslation).toBeCloseTo(-40 / SCALE, 5);
+    expect(j.m_upperTranslation).toBeCloseTo(40 / SCALE, 5);
     expect(j.m_enableMotor).toBe(true);
     expect(j.m_motorSpeed).toBeCloseTo(300, 5);
     expect(j.m_maxMotorForce).toBeCloseTo(25, 5);
@@ -762,8 +796,8 @@ it('normalizeMap forwards authored distance-joint frequencyHz/dampingRatio (#286
     e.addJoint(md.joints[0], bm);
     const j: any = (e as any).createdJoints.get('joint_0');
     expect(j.m_enableLimit).toBe(true);
-    expect(j.m_lowerTranslation).toBeCloseTo(-50, 5);
-    expect(j.m_upperTranslation).toBeCloseTo(50, 5);
+    expect(j.m_lowerTranslation).toBeCloseTo(-50 / SCALE, 5);
+    expect(j.m_upperTranslation).toBeCloseTo(50 / SCALE, 5);
   });
 
   it('a prismatic joint with a negative or zero length keeps the previous 0/0 range — never inverted (issue #281)', () => {


### PR DESCRIPTION
## Problem
Prismatic travel limits from authored maps were passed to Box2D as raw map-pixel values, making every `lpj`/`lsj`/`p` range 30x wider at the default scale.

## Root cause
`PhysicsEngine.addJoint()` scaled distance-joint lengths and anchors but omitted the map-pixel to world-unit conversion for prismatic translations.

## Changes
- Divide explicit `lowerTranslation`/`upperTranslation` values by the configured physics scale.
- Apply the same conversion to the positive `length` fallback.
- Update the differential joint gate and add regression coverage for `lpj`, `lsj`, and `p` variants.

## Validation
- `npx vitest run`
- `npm run typecheck`

Closes #322
