### PR TITLE
fix(#326): reset server after bind failure

### DIFF
--- a/src/ipc/ipc-bridge.ts
+++ b/src/ipc/ipc-bridge.ts
@@ -240,24 +240,21 @@ export class IpcBridge {
         // re-bound (bind() throws "Socket is closed"). Recreate the transport
         // so a later start() after close() binds a fresh ROUTER and serves
         // again (issue #263): re-wrap the send function on the new socket.
-        let recreated = false;
         if (this.sock.closed) {
             this.sock = new zmq.Router();
             this._wrappedSend = wrap(TelemetryIndices.ZMQ_SEND, this.sock.send.bind(this.sock));
-            recreated = true;
         }
         try {
             await this.sock.bind(addr);
         } catch (err) {
             this.markBindFailed(err);
-            // A socket recreated here is always a restart-after-close() (the
-            // original socket was destroyed by close(), which also left
-            // _closed true until a successful bind). Its bind never succeeded,
-            // so a later close() would early-return and leak the open handle;
-            // close it here so a failed restart is fully clean and a retry
-            // recreates from scratch.
-            if (recreated) {
+            // A bind that never succeeded leaves the ROUTER handle open. Close
+            // it for both first starts and restart attempts; a later start()
+            // recreates a closed socket before retrying (issue #326).
+            try {
                 this.sock.close();
+            } catch {
+                // Preserve the original bind error if socket cleanup fails.
             }
             throw err;
         }

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,20 +26,40 @@ export async function startServer(config?: AppConfig): Promise<void> {
     
     const appConfig = config || getConfig();
     console.log(`Starting server on port ${appConfig.server.port} (config: ${config ? 'provided' : 'cached'})`);
-    bridge = new IpcBridge(appConfig);
+    const serverBridge = new IpcBridge(appConfig);
+    bridge = serverBridge;
 
-    // Issue #237: initialize the telemetry controller once at startup so the
-    // parsed flags are cached (no per-tick process.argv scan) and the
-    // documented config surfaces (reportIntervalMs, dashboardPort,
-    // outputFormat: 'file') take effect. This must happen before bridge.start()
-    // is awaited: start() only resolves when the server closes.
-    const controller = getTelemetryController();
-    controller.initialize(appConfig.telemetry, appConfig.physics.ticksPerSecond);
-    if (controller.getFlags().enableTelemetry) {
-        controller.startDashboard(appConfig.telemetry.dashboardPort);
+    try {
+        // Issue #237: initialize the telemetry controller once at startup so the
+        // parsed flags are cached (no per-tick process.argv scan) and the
+        // documented config surfaces (reportIntervalMs, dashboardPort,
+        // outputFormat: 'file') take effect. This must happen before bridge.start()
+        // is awaited: start() only resolves when the server closes.
+        const controller = getTelemetryController();
+        controller.initialize(appConfig.telemetry, appConfig.physics.ticksPerSecond);
+        if (controller.getFlags().enableTelemetry) {
+            controller.startDashboard(appConfig.telemetry.dashboardPort);
+        }
+
+        await serverBridge.start();
+    } catch (error) {
+        // A failed bind never started a serve cycle, so roll back the singleton
+        // state and release everything created for this attempt. In particular,
+        // this closes the failed bridge's ROUTER socket and telemetry dashboard
+        // so callers can retry without an intervening stopServer() (issue #326).
+        bridge = null;
+        try {
+            await serverBridge.close();
+        } catch (cleanupError) {
+            console.error('Error during failed server startup cleanup:', cleanupError);
+        }
+        try {
+            getTelemetryController().shutdown();
+        } catch (cleanupError) {
+            console.error('Error during telemetry startup cleanup:', cleanupError);
+        }
+        throw error;
     }
-
-    await bridge.start();
 }
 
 /**

--- a/tests/unit/server-lifecycle.test.ts
+++ b/tests/unit/server-lifecycle.test.ts
@@ -1,0 +1,155 @@
+/**
+ * server-lifecycle.test.ts — regression coverage for issue #326
+ *
+ * A failed standalone server bind must release its bridge, ROUTER socket, and
+ * telemetry dashboard so the caller can retry after the port becomes free.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as net from 'net';
+import { IpcBridge } from '../../src/ipc/ipc-bridge';
+import { startServer, stopServer, isServerRunning } from '../../src/server';
+import { deepMerge, loadConfig, resetConfig, type AppConfig } from '../../src/config/config-loader';
+import { getTelemetryController } from '../../src/telemetry/telemetry-controller';
+
+interface ListeningServer {
+  server: net.Server;
+  port: number;
+}
+
+async function listenOnEphemeralPort(): Promise<ListeningServer> {
+  const server = net.createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Failed to determine ephemeral test port');
+  }
+  return { server, port: address.port };
+}
+
+async function closeServer(server: net.Server): Promise<void> {
+  if (!server.listening) return;
+  await new Promise<void>(resolve => server.close(() => resolve()));
+}
+
+async function waitForServerPort(port: number, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const reachable = await new Promise<boolean>(resolve => {
+      const socket = net.connect({ host: '127.0.0.1', port });
+      socket.once('connect', () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.once('error', () => {
+        socket.destroy();
+        resolve(false);
+      });
+    });
+    if (reachable) return;
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+  throw new Error(`server port ${port} never became reachable`);
+}
+
+async function waitForPortAvailable(port: number, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const probe = net.createServer();
+    const available = await new Promise<boolean>(resolve => {
+      probe.once('error', () => resolve(false));
+      probe.listen(port, '127.0.0.1', () => {
+        probe.close(() => resolve(true));
+      });
+    });
+    if (available) return;
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+  throw new Error(`port ${port} did not become available`);
+}
+
+function makeConfig(port: number, telemetryEnabled = false, dashboardPort?: number): AppConfig {
+  const base = loadConfig();
+  return deepMerge(base, {
+    server: { port, bindAddress: '127.0.0.1' },
+    workerPool: { numWorkers: 1, useSharedMemory: false },
+    telemetry: {
+      enabled: telemetryEnabled,
+      outputFormat: 'console',
+      ...(dashboardPort === undefined ? {} : { dashboardPort }),
+    },
+  } as Partial<AppConfig>);
+}
+
+describe('standalone server bind-failure lifecycle (issue #326)', () => {
+  beforeEach(() => {
+    resetConfig();
+    getTelemetryController().shutdown();
+  });
+
+  afterEach(async () => {
+    await stopServer();
+    getTelemetryController().shutdown();
+  });
+
+  it('rolls back running state after a bind failure', async () => {
+    const blocker = await listenOnEphemeralPort();
+    try {
+      await expect(startServer(makeConfig(blocker.port))).rejects.toThrow(/address already in use|eaddrinuse/i);
+      expect(isServerRunning()).toBe(false);
+    } finally {
+      await closeServer(blocker.server);
+    }
+  });
+
+  it('restarts successfully after the failed port is released without stopServer()', async () => {
+    const blocker = await listenOnEphemeralPort();
+    const config = makeConfig(blocker.port);
+    try {
+      await expect(startServer(config)).rejects.toThrow(/address already in use|eaddrinuse/i);
+      expect(isServerRunning()).toBe(false);
+    } finally {
+      await closeServer(blocker.server);
+    }
+
+    const serverStart = startServer(config);
+    try {
+      await waitForServerPort(blocker.port);
+      expect(isServerRunning()).toBe(true);
+    } finally {
+      await stopServer();
+      await serverStart;
+    }
+    expect(isServerRunning()).toBe(false);
+  });
+
+  it('releases the telemetry dashboard after a failed server bind', async () => {
+    const blocker = await listenOnEphemeralPort();
+    const dashboard = await listenOnEphemeralPort();
+    await closeServer(dashboard.server);
+
+    try {
+      await expect(startServer(makeConfig(blocker.port, true, dashboard.port))).rejects.toThrow(/address already in use|eaddrinuse/i);
+      expect(isServerRunning()).toBe(false);
+      await waitForPortAvailable(dashboard.port);
+    } finally {
+      await closeServer(blocker.server);
+    }
+  });
+
+  it('closes a ROUTER socket when a direct bridge bind fails', async () => {
+    const blocker = await listenOnEphemeralPort();
+    const bridge = new IpcBridge(makeConfig(blocker.port));
+    try {
+      await expect(bridge.start()).rejects.toThrow(/address already in use|eaddrinuse/i);
+      expect((bridge as any).sock.closed).toBe(true);
+    } finally {
+      await bridge.close();
+      await closeServer(blocker.server);
+    }
+  });
+});


### PR DESCRIPTION
## Problem
`startServer()` published its `IpcBridge` before the ROUTER bind completed. When the bind failed, the module retained the bridge, leaked its unbound socket, and left the telemetry dashboard running, so retries were rejected as already running.

## Changes
- Roll back the module-level bridge and shut down telemetry resources when startup fails.
- Close ROUTER sockets on every failed bind, including first starts and restart attempts.
- Add regression coverage for state rollback, retry recovery, dashboard cleanup, and direct bridge socket cleanup.

## Validation
- `npx vitest run tests/unit/server-lifecycle.test.ts`
- `npx vitest run tests/integration/ipc-bridge-restart.test.ts`
- `npx vitest run tests/integration/ipc-bridge-bind-address.test.ts`
- `npm test` (`97` files passed, `1710` tests passed, `19` skipped)
- `npm run typecheck`

Closes #326